### PR TITLE
docs(deployment): the upgrade checklist was missing the step that makes an old account work again

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -404,7 +404,22 @@ Upgrade checklist:
 1. Back up the database first (cp data/hub.db ... or pg_dump -Fc ...).
 2. Prefer pinning the release selected for your deployment (for example `ghcr.io/deliciousbuding/metapi-go:vX.Y.Z`) over `latest` so rollback is reproducible.
 3. After upgrade, verify GET /ready returns 200 and run bash web/scripts/verify-live-assets.sh http://127.0.0.1:4000.
-4. Rollback = restore the pre-upgrade backup and re-run the previous pinned image tag. Schema changes are forward-only; do not downgrade the schema by deleting rows from schema_migrations.
+4. **Upgrading from v0.17.x or older? Re-bind each upstream account once.**
+   Those versions stored the upstream *dashboard session* as the account
+   credential — on New API-family sites that is a JWT which expires in about
+   fifteen minutes — and no schema migration can turn it into the durable
+   credential v0.18.0+ uses. The upgrade keeps the account row, so everything
+   looks bound; then model refresh and relay start failing once that session is
+   gone (`503 No available channels`, an empty model list, `balance refresh
+   failed: upstream credential expired`). Re-bind from **添加账号 (Add account)**
+   with the *same site and the same username*: the backend upserts that account,
+   exchanges the login for the site's durable credential, revokes the transient
+   session, and re-syncs its models immediately. There is no separate
+   "re-login" button for password/session accounts. This was verified on a real
+   v0.16.23 → v0.19.0 in-place upgrade of a live SQLite database: 28 additive
+   migrations, site / account / downstream key / route all preserved, and the
+   chain only served a real completion again after this step.
+5. Rollback = restore the pre-upgrade backup and re-run the previous pinned image tag. Schema changes are forward-only; do not downgrade the schema by deleting rows from schema_migrations.
 
 ## Post-deploy asset smoke (mandatory)
 


### PR DESCRIPTION
## Observed failure

An operator upgrading from v0.16.23 to v0.19.0 does everything the upgrade checklist says — back up, pin the tag, pull, restart, verify `/ready` — and the deployment still cannot serve a request.

**1. Who hit it:** the Case 2 upgrade walkthrough of the v0.19 stability window, on the released v0.19.0 bytes and a real v0.16.23 SQLite database, reproducing the deployment shape of #1179 (the report that turned this project around: *"部署后基本用不了"*).
**2. What were they doing:** following `docs/deployment.md`'s upgrade checklist, then using the instance.
**3. What actually happened:** the upgrade itself is clean — 28 additive migrations, site / account / downstream key / route all preserved, `about` reporting the new version and commit. But the account still carried the credential its old version stored: the upstream **dashboard session**, which on New API-family sites is a JWT that expires in about fifteen minutes. Nothing in a schema migration can turn that into the durable credential v0.18.0+ uses. The row looks bound, so the failure surfaces later and elsewhere: `models=0`, `503 No available channels`, `balance refresh failed: upstream credential expired (HTTP 401)`.
**4. What was expected:** the checklist to name the one operator step that makes an old account work again. It is already documented in `getting-started.md` §3 (re-bind via **Add account**, same site + username — the backend upserts, exchanges the login for the durable credential, revokes the transient session, re-syncs models immediately) and it is what we told the reporting user to do in #1179. The upgrade doc — the place an upgrader actually reads — did not mention it.
**5. Reproducible:** yes. `stability-v019/upgrade/upgrade-test.sh`, 24 passed / 0 failed / 8 noted: the symptom is reproduced on v0.16.23 first (`503 No available channels` with `models=0` right after binding), the same data dir is then upgraded in place, and the chain serves a real completion — with the mock upstream's request log as proof — only after the re-bind step, and still does after a restart.
**6. Which layer should have caught it:** no automated layer can; this is a documentation completeness gap on the upgrade path.
**7. Why it didn't:** the re-bind requirement was discovered while fixing #1179 and written into the credential-mode guidance and an issue reply. The upgrade checklist was never re-read against it.
**8. Smallest root fix:** one checklist item, in the doc that owns upgrades. No code, no behaviour, no test changes.

## What changes

`docs/deployment.md` — upgrade checklist gains item 4: upgrading from v0.17.x or older requires re-binding each upstream account once, with the reason (session credential vs durable credential), the symptoms to expect if you skip it, the exact UI path, an explicit note that there is no separate "re-login" button for password/session accounts, and the evidence it was verified against. The old item 4 (rollback) becomes item 5.

`go test ./docs/` green (public-markdown hygiene, internal-link and relative-link gates).

## Release

None. Docs-only; accumulates with #1225 and #1227 towards v0.19.1.
