### PR TITLE
feat(scheduler): bound model_probe_results, without eating the row routing reads (#1221)

### DIFF
--- a/app/services.go
+++ b/app/services.go
@@ -116,6 +116,15 @@ func buildSchedulers(cfg *config.Config) (
 	// list) cannot grow unboundedly.
 	newRegistry.Register(scheduler.NewAdminBackgroundTaskRetentionScheduler(cfg))
 
+	// ---- Scheduler 13d: Model Probe Result Retention ----
+	// model_probe_results is the highest-volume table once probing is on (one
+	// row per probed channel+model per pass) and had no DELETE path at all. Both
+	// of its readers want only the newest rows — route rebuild's probe filter
+	// reads the latest per (account_id, model_name), the history endpoint the
+	// latest N per channel/account — so the job prunes on age and exempts the
+	// latest-per-pair row outright.
+	newRegistry.Register(scheduler.NewModelProbeResultRetentionScheduler(cfg))
+
 	// ---- Scheduler 14: Proxy Log Retention (legacy fallback) ----
 	newRegistry.Register(scheduler.NewProxyLogRetentionScheduler(cfg))
 

--- a/app/services_registration_test.go
+++ b/app/services_registration_test.go
@@ -32,6 +32,7 @@ func TestBuildSchedulersRegistration(t *testing.T) {
 		"proxy-video-task-retention",
 		"proxy-log-retention",
 		"admin-background-task-retention",
+		"model-probe-result-retention",
 		"oauth-refresh",
 	}
 

--- a/scheduler/probe_retention.go
+++ b/scheduler/probe_retention.go
@@ -1,0 +1,68 @@
+package scheduler
+
+import (
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// modelProbeResultRetentionDays bounds model_probe_results, the highest-volume
+// table in a deployment that turns probing on: one row per probed
+// (channel, model) per pass, which on a busy instance is tens of thousands of
+// rows a day and, until now, never a single DELETE.
+//
+// Seven days is already generous relative to what anything reads:
+//
+//   - service.loadLatestProbeFailures (route rebuild's probe filter, #625)
+//     reads only the newest row per (account_id, model_name), and those rows are
+//     exempt from this job outright — see modelProbeResultKeepLatestWhere;
+//   - handler/admin.queryProbeHistory shows the newest N rows per channel or
+//     account with NO time filter, so extra days never reach the screen while
+//     every extra row is paid for twice: the window scan that query performs
+//     over the whole table, and the three indexes each insert maintains.
+//
+// The window is a constant rather than a new knob on purpose. Nobody has asked
+// to tune it, RetentionSchedulerOptions already reads both values from config,
+// and promoting it later is a two-line change here plus a docs/env-parity
+// entry — cheaper than carrying an unexercised setting now.
+const modelProbeResultRetentionDays = 7
+
+// modelProbeResultPruneIntervalMin is the prune cadence. Hourly, matching a
+// table that grows continuously rather than in daily batches, so the table
+// never sits more than ~1/24 of a day above its steady-state size.
+const modelProbeResultPruneIntervalMin = 60
+
+// modelProbeResultKeepLatestWhere exempts the newest row of every
+// (account_id, model_name) pair from the prune, however old it is.
+//
+// This is what makes the window safe to have at all: route rebuild's probe
+// filter reads exactly that row set
+//
+//	WHERE id IN (SELECT MAX(id) FROM model_probe_results GROUP BY account_id, model_name)
+//
+// so a plain age-based DELETE would silently drop the filter's input for any
+// model that has not been probed inside the window — probing paused, channel
+// disabled, account idle — and routing would change behaviour because a cleanup
+// job ran. MAX(id) is never NULL within a group (id is the primary key), so the
+// NOT IN cannot degenerate into "delete nothing" the way a nullable subquery
+// would.
+const modelProbeResultKeepLatestWhere = " AND id NOT IN (SELECT MAX(id) FROM model_probe_results GROUP BY account_id, model_name)"
+
+// ModelProbeResultRetentionScheduler periodically prunes aged
+// model_probe_results rows. Implemented by the shared RetentionScheduler.
+type ModelProbeResultRetentionScheduler = RetentionScheduler
+
+// NewModelProbeResultRetentionScheduler creates the probe-result retention
+// scheduler. It runs by default: there is no operator opt-out, because the rows
+// it deletes are provably unread (the two consumers are listed above) while the
+// rows it keeps are pinned by modelProbeResultKeepLatestWhere.
+func NewModelProbeResultRetentionScheduler(cfg *config.Config) *RetentionScheduler {
+	return NewRetentionScheduler(cfg, RetentionSchedulerOptions{
+		Name:               "model-probe-result-retention",
+		Table:              "model_probe_results",
+		ExtraWhere:         modelProbeResultKeepLatestWhere,
+		UseUTC:             true, // created_at is written as time.Now().UTC().RFC3339
+		DefaultIntervalMin: modelProbeResultPruneIntervalMin,
+		RetentionDaysFn:    func(*config.Config) int { return modelProbeResultRetentionDays },
+		IntervalMinFn:      func(*config.Config) int { return modelProbeResultPruneIntervalMin },
+		DisabledFn:         func(*config.Config) (bool, string) { return false, "" },
+	})
+}

--- a/scheduler/probe_retention_test.go
+++ b/scheduler/probe_retention_test.go
@@ -1,0 +1,216 @@
+package scheduler
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// The prune has to satisfy two claims at once, and only the second one is
+// interesting: aged probe rows go away, and the row route rebuild reads never
+// does — however old it is. A plain age-based DELETE passes the first and
+// silently breaks the probe filter (#625) for any model that has not been
+// probed inside the window, which is a routing behaviour change caused by a
+// cleanup job.
+
+func TestModelProbeResultRetention_SQLitePrunesHistoryButNeverTheRowRoutingReads(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate sqlite: %v", err)
+	}
+
+	runModelProbeResultRetentionLifecycle(t, db, "sqlite-"+strings.ReplaceAll(t.Name(), "/", "-"))
+}
+
+func TestModelProbeResultRetention_PostgresPrunesHistoryButNeverTheRowRoutingReads(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("PG_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("PG_TEST_DSN not set; skipping PostgreSQL integration test")
+	}
+	db, err := store.Open(store.DialectPostgres, dsn, false)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate postgres: %v", err)
+	}
+
+	runModelProbeResultRetentionLifecycle(t, db, "pg-"+fmt.Sprint(time.Now().UnixNano()))
+}
+
+func runModelProbeResultRetentionLifecycle(t *testing.T, db *store.DB, suffix string) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	siteID := insertProbeRetentionSite(t, db, suffix, now)
+	accountA := insertProbeRetentionAccount(t, db, siteID, suffix+"-a", now)
+	accountB := insertProbeRetentionAccount(t, db, siteID, suffix+"-b", now)
+	t.Cleanup(func() {
+		for _, accountID := range []int64{accountA, accountB} {
+			_, _ = db.Exec("DELETE FROM model_probe_results WHERE account_id = ?", accountID)
+			_, _ = db.Exec("DELETE FROM accounts WHERE id = ?", accountID)
+		}
+		_, _ = db.Exec("DELETE FROM sites WHERE id = ?", siteID)
+	})
+
+	aged := func(days int) string {
+		return now.Add(-time.Duration(days) * 24 * time.Hour).Format(time.RFC3339)
+	}
+	countMine := func() int {
+		t.Helper()
+		return countRows(t, db,
+			`SELECT COUNT(*) FROM model_probe_results WHERE account_id IN (?, ?)`,
+			accountA, accountB)
+	}
+	hasRow := func(accountID int64, model, createdAt string) bool {
+		t.Helper()
+		return countRows(t, db,
+			`SELECT COUNT(*) FROM model_probe_results WHERE account_id = ? AND model_name = ? AND created_at = ?`,
+			accountID, model, createdAt) == 1
+	}
+
+	// (account A, "gpt-stale"): three rows, ALL outside the 7-day window. The
+	// newest of the three is the one route rebuild reads, so age alone must not
+	// decide its fate.
+	insertProbeResult(t, db, accountA, siteID, "gpt-stale", aged(30)) // pruned
+	insertProbeResult(t, db, accountA, siteID, "gpt-stale", aged(20)) // pruned
+	staleNewestA := aged(8)
+	insertProbeResult(t, db, accountA, siteID, "gpt-stale", staleNewestA) // exempt
+	// (account A, "gpt-fresh"): inside the window, kept for its age.
+	freshA := aged(1)
+	insertProbeResult(t, db, accountA, siteID, "gpt-fresh", freshA)
+	// (account B, "gpt-stale"): the exemption is per (account, model), not one
+	// global newest row — a second account's latest probe survives too.
+	insertProbeResult(t, db, accountB, siteID, "gpt-stale", aged(40)) // pruned
+	staleNewestB := aged(9)
+	insertProbeResult(t, db, accountB, siteID, "gpt-stale", staleNewestB) // exempt
+
+	// Anti-vacuity: prove the seed landed before asserting what the prune left.
+	if got := countMine(); got != 6 {
+		t.Fatalf("seeded %d probe rows, want 6 — the lifecycle would prove nothing", got)
+	}
+
+	s := NewModelProbeResultRetentionScheduler(&config.Config{})
+	s.runCleanupLocked(db, modelProbeResultRetentionDays)
+
+	if got := countMine(); got != 3 {
+		t.Errorf("probe rows after prune = %d, want 3 (aged history gone, latest-per-pair kept)", got)
+	}
+	if !hasRow(accountA, "gpt-stale", staleNewestA) {
+		t.Errorf("pruned the newest (account A, gpt-stale) row at %s: route rebuild's probe filter reads exactly this row", staleNewestA)
+	}
+	if !hasRow(accountB, "gpt-stale", staleNewestB) {
+		t.Errorf("pruned the newest (account B, gpt-stale) row: the exemption must be per (account_id, model_name), not global")
+	}
+	if !hasRow(accountA, "gpt-fresh", freshA) {
+		t.Errorf("pruned an in-window row at %s", freshA)
+	}
+	if hasRow(accountA, "gpt-stale", aged(30)) || hasRow(accountA, "gpt-stale", aged(20)) {
+		t.Errorf("aged non-latest rows survived; the table would still grow without bound")
+	}
+	if hasRow(accountB, "gpt-stale", aged(40)) {
+		t.Errorf("aged non-latest row for account B survived")
+	}
+
+	// The consumer's own query, not a paraphrase of it: after the prune, route
+	// rebuild must still see one latest row per (account, model) pair.
+	routingRows := countRows(t, db,
+		`SELECT COUNT(*) FROM model_probe_results
+		 WHERE account_id IN (?, ?)
+		   AND id IN (SELECT MAX(id) FROM model_probe_results GROUP BY account_id, model_name)`,
+		accountA, accountB)
+	if routingRows != 3 {
+		t.Errorf("route rebuild's latest-per-pair query returns %d rows for the seeded pairs, want 3", routingRows)
+	}
+}
+
+// TestModelProbeResultRetentionJobRuns guards the failure mode
+// app.TestBuildSchedulersRegistration was written for: a job that is
+// constructed and registered but disabled by its own predicate, so the table
+// keeps growing while everything looks wired.
+func TestModelProbeResultRetentionJobRuns(t *testing.T) {
+	cfg := &config.Config{}
+	s := NewModelProbeResultRetentionScheduler(cfg)
+
+	if got := s.Name(); got != "model-probe-result-retention" {
+		t.Errorf("Name() = %q, want %q", got, "model-probe-result-retention")
+	}
+	if disabled, reason := s.opts.DisabledFn(cfg); disabled {
+		t.Errorf("job is disabled by default (%s); model_probe_results would grow without bound", reason)
+	}
+	if got := s.opts.RetentionDaysFn(cfg); got <= 0 {
+		t.Errorf("retention window = %d days; runCleanup treats <= 0 as \"do nothing\"", got)
+	}
+	if s.opts.Table != "model_probe_results" {
+		t.Errorf("Table = %q, want model_probe_results", s.opts.Table)
+	}
+}
+
+func insertProbeRetentionSite(t *testing.T, db *store.DB, suffix string, now time.Time) int64 {
+	t.Helper()
+	stamp := now.Format(time.RFC3339)
+	query := `INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, 'openai', 'active', ?, ?)`
+	args := []any{"probe-retention-" + suffix, "https://probe-retention-" + suffix + ".example.test", stamp, stamp}
+	if db.Dialect == store.DialectPostgres {
+		var id int64
+		if err := db.QueryRow(query+" RETURNING id", args...).Scan(&id); err != nil {
+			t.Fatalf("insert postgres site: %v", err)
+		}
+		return id
+	}
+	result, err := db.Exec(query, args...)
+	if err != nil {
+		t.Fatalf("insert sqlite site: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("sqlite site LastInsertId: %v", err)
+	}
+	return id
+}
+
+func insertProbeRetentionAccount(t *testing.T, db *store.DB, siteID int64, suffix string, now time.Time) int64 {
+	t.Helper()
+	stamp := now.Format(time.RFC3339)
+	query := `INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?, ?)`
+	args := []any{siteID, "probe-retention-" + suffix, "sk-probe-retention-" + suffix, true, stamp, stamp}
+	if db.Dialect == store.DialectPostgres {
+		var id int64
+		if err := db.QueryRow(query+" RETURNING id", args...).Scan(&id); err != nil {
+			t.Fatalf("insert postgres account: %v", err)
+		}
+		return id
+	}
+	result, err := db.Exec(query, args...)
+	if err != nil {
+		t.Fatalf("insert sqlite account: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("sqlite account LastInsertId: %v", err)
+	}
+	return id
+}
+
+func insertProbeResult(t *testing.T, db *store.DB, accountID, siteID int64, model, createdAt string) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO model_probe_results
+			(channel_id, account_id, site_id, model_name, status, latency_ms, http_status, error_text, created_at)
+		 VALUES (NULL, ?, ?, ?, 'success', 12, 200, NULL, ?)`,
+		accountID, siteID, model, createdAt); err != nil {
+		t.Fatalf("insert probe result (%d, %s, %s): %v", accountID, model, createdAt, err)
+	}
+}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1772,6 +1772,7 @@ func TestAllSchedulersImplementInterface(t *testing.T) {
 		NewSub2APIRefreshScheduler(cfg),
 		NewSiteAnnouncementScheduler(cfg),
 		NewAdminBackgroundTaskRetentionScheduler(cfg),
+		NewModelProbeResultRetentionScheduler(cfg),
 	}
 
 	names := make(map[string]bool)
@@ -1791,7 +1792,7 @@ func TestAllSchedulersImplementInterface(t *testing.T) {
 		"log-cleanup", "daily-summary", "usage-aggregation",
 		"backup-webdav",
 		"proxy-log-retention", "sub2api-refresh", "site-announcement",
-		"admin-background-task-retention",
+		"admin-background-task-retention", "model-probe-result-retention",
 	}
 
 	for _, exp := range expectedNames {


### PR DESCRIPTION
## The gap

`model_probe_results` had no `DELETE` anywhere in the codebase. One row per probed `(channel, model)` per pass — tens of thousands of rows a day once probing is on — kept forever, in the one table that is also excluded from backups (`store/tablesets.go`: stale rows from another deployment would steer routing, and the prober regenerates them). Every other high-write table already had a bounded life through the shared `RetentionScheduler`: `proxy_logs`, `proxy_video_tasks`, `admin_background_tasks`.

It is not only a "someday" cost. Both readers want the newest rows and nothing else:

- `service.loadLatestProbeFailures` (the route-rebuild probe filter, #625) reads `WHERE id IN (SELECT MAX(id) … GROUP BY account_id, model_name)` — the latest row per pair. Every other row is invisible to routing.
- `handler/admin.queryProbeHistory` takes the latest N rows per channel/account with **no time filter**, through a `ROW_NUMBER()` window over the whole table. Extra days never reach the screen; every extra row is paid for on each history request and by three indexes on each insert.

## The policy

Seven days, hourly, one exemption — registered with the existing owner (`scheduler/probe_retention.go`, wired as Scheduler 13d). No new framework, no new config surface: `RetentionSchedulerOptions` already reads both values from config, so promoting the window to a knob later is two lines here plus a docs/env-parity entry, cheaper than carrying an unexercised setting now.

The exemption is the part that matters:

```sql
DELETE FROM model_probe_results WHERE created_at < ?
  AND id NOT IN (SELECT MAX(id) FROM model_probe_results GROUP BY account_id, model_name)
```

The newest row of every `(account_id, model_name)` pair survives **however old it is**, because that is exactly the row set route rebuild reads. A plain age-based prune would drop the probe filter's input for any model not probed inside the window — probing paused, channel disabled, account idle — and a cleanup job would silently change routing. `MAX(id)` is never NULL within a group (`id` is the primary key), so the `NOT IN` cannot degenerate into "delete nothing" the way a nullable subquery would.

## Evidence

Both dialects run for real, not one plus a mock — SQLite in-memory and PostgreSQL 16 behind `PG_TEST_DSN` — and the test asserts the consumer's **own** query rather than a paraphrase: after the prune, `WHERE id IN (SELECT MAX(id) … GROUP BY account_id, model_name)` still returns one row per seeded pair. Seeded per pair: an aged non-newest row (must go), an aged newest row (must stay), an in-window row (must stay), and a second account to prove the exemption is per `(account, model)` and not one global newest row. The seed is counted before the prune, so a failed insert cannot pass vacuously.

Live, in a real process on the **shipping** configuration — no mutant, no harness, a throwaway instance with its own `DATA_DIR` and a binary stamped with the branch commit (`/api/about` asserted to match):

```
level=INFO msg="model-probe-result-retention scheduler started" interval_min=60 retention_days=7
level=INFO msg="model-probe-result-retention: cleanup complete" deleted=1 cutoff=2026-08-27T22:53:32Z retention_days=7
remaining probe rows: 2
  kept model=gpt-aged  created_at=…now-8d   <- out of window, exempt: route rebuild reads this one
  kept model=gpt-fresh created_at=…now-1h
LIVE_PROOF_E7B: PASS
```

Mutation probes — each property broken on purpose, each had to go red, then restored byte-exactly with the control green again:

| probe | mutation | result |
|---|---|---|
| drop the exemption | `ExtraWhere: ""` | red — `pruned the newest (account A, gpt-stale) row …: route rebuild's probe filter reads exactly this row`, `latest-per-pair query returns 1 rows, want 3`, on **both** dialects |
| zero-day window | `modelProbeResultRetentionDays = 0` | red — in-window row pruned, plus `retention window = 0 days; runCleanup treats <= 0 as "do nothing"` |
| constructed but never registered | `Register(...)` → `_ = ...` | red — `registered 15 schedulers, want 16` |

The third probe is the one worth naming: `app.TestBuildSchedulersRegistration` exists because balance-refresh, log-cleanup and backup-webdav were once constructed and never registered, so they silently never started. A new job that no test would notice missing is exactly that regression.

Regression, real PG DSN, `-count=1`: `scheduler 19.9s · app 1.4s · service 5.7s · handler/admin 53.7s`, all `ok`.

## Deliberately not here

`admin_audit_logs` (the largest table on the reference testbed) and `checkin_logs` also have no retention. Deleting audit history is a product decision that needs an operator's sign-off, not something to slip in beside a telemetry prune, so both stay untouched and recorded.

Fixes #1221
