### PR TITLE
fix(platform): report what the upstream actually answered when a login is blocked

### DIFF
--- a/platform/login_blocked_reason_test.go
+++ b/platform/login_blocked_reason_test.go
@@ -1,0 +1,152 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A login answer that is not a JSON object used to be reported with one fixed
+// sentence, "shield challenge blocked login", no matter what the site actually
+// said. Observed against a real new-api: HTTP 429 on /api/user/login (its own
+// access log, at exactly the moments Metapi reported a shield challenge) after
+// the documented re-bind path was used a few times in a row. The message named a
+// cause that did not exist and gave the operator nothing to do about the one
+// that did.
+//
+// These tests pin the two halves of the fix: the observed status/content type
+// decide the wording, and the upstream body is never echoed — a challenge or
+// error page can carry markup, tokens or internal URLs, and a login failure
+// message travels back to whoever called the admin API.
+
+// loginAnswerServer answers /api/user/login with an exact status, content type
+// and body, which is the whole input to the blocked-login message.
+func loginAnswerServer(t *testing.T, status int, contentType, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/user/login" {
+			http.NotFound(w, r)
+			return
+		}
+		if contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		w.WriteHeader(status)
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// loginCapable is the shared Login shape of the two adapters that fetch a
+// dashboard login through fetchLoginResponse.
+type loginCapable interface {
+	Login(ctx context.Context, baseURL, username, password string, platformUserId *int, proxy *ProxyConfig) (*LoginResult, error)
+}
+
+func TestLoginBlockedMessageReportsTheObservedUpstreamAnswer(t *testing.T) {
+	cases := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		wantAll     []string
+		wantNone    []string
+	}{
+		{
+			name:        "the site rate-limited the login",
+			status:      http.StatusTooManyRequests,
+			contentType: "text/plain; charset=utf-8",
+			body:        "Too Many Requests",
+			wantAll:     []string{"429", "rate-limit", "retry"},
+			// A 429 must not be dressed up as anti-bot protection: that is the
+			// exact misdiagnosis this fix exists to remove.
+			wantNone: []string{"shield challenge blocked login", "WAF/shield challenge", "Too Many Requests"},
+		},
+		{
+			name:        "a WAF/shield challenge page on HTTP 200",
+			status:      http.StatusOK,
+			contentType: "text/html",
+			body:        "<html><script>var acw_sc__v2='challenge-secret-do-not-leak';</script></html>",
+			wantAll:     []string{"200", "text/html", "WAF/shield challenge"},
+			wantNone:    []string{"challenge-secret-do-not-leak", "<script>"},
+		},
+		{
+			name:        "a proxy or gateway error page",
+			status:      http.StatusServiceUnavailable,
+			contentType: "text/html; charset=utf-8",
+			body:        "<html><body>503 upstream connect error, internal-host-9.internal</body></html>",
+			wantAll:     []string{"503", "text/html"},
+			wantNone:    []string{"internal-host-9.internal", "upstream connect error"},
+		},
+		{
+			name:        "no content type at all",
+			status:      http.StatusBadGateway,
+			contentType: "",
+			body:        "",
+			wantAll:     []string{"502"},
+			wantNone:    []string{"shield challenge blocked login"},
+		},
+	}
+
+	adapters := map[string]loginCapable{
+		"new-api": &NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")},
+		"one-api": &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")},
+	}
+
+	for _, tc := range cases {
+		for name, adapter := range adapters {
+			t.Run(name+"/"+tc.name, func(t *testing.T) {
+				srv := loginAnswerServer(t, tc.status, tc.contentType, tc.body)
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				result, err := adapter.Login(ctx, srv.URL, "root", "metapi123", nil, nil)
+				if err != nil {
+					t.Fatalf("Login returned an error instead of a failed result: %v", err)
+				}
+				if result.Success {
+					t.Fatalf("Login.Success = true for a non-JSON HTTP %d answer", tc.status)
+				}
+				msg := result.Message
+				if strings.TrimSpace(msg) == "" {
+					t.Fatal("Login.Message is empty: the operator gets no reason at all")
+				}
+				for _, want := range tc.wantAll {
+					if !strings.Contains(msg, want) {
+						t.Errorf("Login.Message = %q, want it to name %q", msg, want)
+					}
+				}
+				for _, notWant := range tc.wantNone {
+					if strings.Contains(msg, notWant) {
+						t.Errorf("Login.Message = %q, must not contain %q", msg, notWant)
+					}
+				}
+			})
+		}
+	}
+}
+
+// The accurate message must not cost the accurate success paths: a JSON answer
+// still decides everything, including the legacy cookie-only login.
+func TestLoginStillTrustsAJsonAnswerOverTheBlockedMessage(t *testing.T) {
+	srv := loginAnswerServer(t, http.StatusOK, "application/json",
+		`{"success":true,"message":"","data":{"access_token":"sk-durable-token"}}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := (&NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")}).Login(ctx, srv.URL, "root", "metapi123", nil, nil)
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !result.Success || result.AccessToken != "sk-durable-token" {
+		t.Fatalf("Login = %+v, want success with the JSON token", result)
+	}
+	if strings.Contains(result.Message, "login blocked") {
+		t.Errorf("a successful JSON login carried the blocked message: %q", result.Message)
+	}
+}

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -64,13 +64,14 @@ func (n *NewApiAdapter) Login(ctx context.Context, baseURL, username, password s
 		"User-Agent":       DefaultBrowserUserAgent,
 	}
 
-	parsed, cookieHeader, err := fetchLoginResponse(ctx, baseURL+"/api/user/login", body, headers, proxy)
+	answer, err := fetchLoginResponse(ctx, baseURL+"/api/user/login", body, headers, proxy)
 	if err != nil {
 		return &LoginResult{Success: false, Message: err.Error()}, nil
 	}
+	parsed, cookieHeader := answer.Parsed, answer.Cookie
 
 	if parsed == nil {
-		return &LoginResult{Success: false, Message: "shield challenge blocked login"}, nil
+		return &LoginResult{Success: false, Message: loginBlockedMessage(answer.Status, answer.ContentType)}, nil
 	}
 
 	data, _ := getMap(parsed, "data")
@@ -875,20 +876,31 @@ func (n *NewApiAdapter) GetSiteAnnouncements(ctx context.Context, baseURL, acces
 
 // --- Login fetch ---
 
-// fetchLoginResponse performs a single login POST and returns the parsed JSON
-// body (nil for non-JSON responses) plus the accumulated Set-Cookie header.
+// loginResponse is what an upstream login endpoint actually answered. The status
+// and content type travel with the parsed body because "could not parse it" is
+// not a diagnosis: a rate limit, a WAF challenge, an error page and a proxy in
+// front of the site all arrive here looking the same, and only the status line
+// tells them apart.
+type loginResponse struct {
+	Parsed      map[string]interface{} // nil when the body was not a JSON object
+	Cookie      string                 // accumulated Set-Cookie header
+	Status      int
+	ContentType string
+}
+
+// fetchLoginResponse performs a single login POST and returns what arrived.
 // Shield-protected sites return an HTML challenge here; parsing fails and the
-// caller reports "shield challenge blocked login" without retrying (the
-// acw_sc__v2 challenge requires JS execution, which Go cannot provide).
-func fetchLoginResponse(ctx context.Context, url string, body map[string]string, headers map[string]string, proxy *ProxyConfig) (map[string]interface{}, string, error) {
+// caller reports the observed status instead of retrying (the acw_sc__v2
+// challenge requires JS execution, which Go cannot provide).
+func fetchLoginResponse(ctx context.Context, url string, body map[string]string, headers map[string]string, proxy *ProxyConfig) (loginResponse, error) {
 	reqBody, err := json.Marshal(body)
 	if err != nil {
-		return nil, "", fmt.Errorf("marshal body: %w", err)
+		return loginResponse{}, fmt.Errorf("marshal body: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(reqBody)))
 	if err != nil {
-		return nil, "", fmt.Errorf("create request: %w", err)
+		return loginResponse{}, fmt.Errorf("create request: %w", err)
 	}
 	if _, ok := headers["Content-Type"]; !ok {
 		headers["Content-Type"] = "application/json"
@@ -899,19 +911,47 @@ func fetchLoginResponse(ctx context.Context, url string, body map[string]string,
 
 	resp, err := DoWithProxy(ctx, req, proxy)
 	if err != nil {
-		return nil, "", fmt.Errorf("request: %w", err)
+		return loginResponse{}, fmt.Errorf("request: %w", err)
 	}
-	cookieHeader := mergeSetCookie("", resp.Header["Set-Cookie"])
+	out := loginResponse{
+		Cookie:      mergeSetCookie("", resp.Header["Set-Cookie"]),
+		Status:      resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+	}
 
 	respBody, err := readPlatformResponseBody(resp.Body, platformTextResponseBodyLimit)
 	resp.Body.Close()
 	if err != nil {
-		return nil, cookieHeader, fmt.Errorf("read body: %w", err)
+		return out, fmt.Errorf("read body: %w", err)
 	}
 
-	var parsed map[string]interface{}
-	if json.Unmarshal(respBody, &parsed) != nil {
-		return nil, cookieHeader, nil
+	if json.Unmarshal(respBody, &out.Parsed) != nil {
+		out.Parsed = nil
 	}
-	return parsed, cookieHeader, nil
+	return out, nil
+}
+
+// loginBlockedMessage renders the failure an operator actually has to act on when
+// a login answer was not a JSON object. This used to be one sentence for every
+// case — "shield challenge blocked login" — so a site answering HTTP 429 was
+// reported as a WAF challenge, sending the operator hunting for anti-bot
+// protection that did not exist. Observed live against a real new-api: its access
+// log shows 429 on /api/user/login at exactly the moments Metapi reported a
+// shield challenge, and the same request replayed two minutes later returned
+// JSON 200. Re-binding an account a few times in a row is enough to trip a
+// site's own login limiter, and re-binding is the recovery path the docs tell
+// users to take when a credential ages out.
+//
+// Only the status and the content type are reported. The body is deliberately
+// not echoed: a challenge or error page can carry markup, tokens or internal
+// URLs, and none of that belongs in a message a downstream client can read.
+func loginBlockedMessage(status int, contentType string) string {
+	if status == http.StatusTooManyRequests {
+		return "upstream rate-limited the login (HTTP 429): wait a minute and retry — repeated re-binds trip the site's own login limiter"
+	}
+	kind := strings.TrimSpace(contentType)
+	if kind == "" {
+		kind = "no content type"
+	}
+	return fmt.Sprintf("login blocked: upstream answered HTTP %d with %s instead of JSON — a WAF/shield challenge (which needs a real browser), an error or rate-limit page, or a proxy in front of the site", status, kind)
 }

--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -60,13 +60,14 @@ func (o *OneApiAdapter) Login(ctx context.Context, baseURL, username, password s
 		"User-Agent":       DefaultBrowserUserAgent,
 	}
 
-	parsed, cookieHeader, err := fetchLoginResponse(ctx, baseURL+"/api/user/login", body, headers, proxy)
+	answer, err := fetchLoginResponse(ctx, baseURL+"/api/user/login", body, headers, proxy)
 	if err != nil {
 		return &LoginResult{Success: false, Message: err.Error()}, nil
 	}
+	parsed, cookieHeader := answer.Parsed, answer.Cookie
 
 	if parsed == nil {
-		return &LoginResult{Success: false, Message: "shield challenge blocked login"}, nil
+		return &LoginResult{Success: false, Message: loginBlockedMessage(answer.Status, answer.ContentType)}, nil
 	}
 
 	data, _ := getMap(parsed, "data")


### PR DESCRIPTION
## Observed failure

`POST /api/accounts/login` answered **`{"error":"shield challenge blocked login"}`** while the upstream was answering **HTTP 429**.

**1. Who hit it:** the v0.19 stability window, walking the recovery path our own docs prescribe. Twice in one afternoon — once from the fresh-install walkthrough, once from the public `scripts/e2e/smoke.sh` chain.
**2. What were they doing:** re-binding an account whose credential had aged out, exactly as `docs/getting-started.md` §3 now instructs (*"Credentials age out. Re-bind by choosing Add account again with the same site and the same username"*). Doing that a few times in a row is precisely what trips a site's own login limiter.
**3. What actually happened:** the upstream's access log records `429` on `POST /api/user/login` at the exact timestamps of both failures (and `200` for the attempts on either side). The identical request replayed by hand two minutes later returned JSON `200 success:true`. Metapi said "shield challenge blocked login" — naming a WAF anti-bot challenge that did not exist, and hiding the one thing the operator could act on.
**4. What was expected:** the reason the server actually observed. `platform/newapi.go` already knew the answer was not JSON; it did not know *why*, because `fetchLoginResponse` threw the status line away and every non-JSON answer collapsed into one pre-chosen diagnosis.
**5. Reproducible:** yes, deterministically. `login-reason/live-proof.sh` runs an upstream that answers a login the two ways the real one does — `429 text/plain` and `200 text/html` — and drives both binaries through the real admin API: the released v0.19.0 asset says `shield challenge blocked login` for **both**, the branch says `upstream rate-limited the login (HTTP 429): wait a minute and retry …` for the first and names `HTTP 200` + `text/html` with a WAF challenge listed as one possibility for the second. 19 passed / 0 failed.
**6. Which layer should have caught it:** the adapter's login tests. They covered JSON success, JSON failure and cookie-only login — every answer that *parses*. Nothing covered an answer that does not, which is the only case where this message exists.
**7. Why it didn't:** the message was a constant, so no input could make it wrong. A constant cannot be tested into being accurate.
**8. Smallest root fix:** carry the two facts the fetch already has — status and content type — out of `fetchLoginResponse`, and render them. No retry, no backoff, no new type, no control-flow change: an unparseable login answer still fails the login exactly as before, it just says what it saw.

## What changes

- `platform/newapi.go` — `fetchLoginResponse` returns a `loginResponse` (parsed body, cookie, status, content type) instead of `(map, string, error)`; new `loginBlockedMessage(status, contentType)` renders the observed answer: `429` says rate-limited and retry, anything else names the status and content type and lists a WAF/shield challenge as *one* possibility next to an error page or a proxy in front of the site.
- `platform/newapi.go` + `platform/oneapi.go` — both call sites (the two adapters that share this fetch) report it. The fixed sentence is gone from production code.
- `platform/login_blocked_reason_test.go` — pins the two halves: the observed status/content type choose the wording, and **the upstream body is never echoed** (a challenge or error page can carry markup, tokens or internal hostnames, and this message travels back to whoever called the admin API). Both adapters are covered, and a JSON answer still decides everything, including the legacy cookie-only login.

The body is deliberately not included in the message; only the status line and the content type are. That is also why the fix cannot leak a challenge page's own markup into a client-visible error.

## Proof it can go red

Five mutation probes, each committed-then-reverted, each red for the stated reason and green after restore:

| # | mutation | result |
|---|---|---|
| P1 | ignore the status when choosing words (`if false`) | red: the 429 case gets the generic sentence, which dresses a rate limit up as anti-bot protection |
| P2 | revert the new-api call site to the constant | red: 5 subtests, message is the old sentence |
| P3 | stop plumbing the content type out of the fetch | red: the HTML-challenge case reports "no content type" |
| P4 | stop plumbing the status out of the fetch | red: 9 subtests report `HTTP 0` |
| P5 | revert the one-api call site | red: the one-api subtests, i.e. the second owner of the same sentence |

Local: `go build ./...`, `go vet`, `gofmt`, `go test ./platform/` (full package) and `go test ./handler/admin/ -run 'Login|Account'` green.

## Release

None. v0.19.0 stays the frozen baseline; this accumulates towards v0.19.1 with #1225.
