### PR TITLE
fix(admin): a deleted route no longer makes its downstream keys uneditable

### DIFF
--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -512,6 +513,22 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 	if hasField["allowedRouteIds"] {
 		allowedRouteIds = normalizeAllowedRouteIdsInput(body.AllowedRouteIds)
 	}
+	// Heal an allowlist this request did not choose. A route deleted before
+	// pruneDeletedRouteIDsFromDownstreamKeys existed left its id behind here, and
+	// the validation below then rejected EVERY save of this key — including a
+	// rename, because an omitted allowedRouteIds carries the stored list forward.
+	// The UI has no control for this field, so there was no way to drop the dead
+	// id: the key became permanently uneditable. Ids the request inherits are
+	// pruned and reported; ids it introduces stay in the list so validation still
+	// rejects a mistyped route id loudly.
+	grants, healErr := h.healInheritedRouteGrants(allowedRouteIds, existingAllowedRouteIds)
+	if healErr != nil {
+		slog.Warn("downstream key update could not check inherited route grants",
+			"downstreamKeyId", id, "error", healErr)
+		writeError(w, http.StatusInternalServerError, "failed to validate policy references")
+		return
+	}
+	allowedRouteIds = grants.Persist
 
 	existingSiteWeightMultipliers := parseMapFromDB(existing, "site_weight_multipliers")
 	siteWeightMultipliers := existingSiteWeightMultipliers
@@ -604,7 +621,11 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 	}
 
 	// Policy reference validation.
-	refErr, refDbErr := h.validateDownstreamPolicyReferences(allowedRouteIds, siteWeightMultipliers, excludedSiteIds, excludedCredentialRefs, allowedSiteIds, allowedCredentialRefs)
+	// Validation vouches for what this save is responsible for: live grants and
+	// ids the request introduced. Grants left behind by a route deletion that
+	// cannot be pruned without widening the key are reported instead of rejected,
+	// which is what made such a key uneditable before.
+	refErr, refDbErr := h.validateDownstreamPolicyReferences(grants.Validate, siteWeightMultipliers, excludedSiteIds, excludedCredentialRefs, allowedSiteIds, allowedCredentialRefs)
 	if refDbErr != nil {
 		writeError(w, http.StatusInternalServerError, "failed to validate policy references")
 		return
@@ -651,10 +672,217 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 	// Update must not return full key; only keyMasked.
 	redactDownstreamKeySecret(updated)
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	response := map[string]any{
 		"success": true,
 		"item":    updated,
-	})
+	}
+	if len(grants.Healed) > 0 {
+		// The save succeeded and the allowlist got smaller; say so rather than
+		// let the caller believe it wrote the list it sent.
+		response["prunedRouteIds"] = grants.Healed
+		slog.Warn("downstream key update dropped route grants that no longer exist",
+			"downstreamKeyId", id, "prunedRouteIds", grants.Healed)
+	}
+	if len(grants.Stale) > 0 {
+		response["staleRouteIds"] = grants.Stale
+		response["staleRouteGrantNotice"] = "this key authorizes only routes that no longer exist, so it serves nothing; the grants were kept because dropping them would widen the key to every route — replace them with live routes, or clear the list to allow all routes"
+		slog.Warn("downstream key still authorizes only deleted routes",
+			"downstreamKeyId", id, "staleRouteIds", grants.Stale)
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// routeGrantHeal is the outcome of reconciling a key's route allowlist with the
+// routes that still exist.
+//
+// The rule, stated once because both the save path and the route-delete path
+// depend on it: a dead grant is removed only when removing it cannot widen the
+// key. An empty allowlist means "no route restriction", so pruning the LAST
+// grant of a restricted key would silently promote it from "serves nothing" to
+// "serves every route" — the same fail-open shape as an allowlist that falls
+// back to empty. When every grant is dead the ids stay (the key keeps denying),
+// the save still succeeds, and the ids are reported so an operator can decide:
+// widening a credential has to be an explicit act.
+type routeGrantHeal struct {
+	Persist  []int64 // what goes to the database
+	Validate []int64 // what reference validation must still vouch for
+	Healed   []int64 // dead grants removed
+	Stale    []int64 // dead grants kept, because removing them would widen the key
+}
+
+// healInheritedRouteGrants applies that rule to one key. Inherited ids are the
+// ones already stored: a dead id this request did not introduce is a leftover of
+// a route deletion, not a mistake to reject. Ids the request introduces stay in
+// Validate, so a mistyped route id is still rejected loudly instead of being
+// quietly dropped — dropping what an operator just typed would also widen the
+// policy they asked for.
+func (h *downstreamKeysHandler) healInheritedRouteGrants(requested, inherited []int64) (routeGrantHeal, error) {
+	out := routeGrantHeal{Persist: requested, Validate: requested}
+	if len(requested) == 0 {
+		return out, nil
+	}
+	existing := make(map[int64]bool, len(requested))
+	query, args, err := sqlx.In("SELECT id FROM token_routes WHERE id IN (?)", requested)
+	if err != nil {
+		return out, err
+	}
+	rows, err := queryRowsErr(h.db, query, args...)
+	if err != nil {
+		return out, err
+	}
+	for _, row := range rows {
+		if routeID, ok := rowInt64(row["id"]); ok {
+			existing[routeID] = true
+		}
+	}
+	inheritedSet := make(map[int64]bool, len(inherited))
+	for _, routeID := range inherited {
+		inheritedSet[routeID] = true
+	}
+
+	persist := make([]int64, 0, len(requested))
+	validate := make([]int64, 0, len(requested))
+	for _, routeID := range requested {
+		switch {
+		case existing[routeID]:
+			persist = append(persist, routeID)
+			validate = append(validate, routeID)
+		case !inheritedSet[routeID]:
+			// Chosen by this request and unknown: keep it in both lists so
+			// validation rejects it with the reason.
+			persist = append(persist, routeID)
+			validate = append(validate, routeID)
+		default:
+			// Inherited and dead. Dropped only when something live survives.
+			out.Healed = append(out.Healed, routeID)
+		}
+	}
+	if len(persist) == 0 {
+		// Every grant is dead: keep them all so the key still denies every
+		// route, and exempt them from validation so the key stays editable.
+		out.Stale = out.Healed
+		out.Healed = nil
+		out.Persist = requested
+		out.Validate = nil
+		return out, nil
+	}
+	out.Persist, out.Validate = persist, validate
+	return out, nil
+}
+
+// pruneDeletedRouteIDsFromDownstreamKeys drops deleted routes from downstream
+// key allowlists inside the transaction that deletes them, and reports the keys
+// it could not prune without widening.
+//
+// Route deletion cleaned route_group_sources, route_channels and token_routes
+// and stopped there, so downstream_api_keys.allowed_route_ids kept the dead id
+// forever. That is not a cosmetic leak: the key update path validates the list,
+// carries the stored list forward when a request omits it, and the admin UI has
+// no control for the field — so one deleted route made every later edit of that
+// key fail with "allowedRouteIds contains unknown routes: <id>", with no way to
+// remove the id. Reported by an operator running 100+ sites, where route churn
+// is normal rather than exceptional.
+//
+// Route ids are never reused (SQLite AUTOINCREMENT, PostgreSQL SERIAL), so a
+// stale grant can never come back to life pointing at a different route.
+func pruneDeletedRouteIDsFromDownstreamKeys(tx *sqlx.Tx, routeIDs ...int64) (onlyDeleted []int64, err error) {
+	if len(routeIDs) == 0 {
+		return nil, nil
+	}
+	gone := make(map[int64]bool, len(routeIDs))
+	for _, routeID := range routeIDs {
+		gone[routeID] = true
+	}
+
+	rows, err := tx.Queryx(tx.Rebind(
+		"SELECT id, name, allowed_route_ids FROM downstream_api_keys WHERE allowed_route_ids IS NOT NULL AND allowed_route_ids <> ''"))
+	if err != nil {
+		return nil, fmt.Errorf("read downstream key route grants: %w", err)
+	}
+	type heal struct {
+		keyID   int64
+		kept    []int64
+		removed []int64
+		allDead bool
+	}
+	var heals []heal
+	for rows.Next() {
+		row := map[string]any{}
+		if scanErr := rows.MapScan(row); scanErr != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan downstream key: %w", scanErr)
+		}
+		ids := parseIntArrayFromDB(row, "allowed_route_ids")
+		if len(ids) == 0 {
+			continue
+		}
+		kept := make([]int64, 0, len(ids))
+		var removed []int64
+		for _, routeID := range ids {
+			if gone[routeID] {
+				removed = append(removed, routeID)
+				continue
+			}
+			kept = append(kept, routeID)
+		}
+		if len(removed) == 0 {
+			continue
+		}
+		keyID, ok := rowInt64(row["id"])
+		if !ok {
+			rows.Close()
+			return nil, fmt.Errorf("downstream key row has no usable id")
+		}
+		heals = append(heals, heal{keyID: keyID, kept: kept, removed: removed, allDead: len(kept) == 0})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate downstream keys: %w", err)
+	}
+	rows.Close()
+
+	for _, h := range heals {
+		if h.allDead {
+			// Pruning would empty the allowlist, and empty means "every route".
+			// Leave the dead grant in place so the key keeps serving nothing; the
+			// save path tolerates and reports it, so the key stays editable.
+			onlyDeleted = append(onlyDeleted, h.keyID)
+			slog.Warn("route delete left a downstream key authorizing only deleted routes",
+				"downstreamKeyId", h.keyID, "deletedRouteIds", h.removed,
+				"reason", "pruning the last grant would widen the key to every route; re-authorize it explicitly")
+			continue
+		}
+		if _, execErr := tx.Exec(tx.Rebind("UPDATE downstream_api_keys SET allowed_route_ids = ? WHERE id = ?"),
+			toPersistenceJSON(h.kept), h.keyID); execErr != nil {
+			return nil, fmt.Errorf("prune downstream key %d route grants: %w", h.keyID, execErr)
+		}
+		slog.Info("route delete pruned downstream key route grants",
+			"downstreamKeyId", h.keyID, "removedRouteIds", h.removed, "remainingRouteIds", len(h.kept))
+	}
+	return onlyDeleted, nil
+}
+
+// rowInt64 reads an integer column across both dialects: SQLite scans into
+// int64, PostgreSQL into int64 as well but a driver change or a NUMERIC column
+// must not silently read as "no id".
+func rowInt64(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case float64:
+		return int64(v), true
+	case []byte:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(string(v)), 10, 64)
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		return parsed, err == nil
+	}
+	return 0, false
 }
 
 // POST /api/downstream-keys/:id/reset-usage

--- a/handler/admin/downstream_keys_route_grants_test.go
+++ b/handler/admin/downstream_keys_route_grants_test.go
@@ -1,0 +1,263 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// A deleted route used to stay behind in downstream_api_keys.allowed_route_ids:
+// the delete transaction cleaned route_group_sources, route_channels and
+// token_routes and stopped there. The key update path validates that list and
+// carries the stored list forward when a request omits it, and the admin UI has
+// no control for the field — so one deleted route made every later edit of that
+// key fail with "allowedRouteIds contains unknown routes: <id>" and there was no
+// way to remove the id. An operator running 100+ sites reported exactly that.
+//
+// The fix has two halves, and one hard constraint: pruning must never widen a
+// credential. An empty allowlist means "no route restriction", so dropping the
+// LAST grant of a restricted key would promote it from "serves nothing" to
+// "serves every route". TestDeleteTheLastAuthorizedRouteDoesNotWidenTheKey is
+// the one that protects that; the others protect the unblocking.
+
+func setupRouteGrantTest(t *testing.T) (*store.DB, chi.Router) {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("failed to open SQLite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+	r := chi.NewRouter()
+	RegisterTokenRoutesWithDeps(r, db.DB, TokenRoutesDeps{})
+	RegisterDownstreamKeysRoutes(r, db.DB)
+	return db, r
+}
+
+func seedRouteGrantRoute(t *testing.T, db *store.DB, pattern string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(db.Rebind(
+		`INSERT INTO token_routes (model_pattern, display_name, route_mode, enabled, created_at, updated_at)
+		 VALUES (?, ?, 'pattern', ?, ?, ?)`), pattern, pattern, true, now, now)
+	if err != nil {
+		t.Fatalf("seed route %s: %v", pattern, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("route %s LastInsertId: %v", pattern, err)
+	}
+	return id
+}
+
+func seedRouteGrantKey(t *testing.T, r chi.Router, name string, allowedRouteIDs []int64) int64 {
+	t.Helper()
+	resp := doPostJSON(t, r, "/api/downstream-keys", map[string]any{
+		"name":            name,
+		"key":             "sk-" + name,
+		"supportedModels": []string{"*"},
+		"allowedRouteIds": allowedRouteIDs,
+	})
+	if resp.Code != http.StatusOK && resp.Code != http.StatusCreated {
+		t.Fatalf("create key %s returned %d: %s", name, resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Item struct {
+			ID int64 `json:"id"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode create response for %s: %v (%s)", name, err, resp.Body.String())
+	}
+	if body.Item.ID == 0 {
+		t.Fatalf("create key %s returned no id: %s", name, resp.Body.String())
+	}
+	return body.Item.ID
+}
+
+func storedRouteGrants(t *testing.T, db *store.DB, keyID int64) []int64 {
+	t.Helper()
+	row := queryRow(db.DB, "SELECT * FROM downstream_api_keys WHERE id = ?", keyID)
+	if row == nil {
+		t.Fatalf("downstream key %d is gone", keyID)
+	}
+	return parseIntArrayFromDB(row, "allowed_route_ids")
+}
+
+func decodeGrantBody(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	out := map[string]any{}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode response: %v (%s)", err, body)
+	}
+	return out
+}
+
+func idList(t *testing.T, value any) []int64 {
+	t.Helper()
+	if value == nil {
+		return nil
+	}
+	raw, ok := value.([]any)
+	if !ok {
+		t.Fatalf("expected a JSON array, got %T (%v)", value, value)
+	}
+	out := make([]int64, 0, len(raw))
+	for _, item := range raw {
+		number, ok := item.(float64)
+		if !ok {
+			t.Fatalf("expected numbers in %v, got %T", raw, item)
+		}
+		out = append(out, int64(number))
+	}
+	return out
+}
+
+// The common case: a key authorized for several routes loses one to a delete and
+// must stay editable afterwards.
+func TestDeleteRoutePrunesTheGrantFromDownstreamKeys(t *testing.T) {
+	db, r := setupRouteGrantTest(t)
+	routeA := seedRouteGrantRoute(t, db, "grant-a-*")
+	routeB := seedRouteGrantRoute(t, db, "grant-b-*")
+	keyID := seedRouteGrantKey(t, r, "multi-grant", []int64{routeA, routeB})
+
+	resp := doDelete(t, r, "/api/routes/"+strconv.FormatInt(routeA, 10))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("delete route returned %d: %s", resp.Code, resp.Body.String())
+	}
+	body := decodeGrantBody(t, resp.Body.Bytes())
+	if got := idList(t, body["downstreamKeysWithOnlyDeletedRoutes"]); len(got) != 0 {
+		t.Errorf("delete reported keys it should have pruned cleanly: %v", got)
+	}
+
+	got := storedRouteGrants(t, db, keyID)
+	if len(got) != 1 || got[0] != routeB {
+		t.Fatalf("stored grants after delete = %v, want [%d] (the deleted route must not stay behind)", got, routeB)
+	}
+
+	// The point of the cascade: this save used to fail on the dead id.
+	rename := doPutJSON(t, r, "/api/downstream-keys/"+strconv.FormatInt(keyID, 10), map[string]any{"name": "renamed-after-delete"})
+	if rename.Code != http.StatusOK {
+		t.Fatalf("renaming the key after a route delete returned %d: %s", rename.Code, rename.Body.String())
+	}
+}
+
+// The constraint that outranks the convenience: pruning the last grant would
+// turn "serves nothing" into "serves every route", so it must not happen.
+func TestDeleteTheLastAuthorizedRouteDoesNotWidenTheKey(t *testing.T) {
+	db, r := setupRouteGrantTest(t)
+	routeA := seedRouteGrantRoute(t, db, "only-grant-*")
+	keyID := seedRouteGrantKey(t, r, "single-grant", []int64{routeA})
+
+	resp := doDelete(t, r, "/api/routes/"+strconv.FormatInt(routeA, 10))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("delete route returned %d: %s", resp.Code, resp.Body.String())
+	}
+	body := decodeGrantBody(t, resp.Body.Bytes())
+	reported := idList(t, body["downstreamKeysWithOnlyDeletedRoutes"])
+	if len(reported) != 1 || reported[0] != keyID {
+		t.Fatalf("delete must name the key it left authorizing only deleted routes, got %v (want [%d])", reported, keyID)
+	}
+
+	got := storedRouteGrants(t, db, keyID)
+	if len(got) != 1 || got[0] != routeA {
+		t.Fatalf("stored grants = %v, want the dead id [%d] kept: an empty allowlist means EVERY route, so pruning here would widen the key", got, routeA)
+	}
+
+	// The key must still be editable — that is the whole unblock — and the save
+	// must say out loud that its grants point at nothing.
+	rename := doPutJSON(t, r, "/api/downstream-keys/"+strconv.FormatInt(keyID, 10), map[string]any{"name": "renamed-single-grant"})
+	if rename.Code != http.StatusOK {
+		t.Fatalf("saving a key whose only grant was deleted returned %d: %s (this is the reported defect)", rename.Code, rename.Body.String())
+	}
+	renameBody := decodeGrantBody(t, rename.Body.Bytes())
+	if stale := idList(t, renameBody["staleRouteIds"]); len(stale) != 1 || stale[0] != routeA {
+		t.Errorf("staleRouteIds = %v, want [%d]", stale, routeA)
+	}
+	notice, _ := renameBody["staleRouteGrantNotice"].(string)
+	if !strings.Contains(notice, "every route") {
+		t.Errorf("the notice must explain why the grant was kept, got %q", notice)
+	}
+	if pruned := idList(t, renameBody["prunedRouteIds"]); len(pruned) != 0 {
+		t.Errorf("prunedRouteIds = %v, want none: pruning the last grant is the widening this test forbids", pruned)
+	}
+	if got := storedRouteGrants(t, db, keyID); len(got) != 1 || got[0] != routeA {
+		t.Fatalf("stored grants after save = %v, want the dead id still there", got)
+	}
+
+	// Widening stays an explicit operator act: clearing the list is allowed.
+	clear := doPutJSON(t, r, "/api/downstream-keys/"+strconv.FormatInt(keyID, 10), map[string]any{"allowedRouteIds": []int64{}})
+	if clear.Code != http.StatusOK {
+		t.Fatalf("clearing the allowlist returned %d: %s", clear.Code, clear.Body.String())
+	}
+	if got := storedRouteGrants(t, db, keyID); len(got) != 0 {
+		t.Fatalf("stored grants after an explicit clear = %v, want empty", got)
+	}
+}
+
+// Rows that are already dangling in the wild (written before the cascade
+// existed) heal on the next save instead of blocking it.
+func TestUpdateKeyHealsAnInheritedDeadGrantAndKeepsTheLiveOnes(t *testing.T) {
+	db, r := setupRouteGrantTest(t)
+	routeB := seedRouteGrantRoute(t, db, "heal-live-*")
+	keyID := seedRouteGrantKey(t, r, "inherited-dead", []int64{routeB})
+
+	dead := int64(999999)
+	if _, err := db.Exec(db.Rebind("UPDATE downstream_api_keys SET allowed_route_ids = ? WHERE id = ?"),
+		"["+strconv.FormatInt(routeB, 10)+","+strconv.FormatInt(dead, 10)+"]", keyID); err != nil {
+		t.Fatalf("simulate a pre-fix dangling grant: %v", err)
+	}
+
+	resp := doPutJSON(t, r, "/api/downstream-keys/"+strconv.FormatInt(keyID, 10), map[string]any{"name": "renamed-healed"})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("saving a key with an inherited dead grant returned %d: %s", resp.Code, resp.Body.String())
+	}
+	body := decodeGrantBody(t, resp.Body.Bytes())
+	if pruned := idList(t, body["prunedRouteIds"]); len(pruned) != 1 || pruned[0] != dead {
+		t.Errorf("prunedRouteIds = %v, want [%d]", pruned, dead)
+	}
+	if stale := idList(t, body["staleRouteIds"]); len(stale) != 0 {
+		t.Errorf("staleRouteIds = %v, want none: a live grant survived, so the dead one is pruned", stale)
+	}
+	if got := storedRouteGrants(t, db, keyID); len(got) != 1 || got[0] != routeB {
+		t.Fatalf("stored grants = %v, want [%d]", got, routeB)
+	}
+}
+
+// Healing must not become a way to smuggle in a route id that does not exist:
+// what the request chose is still validated.
+func TestUpdateKeyStillRejectsANewlyChosenUnknownRoute(t *testing.T) {
+	db, r := setupRouteGrantTest(t)
+	routeB := seedRouteGrantRoute(t, db, "reject-live-*")
+	keyID := seedRouteGrantKey(t, r, "reject-unknown", []int64{routeB})
+
+	resp := doPutJSON(t, r, "/api/downstream-keys/"+strconv.FormatInt(keyID, 10), map[string]any{
+		"allowedRouteIds": []int64{routeB, 999999},
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("a newly chosen unknown route returned %d, want 400: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "allowedRouteIds contains unknown routes: 999999") {
+		t.Errorf("the rejection must name the id, got %s", resp.Body.String())
+	}
+	if got := storedRouteGrants(t, db, keyID); len(got) != 1 || got[0] != routeB {
+		t.Fatalf("a rejected save must not change the stored grants, got %v", got)
+	}
+
+	created := doPostJSON(t, r, "/api/downstream-keys", map[string]any{
+		"name":            "create-unknown",
+		"key":             "sk-create-unknown",
+		"allowedRouteIds": []int64{999999},
+	})
+	if created.Code != http.StatusBadRequest {
+		t.Fatalf("create with an unknown route returned %d, want 400: %s", created.Code, created.Body.String())
+	}
+}

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -698,6 +698,15 @@ func (h *tokenRoutesHandler) deleteRoute(w http.ResponseWriter, r *http.Request)
 		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to delete route")
 		return
 	}
+	// Downstream keys may authorize this route by id. Leaving the reference
+	// behind made the key unsavable afterwards (its allowlist is validated on
+	// every update and the UI cannot edit it), so the delete owns removing it.
+	onlyDeletedGrants, err := pruneDeletedRouteIDsFromDownstreamKeys(tx, id)
+	if err != nil {
+		slog.Warn("route delete could not prune downstream key route grants", "routeId", id, "error", err)
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to delete route")
+		return
+	}
 	if _, err := tx.Exec(tx.Rebind("DELETE FROM token_routes WHERE id = ?"), id); err != nil {
 		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to delete route")
 		return
@@ -710,7 +719,13 @@ func (h *tokenRoutesHandler) deleteRoute(w http.ResponseWriter, r *http.Request)
 
 	routing.InvalidateCache()
 	invalidateChannelsSnapshotCache()
-	writeJSON(w, http.StatusOK, map[string]any{"success": true})
+	response := map[string]any{"success": true}
+	if len(onlyDeletedGrants) > 0 {
+		// Truthful at the moment the operator can still act on it: these keys now
+		// authorize nothing that exists, and were deliberately not widened.
+		response["downstreamKeysWithOnlyDeletedRoutes"] = onlyDeletedGrants
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 // ---- Batch Routes ----


### PR DESCRIPTION
## Observed failure

A real operator reported it in #1223 with the response body attached:

```
error: "allowedRouteIds contains unknown routes: 3715"
```

Saving a downstream key fails, every time, for any edit — a rename, a limit change, an enable toggle.

**1. Who hit it:** the reporter of #1223, running **100+ sites (~70 usable)**, i.e. a fleet where routes are created and deleted routinely rather than exceptionally.
**2. What were they doing:** saving a downstream API key in the admin UI.
**3. What actually happened:** deleting a route cleans `route_group_sources`, `route_channels` and `token_routes` — and stops there. `downstream_api_keys.allowed_route_ids` keeps the dead id forever. The key **update** path validates that list, and carries the stored list forward when the request omits the field, so a rename re-submits the dead id and gets rejected. The admin UI has **no control for this field** (it only renders a grant count), so there is no way to deselect an id that is not in any list: the key becomes permanently uneditable. Their diagnosis ("可能是我删除了，之前重建了路由导致的") was right about the trigger and too kind about the cause.
**4. What was expected:** deleting a route to be a complete operation, and editing a key to keep working afterwards.
**5. Reproducible:** yes, deterministically, on the released asset. `route-grants/live-proof.sh` runs two routes + two keys + a delete + a rename against the released v0.19.0 bytes and the branch side by side (24 passed / 0 failed): the released binary returns `400 allowedRouteIds contains unknown routes: 1` for a **rename**, and `: 2` for the key whose last authorized route was deleted. No upstream is involved — this is a policy-reference defect, not a relay one.
**6. Which layer should have caught it:** the route-delete transaction, which already owns three of the four references to a route id, and the key-update tests, which cover the validation but never a *stored* list holding an id that no longer exists.
**7. Why it didn't:** the validation was tested against ids the request chose. Nothing tested the ids a request *inherits*, which is where a delete can leave a corpse.
**8. Smallest root fix:** the delete prunes its own reference (one owner, one transaction), and a save heals the grants it inherited instead of rejecting them. No schema change, no migration, no new abstraction, and existing rows in the wild heal on their next save — the reporter does not have to touch the database or the API by hand.

## The constraint that shaped the fix

Pruning must never **widen** a credential. An empty allowlist means "no route restriction", so dropping the *last* grant of a restricted key would silently promote it from "serves nothing" to "serves every route" — the same fail-open shape as an allowlist falling back to empty, which is the defect class this repo's settings gate exists to prevent.

So the rule, stated once and used by both halves: **a dead grant is removed only when removing it cannot widen the key.** When every grant is dead, the ids stay (the key keeps denying), the save still succeeds, and both sides report it — `staleRouteIds` + a notice on the save, `downstreamKeysWithOnlyDeletedRoutes` on the delete, a WARN in the log. Widening stays an explicit operator act: clearing the list is allowed and is the only way to get there.

Route ids are never reused (SQLite `AUTOINCREMENT`, PostgreSQL `SERIAL`), so a stale grant can never come back to life pointing at a different route — this is a usability defect, not an authorization one, and the fix does not change what any key can reach.

## What changes

- `handler/admin/token_routes.go` — the delete transaction prunes its id from every key's allowlist and reports the keys it deliberately could not prune.
- `handler/admin/downstream_keys.go` — `healInheritedRouteGrants` separates inherited ids (heal, report) from ids the request chose (still validated, still rejected); the update response carries `prunedRouteIds` / `staleRouteIds` / a notice so a successful save never implies the caller's list was written verbatim; `pruneDeletedRouteIDsFromDownstreamKeys` does the same job inside the delete transaction.
- `handler/admin/downstream_keys_route_grants_test.go` — four tests: the cascade, the widening refusal (including that an explicit clear still works), healing an inherited dead grant while keeping the live ones, and rejecting a newly chosen unknown id on both update and create.

## Proof it can go red

Five mutation probes, each committed-then-reverted, each red for the stated reason and green after restore:

| # | mutation | result |
|---|---|---|
| P1 | remove the cascade from the delete transaction | red: the dead grant survives and the delete names no key |
| P2 | let the delete prune a last grant (ignore the widening case) | red: the delete stops reporting the key it widened |
| P3 | let the save prune a last grant | red: `staleRouteIds` empty and the notice gone |
| P4 | validate what is persisted instead of what the request vouches for | red: **the operator's exact error returns** — `400 allowedRouteIds contains unknown routes: 1` |
| P5 | treat a newly chosen unknown id as inherited | red: a mistyped grant is silently accepted (200 instead of 400) |

Local: `go build ./...`, `go vet`, `gofmt`, `go test ./handler/admin/` (full package, 42.9s) green.

## Release

None. v0.19.0 stays the frozen baseline; this accumulates towards v0.19.1 with #1225 and #1227. The reporter has been given a one-call workaround in the issue (`PUT` with an explicit `allowedRouteIds`) that works on v0.19.0 today.
