### PR TITLE
docs: the credential recovery path an API-key account actually has

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-**Last updated**: 2026-08-22
+**Last updated**: 2026-09-04
 
 > **How to read this page**: just getting started? The README Quick Start covers
 > the 3-minute paths — this page is the full reference behind them. Start with
@@ -415,7 +415,11 @@ Upgrade checklist:
    with the *same site and the same username*: the backend upserts that account,
    exchanges the login for the site's durable credential, revokes the transient
    session, and re-syncs its models immediately. There is no separate
-   "re-login" button for password/session accounts. This was verified on a real
+   "re-login" button for password/session accounts. Accounts bound with a
+   *durable API key* instead need nothing here: that credential does not expire
+   on a fifteen-minute clock, so it survives the upgrade as-is — and if the site
+   later rotates it, replace it in place (row menu → **编辑 (Edit)** → new key →
+   **保存修改 (Save changes)**). This was verified on a real
    v0.16.23 → v0.19.0 in-place upgrade of a live SQLite database: 28 additive
    migrations, site / account / downstream key / route all preserved, and the
    chain only served a real completion again after this step.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-**Last updated**: 2026-08-20
+**Last updated**: 2026-09-04
 
 Frequently asked questions. Anything not covered here lives in
 [`configuration.md`](configuration.md) (env vars), [`deployment.md`](deployment.md)
@@ -92,9 +92,16 @@ Encrypted at rest (AES-GCM keyed by `ACCOUNT_CREDENTIAL_SECRET`, which falls
 back to `AUTH_TOKEN` if unset — set a dedicated secret in production).
 
 **What happens when a session token expires?**
-Platforms with login support re-authenticate automatically; OAuth-connected
-accounts refresh via their refresh token. Accounts that cannot renew are
-marked unhealthy and alerted, not silently used.
+The account is marked unhealthy and alerted, not silently used, and the health
+reason names the credential mode: `Access token expired` (session),
+`Connection expired; update the API key` (API key), or `Credentials expired;
+update the credentials` (OAuth). Renewing it is an operator action, because
+automatic re-login runs only in the check-in scheduler and never renews a
+credential the relay path needs: re-bind a session/password account with
+**添加账号 (Add account)** using the *same site and username*, replace a rotated
+API key via **编辑 (Edit)** → **保存修改 (Save changes)**, and let an OAuth
+account refresh from its refresh token (or **重新绑定 (Rebind)** it). See
+[`getting-started.md`](getting-started.md) §3 for the full table.
 
 ## Contributing & support
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,10 +93,21 @@ Navigate to **账号 (Accounts)** → **添加账号**.
 > `503 No available channels`. For every other platform, use the credential the
 > site itself issues for API access (usually an `sk-` key).
 >
-> **Credentials age out.** Re-bind by choosing **添加账号 (Add account)** again
-> with the *same site and the same username*: the backend upserts that account
-> with the fresh credential and re-syncs its models. There is no separate
-> "re-login" button for password/session accounts.
+> **Credentials age out — and which fix applies depends on how the account was
+> bound.** The health reason on the account row tells you in about thirty
+> seconds, so you do not have to know how Metapi stores credentials:
+>
+> | The row says | What died | What to do |
+> | :--- | :--- | :--- |
+> | `Access token expired` | A **session / password** credential. On a New API-family panel that is the dashboard JWT, which lives about fifteen minutes | Re-bind: choose **添加账号 (Add account)** again with the *same site and the same username*. The backend upserts that account with the fresh credential and re-syncs its models. There is no separate "re-login" button for password/session accounts |
+> | `Connection expired; update the API key` | An **API key** credential — the `sk-…` key the site itself issued — was rotated or revoked upstream | Replace it in place: row menu → **编辑 (Edit)** → paste the new key → **保存修改 (Save changes)** |
+> | `Credentials expired; update the credentials` | An **OAuth** connection | Row menu → **重新绑定 (Rebind)** on the OAuth connections page. OAuth accounts otherwise renew themselves from their refresh token |
+> | Nothing: models still list, and balance refresh does not report `upstream credential expired` | Nothing | Nothing to do. A durable `sk-` API key does not expire on a fifteen-minute clock, so an account bound with one survives an upgrade untouched |
+>
+> Automatic re-login does exist, but only inside the check-in scheduler: it
+> never renews a credential the relay path needs. A dead session credential is
+> therefore always an operator action, and what it leaves behind is an empty
+> model list plus `503 No available channels`.
 
 The account row shows balance and health once the first refresh lands
 (balance refresh runs hourly by default; use the row action to refresh now).
@@ -168,7 +179,7 @@ config export) live in [`client-integration.md`](client-integration.md).
 | `401` on `/v1`                   | `Authorization: Bearer` uses a downstream key or `PROXY_TOKEN` |
 | `503` from the proxy             | No route/channel configured for the model, or upstream unconfigured |
 | `503 No available channels: 未匹配到启用的路由` | No **enabled route** matches that model: add one (§4). Auto-rebuild does not create routes |
-| Models were listed, then went empty / relay started failing | The stored credential aged out: re-bind with **Add account**, same site + username (§3) |
+| Models were listed, then went empty / relay started failing | The stored credential aged out. Session/password account: re-bind with **Add account**, same site + username. API-key account: **Edit** the account and paste the new key (§3) |
 | Account shows unhealthy          | Row action → refresh; verify credential mode matches the platform |
 | Page not loading behind nginx    | WebSocket upgrade headers in the reverse proxy ([deployment.md](deployment.md)) |
 


### PR DESCRIPTION
## Observed failure

The upgrade instruction posted to #1179 told every user to "re-login the account". A real user who had bound his account with an **access token** answered:

> 账号绑定的是 access token，不是账号密码，这种还用重新登录了吗

and waited **13 hours**, because the answer for his case existed only in code — no document in this repository described it:

| Doc | What it said | Why that was not enough |
| :-- | :-- | :-- |
| `getting-started.md` §3 "Credentials age out" | One action: re-bind via **添加账号**, same site + username | That is the session/password path only |
| `deployment.md` upgrade checklist step 4 (#1228) | The same single action | An operator with ~100 sites cannot tell which accounts need it |
| `faq.md` "What happens when a session token expires?" | "Platforms with login support re-authenticate automatically" | True only inside the check-in scheduler — `tryAutoRelogin` has **no caller outside `service/checkin`** — and never true for the credential the relay path uses. Same shape as the promise #1226 removed |

An account bound with a durable API key needs **nothing** after an upgrade, and if the site later rotates that key the recovery is row menu → **编辑 (Edit)** → paste the new key → **保存修改 (Save changes)**. Neither fact was written down anywhere.

## What changed (docs only)

Recovery is now keyed off the health reason the account row **already shows**, which is the same thirty-second self-check given in the issue and needs no knowledge of how Metapi stores credentials:

- `Access token expired` → session/password credential died → re-bind via **添加账号 (Add account)**, same site + username;
- `Connection expired; update the API key` → API key rotated/revoked upstream → **编辑 (Edit)** → new key → **保存修改 (Save changes)**;
- `Credentials expired; update the credentials` → OAuth → **重新绑定 (Rebind)** (otherwise it renews from its refresh token);
- nothing wrong → nothing to do, a durable `sk-` key does not expire on a fifteen-minute clock.

`deployment.md` step 4 now states which accounts it does **not** apply to; `faq.md` stops implying the relay path renews itself and names the three reasons verbatim; the `getting-started.md` troubleshooting row points at both paths.

## Proof

Every quoted fact is mechanically checked against its owner before publishing — health-reason strings against `service/account_health.go`, the composed `balance refresh failed: upstream credential expired` against both halves *and* the site that appends `": " + reason` (#1210), each UI label against the i18n key **and the component that renders it** (`account-form-dialog.tsx`, `accounts-columns.tsx`, `accounts-page.tsx`, `oauth-columns.tsx`), plus the structural claims (auto re-login caller set, OAuth refresh entrypoint, `AccountUpdatePayload` fields, login upsert owner): **19 passed / 0 failed**.

That check earned its keep immediately. Its first version iterated over a list of strings copied out of the code, and two mutation probes stayed green under it — a doc inventing `Access token expiredd`, and a doc renaming 保存修改 (Save changes) to 保存 (Save), which is a real button *on other pages*. Both are exactly the defect it exists to catch, so it was rewritten to extract claims **from the documents** and resolve each to its owner. Probes now **7/7 red**:

| Probe | Mutation | Result |
| :-- | :-- | :-- |
| P1 | doc invents a health reason | red |
| P2 | doc names a different but real button | red |
| P3 | **code** renames the reason, doc left lying | red |
| P4 | troubleshooting row names a nonexistent control | red |
| P5 | composed message with a prefix nobody emits | red |
| P6 | the prose under test moves (anchor lost) | red — fails loudly instead of silently widening the region to EOF |
| P7 | the surface component stops rendering the control | red |

`go test ./docs -count=1` green (includes `TestPublicMarkdownHygiene`, the CI docs gate).

**No new CI gate**: the defect fixed here is an *omission*, and no string check can detect missing prose (Law: gates come from failures an existing gate should have caught). The claim check stays a pre-publish proof run by whoever edits this prose.

Docs only: no code, no behaviour, no test changes. No release — accumulates into v0.19.1.
