### PR TITLE
docs(api): the route-ownership gate named files that never mentioned the route

### DIFF
--- a/docs/api/monitor.md
+++ b/docs/api/monitor.md
@@ -41,3 +41,50 @@ Start a monitoring session.
 Clear the monitoring session.
 
 ---
+
+## Monitor iframe proxy
+
+The monitor page embeds an upstream LDOH dashboard in an iframe. Iframe
+sub-resource requests cannot carry an `Authorization` header, so this surface
+authenticates with the HttpOnly `meta_monitor_auth` cookie minted by
+`POST /api/monitor/session` instead of the admin Bearer token, and it is
+deliberately mounted outside the Bearer-gated group. That cookie is scoped to
+`Path=/monitor-proxy/` — so a stolen value cannot be presented to other
+same-origin endpoints — and lives 7200 seconds.
+
+| Route | Behaviour |
+| :--- | :--- |
+| `ANY /monitor-proxy/ldoh` | proxies the LDOH base URL root |
+| `ANY /monitor-proxy/ldoh/` | the same, trailing-slash form |
+| `ANY /monitor-proxy/ldoh/{wildcard}` | proxies `<LDOH_BASE_URL>/<wildcard>` |
+
+`ANY` means every method: the surface is registered method-agnostically so the
+embedded dashboard's own asset and XHR requests work unchanged.
+
+Upstream and limits:
+
+- `LDOH_BASE_URL` (default `https://ldoh.105117.xyz`) — point the iframe at a
+  self-hosted LDOH instance.
+- `LDOH_PROXY_TIMEOUT_SEC` (default `30`) — per-request upstream timeout, parsed
+  once at startup.
+- The upstream LDOH session cookie the proxy presents is the
+  `monitor_ldoh_cookie` setting: written through `PUT /api/monitor/config`, and
+  reported only as `ldohCookieConfigured` + `ldohCookieMasked` by
+  `GET /api/monitor/config`.
+
+Failures are explicit rather than empty: `401 {"error":"Missing or invalid
+monitor session"}` without a valid monitor cookie; `400` with the plain-text
+body `LDOH cookie not configured` when the upstream cookie is unset; `400
+{"error":"invalid proxy path"}` for any path containing `..`. The traversal
+check runs on the percent-decoded path, so `%2e%2e` is caught too — without it a
+monitor-session holder could normalize outside the LDOH base subpath on the
+upstream host.
+
+**Security note.** `monitor_ldoh_cookie` is stored in plaintext in the settings
+table, so read access to the database — a leaked backup, an injection in another
+handler, a snapshot on a shared host — is equivalent to disclosing the LDOH
+session until it expires upstream. Backup imports are forbidden from setting
+this key (it is listed in `service/backup.RuntimeLocalSettingKeys`, which both
+import paths enforce), because a planted value would pin the monitored session
+to an attacker-controlled credential. Encrypting it at rest is the known
+improvement; until then, treat database access as LDOH credential disclosure.

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -1,6 +1,66 @@
 # Proxy-Facing Endpoints
 
-> **Index**: back to [API Reference](../api.md). This file is the /v1/files & /v1/pricing domain split out of the pre-`docs/api/` `docs/api.md`.
+> **Index**: back to [API Reference](../api.md). This file owns the whole proxy data plane: which routes a downstream key can call, and the error shape, header policy and timeouts that apply to all of them.
+
+## Endpoint surface
+
+Two mounts, one contract. Everything below sits behind the same downstream-key
+proxy auth (`Authorization: Bearer <downstream key>`, or the global
+`PROXY_TOKEN`), the same per-IP and per-key rate limits, and the error shape,
+header policy and timeouts documented in the next three sections. None of it is
+admin surface: these routes never accept an admin token, and `/api/*` never
+accepts a downstream key.
+
+`/v1` — the OpenAI-compatible surface:
+
+| Route | What it relays |
+| :--- | :--- |
+| `POST /v1/chat/completions` | Chat Completions — the main surface |
+| `POST /v1/completions` | legacy Completions |
+| `POST /v1/messages` | Claude Messages |
+| `POST /v1/messages/count_tokens` | Claude token counting |
+| `POST /v1/responses` | Responses |
+| `POST /v1/responses/compact` | Responses, compact mode |
+| `GET /v1/responses` | answers `426`: the upstream GET contract is not proxied |
+| `GET /v1/models` | models reachable through your enabled routes |
+| `POST /v1/embeddings` | embeddings |
+| `POST /v1/rerank` | rerank (OpenAI-compatible and Cohere-style) |
+| `POST /v1/search` | web search |
+| `POST /v1/images/generations` | image generation |
+| `POST /v1/images/edits` | image edit |
+| `POST /v1/images/variations` | image variations |
+| `POST /v1/videos` | video task creation |
+| `GET /v1/videos/{id}` | video task status |
+| `DELETE /v1/videos/{id}` | video task cancel |
+| `POST /v1/files` | file upload |
+| `GET /v1/files` | file list |
+| `GET /v1/files/{fileId}` | file metadata |
+| `GET /v1/files/{fileId}/content` | file download |
+| `DELETE /v1/files/{fileId}` | file delete |
+| `GET /v1/models/price-compare` | cross-site price catalog visible to downstream keys |
+| `GET /v1/pricing` | price catalog for the models a key can call |
+
+Native client paths — the same relay on the paths a vendor CLI already speaks,
+so a client can be pointed at Metapi without rewriting its base path. Registered
+at the root, not under `/v1`, with the same proxy auth:
+
+| Route | Client it exists for |
+| :--- | :--- |
+| `POST /chat/completions` | clients that post Chat Completions to the root |
+| `POST /responses` | Codex native Responses |
+| `POST /responses/{wildcard}` | Codex native Responses sub-paths |
+| `GET /responses` | answers `426`, like its `/v1` twin |
+| `GET /responses/{wildcard}` | answers `426`, like its `/v1` twin |
+| `GET /v1beta/models` | Gemini clients talking to `generativelanguage.googleapis.com/v1beta` |
+| `POST /v1beta/models/{wildcard}` | Gemini `models/{model}:{action}` — the model comes from the path, and `:streamGenerateContent` implies streaming |
+| `GET /gemini/{geminiApiVersion}/models` | the same list with an explicit API version segment |
+| `POST /gemini/{geminiApiVersion}/models/{wildcard}` | the same relay; the version segment is accepted for path compatibility and does not change behaviour |
+| `POST /v1internal::generateContent` | Gemini CLI internal protocol |
+| `POST /v1internal::streamGenerateContent` | Gemini CLI internal protocol, streaming |
+| `POST /v1internal::countTokens` | Gemini CLI internal protocol, token counting |
+
+Gemini-native bodies are converted in `transform/gemini/generate_content`; the
+`/v1` surfaces relay OpenAI-shaped bodies and convert per upstream platform.
 
 ## Error shape (/v1 surface)
 

--- a/docs/api_inventory_parity_test.go
+++ b/docs/api_inventory_parity_test.go
@@ -233,15 +233,47 @@ func TestNonAPIRoutesAreAccountedFor(t *testing.T) {
 }
 
 // routeKeyDocumentedIn reports whether a document states a route. Matching is on
-// the whole "METHOD /path" key, not on the path alone: a file that only mentions
-// `/v1/models/price-compare` must not be credited with documenting
-// `GET /v1/models`. A wildcard route may be written either way.
+// the whole "METHOD /path" key, and the match has to END there: a substring test
+// lets a sibling route stand in for the real one, which is how the first version
+// of this helper passed two mutation probes it should have failed -- deleting the
+// `GET /v1/models` row still matched `GET /v1/models/price-compare`, and deleting
+// `ANY /monitor-proxy/ldoh/` still matched `ANY /monitor-proxy/ldoh/{wildcard}`.
+// A wildcard route may be written either as {wildcard} or as *.
 func routeKeyDocumentedIn(body, routeKey string) bool {
-	if strings.Contains(body, routeKey) {
+	if containsRouteKey(body, routeKey) {
 		return true
 	}
 	if strings.Contains(routeKey, "{wildcard}") {
-		return strings.Contains(body, strings.ReplaceAll(routeKey, "{wildcard}", "*"))
+		return containsRouteKey(body, strings.ReplaceAll(routeKey, "{wildcard}", "*"))
+	}
+	return false
+}
+
+// containsRouteKey finds key in body followed by something that cannot continue a
+// route path, so a prefix of a longer route does not count as documenting it.
+func containsRouteKey(body, key string) bool {
+	for from := 0; ; {
+		j := strings.Index(body[from:], key)
+		if j < 0 {
+			return false
+		}
+		end := from + j + len(key)
+		if end == len(body) || !routePathContinues(body[end]) {
+			return true
+		}
+		from = from + j + 1
+	}
+}
+
+// routePathContinues reports whether c could be the next character of a longer
+// route path (or of its {param} / * wildcard spelling).
+func routePathContinues(c byte) bool {
+	if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+		return true
+	}
+	switch c {
+	case '_', '/', '{', '}', ':', '.', '-', '~', '*':
+		return true
 	}
 	return false
 }
@@ -254,7 +286,7 @@ func TestNonAPIRouteOwnershipIsNotAPaperClaim(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, "docs", "api"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	body := "# Proxy\n\n| `POST /v1/chat/completions` | chat relay |\n| `POST /v1/models/price-compare` | prices |\n"
+	body := "# Proxy\n\n| `POST /v1/chat/completions` | chat relay |\n| `GET /v1/models/price-compare` | prices |\n"
 	if err := os.WriteFile(filepath.Join(root, doc), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -264,10 +296,19 @@ func TestNonAPIRouteOwnershipIsNotAPaperClaim(t *testing.T) {
 	if routeKeyDocumentedIn(body, "GET /v1beta/models") {
 		t.Error("a route the document never states passed -- the gate is paper")
 	}
-	// Path-only matching would credit the price-compare row with documenting
-	// GET /v1/models; the whole-key match must not.
+	// A sibling route must not stand in for the real one, even with the same
+	// verb: the body above states GET /v1/models only inside the longer
+	// price-compare path, and the trailing-slash / wildcard pair below is the
+	// same shape on the monitor surface. Both passed a plain substring match.
 	if routeKeyDocumentedIn(body, "GET /v1/models") {
-		t.Error("a sibling path satisfied the check -- matching must be on the whole route key")
+		t.Error("a sibling path satisfied the check -- matching must end at the route key")
+	}
+	slashes := "`ANY /monitor-proxy/ldoh/{wildcard}` only\n"
+	if routeKeyDocumentedIn(slashes, "ANY /monitor-proxy/ldoh/") {
+		t.Error("the wildcard route satisfied the trailing-slash route -- matching must end at the route key")
+	}
+	if !routeKeyDocumentedIn(slashes+"`ANY /monitor-proxy/ldoh/`\n", "ANY /monitor-proxy/ldoh/") {
+		t.Error("the trailing-slash route was not found when the document states it exactly")
 	}
 	if routeKeyDocumentedIn(body, "POST /responses/{wildcard}") {
 		t.Error("wildcard route matched a document that does not mention it in either spelling")

--- a/docs/api_inventory_parity_test.go
+++ b/docs/api_inventory_parity_test.go
@@ -48,9 +48,10 @@ package docs_test
 //
 // Scope: the inventory documents the /api admin surface, so parity is
 // asserted on /api routes. Every non-/api route still has to be owned by a
-// named document via nonAPIRouteAllowlist (TestNonAPIRoutesAreAccountedFor),
-// and both allowlists are checked for stale entries, so an allowlist cannot
-// accumulate routes that no longer exist.
+// named document via nonAPIRouteAllowlist, and that document has to actually
+// state the route (TestNonAPIRoutesAreAccountedFor) -- naming a file is not
+// documentation. Both allowlists are also checked for stale entries, so neither
+// can accumulate routes that no longer exist.
 
 import (
 	"go/ast"
@@ -182,17 +183,97 @@ func TestAPIRouteInventoryParity(t *testing.T) {
 func TestNonAPIRoutesAreAccountedFor(t *testing.T) {
 	root := repoRoot(t)
 	_, nonAPI := splitByScope(extractRegisteredRoutes(t, root))
-	var unowned []string
+
+	// Naming a document is not the same as the document containing the route.
+	// Until this half existed the allowlist was a paper claim: 33 of its 42
+	// entries pointed at files that never mentioned the route, including the
+	// whole Gemini surface (`/v1beta/models*`, `/gemini/{version}/models*`,
+	// `/v1internal::*`) and the monitor iframe proxy -- reachable, tested, and
+	// undiscoverable from the docs. Same shape as the boundary gate that could
+	// scan nothing and report zero violations (#1214).
+	bodies := map[string]string{}
+	readDoc := func(doc string) (string, bool) {
+		if b, ok := bodies[doc]; ok {
+			return b, true
+		}
+		raw, err := os.ReadFile(filepath.Join(root, doc))
+		if err != nil {
+			return "", false
+		}
+		bodies[doc] = string(raw)
+		return string(raw), true
+	}
+
+	var unowned, paper []string
 	for key, where := range nonAPI {
-		if _, ok := nonAPIRouteAllowlist[key]; ok {
+		doc, ok := nonAPIRouteAllowlist[key]
+		if !ok {
+			unowned = append(unowned, key+"  (registered in "+where+")")
 			continue
 		}
-		unowned = append(unowned, key+"  (registered in "+where+")")
+		body, readable := readDoc(doc)
+		if !readable {
+			paper = append(paper, key+" -> "+doc+"  (owning document cannot be read)")
+			continue
+		}
+		if !routeKeyDocumentedIn(body, key) {
+			paper = append(paper, key+" -> "+doc+"  (that file never states this route)")
+		}
 	}
 	if len(unowned) > 0 {
 		sort.Strings(unowned)
-		t.Fatalf("non-/api routes with no owning document:\n  %s\nDocument them (docs/api/proxy.md for data-plane routes) and record the owner in nonAPIRouteAllowlist with a reason.",
+		t.Errorf("non-/api routes with no owning document:\n  %s\nDocument them (docs/api/proxy.md for data-plane routes) and record the owner in nonAPIRouteAllowlist with a reason.",
 			strings.Join(unowned, "\n  "))
+	}
+	if len(paper) > 0 {
+		sort.Strings(paper)
+		t.Fatalf("non-/api routes whose owning document does not actually document them:\n  %s\nWrite the route into that file (method + exact path), or point the entry at the file that does.",
+			strings.Join(paper, "\n  "))
+	}
+}
+
+// routeKeyDocumentedIn reports whether a document states a route. Matching is on
+// the whole "METHOD /path" key, not on the path alone: a file that only mentions
+// `/v1/models/price-compare` must not be credited with documenting
+// `GET /v1/models`. A wildcard route may be written either way.
+func routeKeyDocumentedIn(body, routeKey string) bool {
+	if strings.Contains(body, routeKey) {
+		return true
+	}
+	if strings.Contains(routeKey, "{wildcard}") {
+		return strings.Contains(body, strings.ReplaceAll(routeKey, "{wildcard}", "*"))
+	}
+	return false
+}
+
+// TestNonAPIRouteOwnershipIsNotAPaperClaim proves the ownership check can fail,
+// in both directions, using the same helper the real gate uses.
+func TestNonAPIRouteOwnershipIsNotAPaperClaim(t *testing.T) {
+	root := t.TempDir()
+	const doc = "docs/api/proxy.md"
+	if err := os.MkdirAll(filepath.Join(root, "docs", "api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "# Proxy\n\n| `POST /v1/chat/completions` | chat relay |\n| `POST /v1/models/price-compare` | prices |\n"
+	if err := os.WriteFile(filepath.Join(root, doc), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !routeKeyDocumentedIn(body, "POST /v1/chat/completions") {
+		t.Error("a route the document states was reported missing -- the gate would fail on correct docs")
+	}
+	if routeKeyDocumentedIn(body, "GET /v1beta/models") {
+		t.Error("a route the document never states passed -- the gate is paper")
+	}
+	// Path-only matching would credit the price-compare row with documenting
+	// GET /v1/models; the whole-key match must not.
+	if routeKeyDocumentedIn(body, "GET /v1/models") {
+		t.Error("a sibling path satisfied the check -- matching must be on the whole route key")
+	}
+	if routeKeyDocumentedIn(body, "POST /responses/{wildcard}") {
+		t.Error("wildcard route matched a document that does not mention it in either spelling")
+	}
+	if !routeKeyDocumentedIn(body+"\n`POST /responses/*`\n", "POST /responses/{wildcard}") {
+		t.Error("the * spelling of a wildcard route was not accepted")
 	}
 }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -323,6 +323,7 @@ pg_dump -Fc 'postgres://<user>:<password>@<host>:5432/metapi?sslmode=require' > 
 
 - Liveness check: `GET /health` returns `{"status":"ok"}` when the HTTP process is alive
 - Readiness check: `GET /ready` returns `{"status":"ok","database":"ok"}` or HTTP 503 when the database is unavailable or the process is draining for shutdown
+- Metrics: `GET /metrics` serves the Prometheus text exposition format directly (no external dependency), and it is registered before the auth middleware — so, like `GET /health` and `GET /ready`, it answers without a token. Series exposed: `metapi_uptime_seconds`, `metapi_active_channels`, `metapi_proxy_requests_total`, `metapi_proxy_errors_total`, `metapi_proxy_outcomes_total`, the `metapi_proxy_request_duration_seconds` histogram, `metapi_proxy_streams_active`, `metapi_stream_missing_usage_total`, `metapi_route_rebuild_total`, `metapi_db_connections_open`, `metapi_db_connections_in_use`, `metapi_db_conn_errors_total`. Scrape it from a network you control, or allowlist the path in your reverse proxy.
 - Docker healthcheck runs `metapi healthcheck`, which polls `/ready` every 30 seconds by default
 - Override the healthcheck target with `METAPI_HEALTHCHECK_URL` or `METAPI_HEALTHCHECK_PATH`
 - Startup exits before binding the HTTP port when database bootstrap, runtime settings load, or runtime schema migration fails.


### PR DESCRIPTION
## Observed failure

`nonAPIRouteAllowlist` maps every registered non-`/api` route to "the document that owns its contract", and the gate asserted only that the map had an entry. Stale entries were already caught; **paper entries were not**. Measured against the tree: **33 of 42** entries pointed at a file that never stated the route.

Undiscoverable-from-docs but registered, authenticated and tested:

| Surface | Routes |
| :-- | :-- |
| Gemini native protocol | `GET /v1beta/models`, `POST /v1beta/models/{wildcard}`, `GET /gemini/{geminiApiVersion}/models`, `POST /gemini/{geminiApiVersion}/models/{wildcard}`, `POST /v1internal::generateContent`, `POST /v1internal::streamGenerateContent`, `POST /v1internal::countTokens` |
| Codex-style root aliases | `POST /chat/completions`, `POST /responses`, `GET /responses`, `POST /responses/{wildcard}`, `GET /responses/{wildcard}` |
| most of the `/v1` relay family | chat/completions, messages, completions, responses(+compact), models, embeddings, rerank, search, images×3, videos×3 |
| monitor iframe proxy | `ANY /monitor-proxy/ldoh`, `ANY /monitor-proxy/ldoh/`, `ANY /monitor-proxy/ldoh/{wildcard}` |
| operational | `GET /metrics` (deployment.md mentioned it only inside a CORS bullet) |

A file titled **"Proxy-Facing Endpoints"** listed two of its own domains (`/v1/files`, `/v1/pricing`) and none of the relay endpoints. This is #1226 inverted: not a doc sending users to something that doesn't exist, but behaviour that exists with no doc pointing at it.

## Docs

- **`docs/api/proxy.md`**: an endpoint surface — the `/v1` table (24 routes) and the native-client-path table (12 routes), with the shared contract stated once (one downstream-key auth, one rate-limit path, one error shape/header policy/timeout set) instead of per row, plus the two truths a client would otherwise have to read a handler for: `GET /v1/responses` answers `426`, and the `{geminiApiVersion}` segment is accepted for path compatibility and does not change behaviour. The file's index line no longer calls itself the `/v1/files` & `/v1/pricing` split.
- **`docs/api/monitor.md`**: the iframe proxy — cookie-not-Bearer auth and why (iframe sub-resources cannot send an `Authorization` header), the `Path=/monitor-proxy/` cookie scope and 7200s lifetime, `LDOH_BASE_URL` / `LDOH_PROXY_TIMEOUT_SEC`, the three explicit failure modes including the percent-decoded `..` rejection, and the plaintext `monitor_ldoh_cookie` trade-off together with the backup-import ban that goes with it.
- **`docs/deployment.md`**: `GET /metrics` stated with the series it exposes and the fact that it is registered before the auth middleware.

## Gate

Strengthened, not added — same test name, no new job:

1. every live non-`/api` route must have an owner entry (existing);
2. **the named document must contain the whole `METHOD /path` key** (new);
3. entries matching no live route are stale (existing).

Whole-key *and* boundary-checked. The first cut used a plain substring match and two end-to-end mutation probes walked straight through it: deleting the `GET /v1/models` row still matched `GET /v1/models/price-compare`, and deleting `ANY /monitor-proxy/ldoh/` still matched `ANY /monitor-proxy/ldoh/{wildcard}`. The match now has to end at the route key. `TestNonAPIRouteOwnershipIsNotAPaperClaim` pins both shapes in both directions plus the missing-file case, through the same helper the real gate calls.

The gate found `GET /metrics` on its first run, which is the point.

## Proof

`go test ./docs -count=1` green. End-to-end mutation probes **5/5 red, each naming the right route**: P1 delete a Gemini row · P2 point an entry at a file that doesn't mention it · P3 delete the trailing-slash row (wildcard sibling must not cover it) · P4 point an entry at a nonexistent file · P5 delete `GET /v1/models` (price-compare sibling must not cover it); baseline green after restore.

One process note worth keeping: the first probe run reported 4 of 5 green because the probe script restores mutations with `git checkout --`, and the gate fix was still uncommitted at that point — the probes had silently reverted it. Commit before probing.

Docs + one test file: no product code, no behaviour change. No release.
