### PR TITLE
chore: two pieces of test-only code were living in production files

### DIFF
--- a/docs/api/monitor.md
+++ b/docs/api/monitor.md
@@ -41,3 +41,50 @@ Start a monitoring session.
 Clear the monitoring session.
 
 ---
+
+## Monitor iframe proxy
+
+The monitor page embeds an upstream LDOH dashboard in an iframe. Iframe
+sub-resource requests cannot carry an `Authorization` header, so this surface
+authenticates with the HttpOnly `meta_monitor_auth` cookie minted by
+`POST /api/monitor/session` instead of the admin Bearer token, and it is
+deliberately mounted outside the Bearer-gated group. That cookie is scoped to
+`Path=/monitor-proxy/` — so a stolen value cannot be presented to other
+same-origin endpoints — and lives 7200 seconds.
+
+| Route | Behaviour |
+| :--- | :--- |
+| `ANY /monitor-proxy/ldoh` | proxies the LDOH base URL root |
+| `ANY /monitor-proxy/ldoh/` | the same, trailing-slash form |
+| `ANY /monitor-proxy/ldoh/{wildcard}` | proxies `<LDOH_BASE_URL>/<wildcard>` |
+
+`ANY` means every method: the surface is registered method-agnostically so the
+embedded dashboard's own asset and XHR requests work unchanged.
+
+Upstream and limits:
+
+- `LDOH_BASE_URL` (default `https://ldoh.105117.xyz`) — point the iframe at a
+  self-hosted LDOH instance.
+- `LDOH_PROXY_TIMEOUT_SEC` (default `30`) — per-request upstream timeout, parsed
+  once at startup.
+- The upstream LDOH session cookie the proxy presents is the
+  `monitor_ldoh_cookie` setting: written through `PUT /api/monitor/config`, and
+  reported only as `ldohCookieConfigured` + `ldohCookieMasked` by
+  `GET /api/monitor/config`.
+
+Failures are explicit rather than empty: `401 {"error":"Missing or invalid
+monitor session"}` without a valid monitor cookie; `400` with the plain-text
+body `LDOH cookie not configured` when the upstream cookie is unset; `400
+{"error":"invalid proxy path"}` for any path containing `..`. The traversal
+check runs on the percent-decoded path, so `%2e%2e` is caught too — without it a
+monitor-session holder could normalize outside the LDOH base subpath on the
+upstream host.
+
+**Security note.** `monitor_ldoh_cookie` is stored in plaintext in the settings
+table, so read access to the database — a leaked backup, an injection in another
+handler, a snapshot on a shared host — is equivalent to disclosing the LDOH
+session until it expires upstream. Backup imports are forbidden from setting
+this key (it is listed in `service/backup.RuntimeLocalSettingKeys`, which both
+import paths enforce), because a planted value would pin the monitored session
+to an attacker-controlled credential. Encrypting it at rest is the known
+improvement; until then, treat database access as LDOH credential disclosure.

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -1,6 +1,66 @@
 # Proxy-Facing Endpoints
 
-> **Index**: back to [API Reference](../api.md). This file is the /v1/files & /v1/pricing domain split out of the pre-`docs/api/` `docs/api.md`.
+> **Index**: back to [API Reference](../api.md). This file owns the whole proxy data plane: which routes a downstream key can call, and the error shape, header policy and timeouts that apply to all of them.
+
+## Endpoint surface
+
+Two mounts, one contract. Everything below sits behind the same downstream-key
+proxy auth (`Authorization: Bearer <downstream key>`, or the global
+`PROXY_TOKEN`), the same per-IP and per-key rate limits, and the error shape,
+header policy and timeouts documented in the next three sections. None of it is
+admin surface: these routes never accept an admin token, and `/api/*` never
+accepts a downstream key.
+
+`/v1` — the OpenAI-compatible surface:
+
+| Route | What it relays |
+| :--- | :--- |
+| `POST /v1/chat/completions` | Chat Completions — the main surface |
+| `POST /v1/completions` | legacy Completions |
+| `POST /v1/messages` | Claude Messages |
+| `POST /v1/messages/count_tokens` | Claude token counting |
+| `POST /v1/responses` | Responses |
+| `POST /v1/responses/compact` | Responses, compact mode |
+| `GET /v1/responses` | answers `426`: the upstream GET contract is not proxied |
+| `GET /v1/models` | models reachable through your enabled routes |
+| `POST /v1/embeddings` | embeddings |
+| `POST /v1/rerank` | rerank (OpenAI-compatible and Cohere-style) |
+| `POST /v1/search` | web search |
+| `POST /v1/images/generations` | image generation |
+| `POST /v1/images/edits` | image edit |
+| `POST /v1/images/variations` | image variations |
+| `POST /v1/videos` | video task creation |
+| `GET /v1/videos/{id}` | video task status |
+| `DELETE /v1/videos/{id}` | video task cancel |
+| `POST /v1/files` | file upload |
+| `GET /v1/files` | file list |
+| `GET /v1/files/{fileId}` | file metadata |
+| `GET /v1/files/{fileId}/content` | file download |
+| `DELETE /v1/files/{fileId}` | file delete |
+| `GET /v1/models/price-compare` | cross-site price catalog visible to downstream keys |
+| `GET /v1/pricing` | price catalog for the models a key can call |
+
+Native client paths — the same relay on the paths a vendor CLI already speaks,
+so a client can be pointed at Metapi without rewriting its base path. Registered
+at the root, not under `/v1`, with the same proxy auth:
+
+| Route | Client it exists for |
+| :--- | :--- |
+| `POST /chat/completions` | clients that post Chat Completions to the root |
+| `POST /responses` | Codex native Responses |
+| `POST /responses/{wildcard}` | Codex native Responses sub-paths |
+| `GET /responses` | answers `426`, like its `/v1` twin |
+| `GET /responses/{wildcard}` | answers `426`, like its `/v1` twin |
+| `GET /v1beta/models` | Gemini clients talking to `generativelanguage.googleapis.com/v1beta` |
+| `POST /v1beta/models/{wildcard}` | Gemini `models/{model}:{action}` — the model comes from the path, and `:streamGenerateContent` implies streaming |
+| `GET /gemini/{geminiApiVersion}/models` | the same list with an explicit API version segment |
+| `POST /gemini/{geminiApiVersion}/models/{wildcard}` | the same relay; the version segment is accepted for path compatibility and does not change behaviour |
+| `POST /v1internal::generateContent` | Gemini CLI internal protocol |
+| `POST /v1internal::streamGenerateContent` | Gemini CLI internal protocol, streaming |
+| `POST /v1internal::countTokens` | Gemini CLI internal protocol, token counting |
+
+Gemini-native bodies are converted in `transform/gemini/generate_content`; the
+`/v1` surfaces relay OpenAI-shaped bodies and convert per upstream platform.
 
 ## Error shape (/v1 surface)
 

--- a/docs/api_inventory_parity_test.go
+++ b/docs/api_inventory_parity_test.go
@@ -233,15 +233,47 @@ func TestNonAPIRoutesAreAccountedFor(t *testing.T) {
 }
 
 // routeKeyDocumentedIn reports whether a document states a route. Matching is on
-// the whole "METHOD /path" key, not on the path alone: a file that only mentions
-// `/v1/models/price-compare` must not be credited with documenting
-// `GET /v1/models`. A wildcard route may be written either way.
+// the whole "METHOD /path" key, and the match has to END there: a substring test
+// lets a sibling route stand in for the real one, which is how the first version
+// of this helper passed two mutation probes it should have failed -- deleting the
+// `GET /v1/models` row still matched `GET /v1/models/price-compare`, and deleting
+// `ANY /monitor-proxy/ldoh/` still matched `ANY /monitor-proxy/ldoh/{wildcard}`.
+// A wildcard route may be written either as {wildcard} or as *.
 func routeKeyDocumentedIn(body, routeKey string) bool {
-	if strings.Contains(body, routeKey) {
+	if containsRouteKey(body, routeKey) {
 		return true
 	}
 	if strings.Contains(routeKey, "{wildcard}") {
-		return strings.Contains(body, strings.ReplaceAll(routeKey, "{wildcard}", "*"))
+		return containsRouteKey(body, strings.ReplaceAll(routeKey, "{wildcard}", "*"))
+	}
+	return false
+}
+
+// containsRouteKey finds key in body followed by something that cannot continue a
+// route path, so a prefix of a longer route does not count as documenting it.
+func containsRouteKey(body, key string) bool {
+	for from := 0; ; {
+		j := strings.Index(body[from:], key)
+		if j < 0 {
+			return false
+		}
+		end := from + j + len(key)
+		if end == len(body) || !routePathContinues(body[end]) {
+			return true
+		}
+		from = from + j + 1
+	}
+}
+
+// routePathContinues reports whether c could be the next character of a longer
+// route path (or of its {param} / * wildcard spelling).
+func routePathContinues(c byte) bool {
+	if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+		return true
+	}
+	switch c {
+	case '_', '/', '{', '}', ':', '.', '-', '~', '*':
+		return true
 	}
 	return false
 }
@@ -254,7 +286,7 @@ func TestNonAPIRouteOwnershipIsNotAPaperClaim(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, "docs", "api"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	body := "# Proxy\n\n| `POST /v1/chat/completions` | chat relay |\n| `POST /v1/models/price-compare` | prices |\n"
+	body := "# Proxy\n\n| `POST /v1/chat/completions` | chat relay |\n| `GET /v1/models/price-compare` | prices |\n"
 	if err := os.WriteFile(filepath.Join(root, doc), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -264,10 +296,19 @@ func TestNonAPIRouteOwnershipIsNotAPaperClaim(t *testing.T) {
 	if routeKeyDocumentedIn(body, "GET /v1beta/models") {
 		t.Error("a route the document never states passed -- the gate is paper")
 	}
-	// Path-only matching would credit the price-compare row with documenting
-	// GET /v1/models; the whole-key match must not.
+	// A sibling route must not stand in for the real one, even with the same
+	// verb: the body above states GET /v1/models only inside the longer
+	// price-compare path, and the trailing-slash / wildcard pair below is the
+	// same shape on the monitor surface. Both passed a plain substring match.
 	if routeKeyDocumentedIn(body, "GET /v1/models") {
-		t.Error("a sibling path satisfied the check -- matching must be on the whole route key")
+		t.Error("a sibling path satisfied the check -- matching must end at the route key")
+	}
+	slashes := "`ANY /monitor-proxy/ldoh/{wildcard}` only\n"
+	if routeKeyDocumentedIn(slashes, "ANY /monitor-proxy/ldoh/") {
+		t.Error("the wildcard route satisfied the trailing-slash route -- matching must end at the route key")
+	}
+	if !routeKeyDocumentedIn(slashes+"`ANY /monitor-proxy/ldoh/`\n", "ANY /monitor-proxy/ldoh/") {
+		t.Error("the trailing-slash route was not found when the document states it exactly")
 	}
 	if routeKeyDocumentedIn(body, "POST /responses/{wildcard}") {
 		t.Error("wildcard route matched a document that does not mention it in either spelling")

--- a/docs/api_inventory_parity_test.go
+++ b/docs/api_inventory_parity_test.go
@@ -48,9 +48,10 @@ package docs_test
 //
 // Scope: the inventory documents the /api admin surface, so parity is
 // asserted on /api routes. Every non-/api route still has to be owned by a
-// named document via nonAPIRouteAllowlist (TestNonAPIRoutesAreAccountedFor),
-// and both allowlists are checked for stale entries, so an allowlist cannot
-// accumulate routes that no longer exist.
+// named document via nonAPIRouteAllowlist, and that document has to actually
+// state the route (TestNonAPIRoutesAreAccountedFor) -- naming a file is not
+// documentation. Both allowlists are also checked for stale entries, so neither
+// can accumulate routes that no longer exist.
 
 import (
 	"go/ast"
@@ -182,17 +183,97 @@ func TestAPIRouteInventoryParity(t *testing.T) {
 func TestNonAPIRoutesAreAccountedFor(t *testing.T) {
 	root := repoRoot(t)
 	_, nonAPI := splitByScope(extractRegisteredRoutes(t, root))
-	var unowned []string
+
+	// Naming a document is not the same as the document containing the route.
+	// Until this half existed the allowlist was a paper claim: 33 of its 42
+	// entries pointed at files that never mentioned the route, including the
+	// whole Gemini surface (`/v1beta/models*`, `/gemini/{version}/models*`,
+	// `/v1internal::*`) and the monitor iframe proxy -- reachable, tested, and
+	// undiscoverable from the docs. Same shape as the boundary gate that could
+	// scan nothing and report zero violations (#1214).
+	bodies := map[string]string{}
+	readDoc := func(doc string) (string, bool) {
+		if b, ok := bodies[doc]; ok {
+			return b, true
+		}
+		raw, err := os.ReadFile(filepath.Join(root, doc))
+		if err != nil {
+			return "", false
+		}
+		bodies[doc] = string(raw)
+		return string(raw), true
+	}
+
+	var unowned, paper []string
 	for key, where := range nonAPI {
-		if _, ok := nonAPIRouteAllowlist[key]; ok {
+		doc, ok := nonAPIRouteAllowlist[key]
+		if !ok {
+			unowned = append(unowned, key+"  (registered in "+where+")")
 			continue
 		}
-		unowned = append(unowned, key+"  (registered in "+where+")")
+		body, readable := readDoc(doc)
+		if !readable {
+			paper = append(paper, key+" -> "+doc+"  (owning document cannot be read)")
+			continue
+		}
+		if !routeKeyDocumentedIn(body, key) {
+			paper = append(paper, key+" -> "+doc+"  (that file never states this route)")
+		}
 	}
 	if len(unowned) > 0 {
 		sort.Strings(unowned)
-		t.Fatalf("non-/api routes with no owning document:\n  %s\nDocument them (docs/api/proxy.md for data-plane routes) and record the owner in nonAPIRouteAllowlist with a reason.",
+		t.Errorf("non-/api routes with no owning document:\n  %s\nDocument them (docs/api/proxy.md for data-plane routes) and record the owner in nonAPIRouteAllowlist with a reason.",
 			strings.Join(unowned, "\n  "))
+	}
+	if len(paper) > 0 {
+		sort.Strings(paper)
+		t.Fatalf("non-/api routes whose owning document does not actually document them:\n  %s\nWrite the route into that file (method + exact path), or point the entry at the file that does.",
+			strings.Join(paper, "\n  "))
+	}
+}
+
+// routeKeyDocumentedIn reports whether a document states a route. Matching is on
+// the whole "METHOD /path" key, not on the path alone: a file that only mentions
+// `/v1/models/price-compare` must not be credited with documenting
+// `GET /v1/models`. A wildcard route may be written either way.
+func routeKeyDocumentedIn(body, routeKey string) bool {
+	if strings.Contains(body, routeKey) {
+		return true
+	}
+	if strings.Contains(routeKey, "{wildcard}") {
+		return strings.Contains(body, strings.ReplaceAll(routeKey, "{wildcard}", "*"))
+	}
+	return false
+}
+
+// TestNonAPIRouteOwnershipIsNotAPaperClaim proves the ownership check can fail,
+// in both directions, using the same helper the real gate uses.
+func TestNonAPIRouteOwnershipIsNotAPaperClaim(t *testing.T) {
+	root := t.TempDir()
+	const doc = "docs/api/proxy.md"
+	if err := os.MkdirAll(filepath.Join(root, "docs", "api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "# Proxy\n\n| `POST /v1/chat/completions` | chat relay |\n| `POST /v1/models/price-compare` | prices |\n"
+	if err := os.WriteFile(filepath.Join(root, doc), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !routeKeyDocumentedIn(body, "POST /v1/chat/completions") {
+		t.Error("a route the document states was reported missing -- the gate would fail on correct docs")
+	}
+	if routeKeyDocumentedIn(body, "GET /v1beta/models") {
+		t.Error("a route the document never states passed -- the gate is paper")
+	}
+	// Path-only matching would credit the price-compare row with documenting
+	// GET /v1/models; the whole-key match must not.
+	if routeKeyDocumentedIn(body, "GET /v1/models") {
+		t.Error("a sibling path satisfied the check -- matching must be on the whole route key")
+	}
+	if routeKeyDocumentedIn(body, "POST /responses/{wildcard}") {
+		t.Error("wildcard route matched a document that does not mention it in either spelling")
+	}
+	if !routeKeyDocumentedIn(body+"\n`POST /responses/*`\n", "POST /responses/{wildcard}") {
+		t.Error("the * spelling of a wildcard route was not accepted")
 	}
 }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -323,6 +323,7 @@ pg_dump -Fc 'postgres://<user>:<password>@<host>:5432/metapi?sslmode=require' > 
 
 - Liveness check: `GET /health` returns `{"status":"ok"}` when the HTTP process is alive
 - Readiness check: `GET /ready` returns `{"status":"ok","database":"ok"}` or HTTP 503 when the database is unavailable or the process is draining for shutdown
+- Metrics: `GET /metrics` serves the Prometheus text exposition format directly (no external dependency), and it is registered before the auth middleware — so, like `GET /health` and `GET /ready`, it answers without a token. Series exposed: `metapi_uptime_seconds`, `metapi_active_channels`, `metapi_proxy_requests_total`, `metapi_proxy_errors_total`, `metapi_proxy_outcomes_total`, the `metapi_proxy_request_duration_seconds` histogram, `metapi_proxy_streams_active`, `metapi_stream_missing_usage_total`, `metapi_route_rebuild_total`, `metapi_db_connections_open`, `metapi_db_connections_in_use`, `metapi_db_conn_errors_total`. Scrape it from a network you control, or allowlist the path in your reverse proxy.
 - Docker healthcheck runs `metapi healthcheck`, which polls `/ready` every 30 seconds by default
 - Override the healthcheck target with `METAPI_HEALTHCHECK_URL` or `METAPI_HEALTHCHECK_PATH`
 - Startup exits before binding the HTTP port when database bootstrap, runtime settings load, or runtime schema migration fails.

--- a/handler/proxy/helpers_test.go
+++ b/handler/proxy/helpers_test.go
@@ -8,28 +8,6 @@ import (
 	"testing"
 )
 
-// ---- itoa ----
-
-func TestItoa(t *testing.T) {
-	tests := []struct {
-		input int64
-		want  string
-	}{
-		{0, "0"},
-		{1, "1"},
-		{-1, "-1"},
-		{42, "42"},
-		{-100, "-100"},
-		{9223372036854775807, "9223372036854775807"},
-	}
-	for _, tt := range tests {
-		got := itoa(tt.input)
-		if got != tt.want {
-			t.Errorf("itoa(%d) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
-
 // ---- writeJSONError ----
 
 func TestWriteJSONError(t *testing.T) {

--- a/handler/proxy/messages.go
+++ b/handler/proxy/messages.go
@@ -40,29 +40,6 @@ func HandleClaudeCountTokens(w http.ResponseWriter, r *http.Request) {
 
 // Helper functions
 
-func itoa(n int64) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := false
-	if n < 0 {
-		neg = true
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
-}
-
 // writeJSON writes a JSON response via the shared encoder.
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	shared.WriteJSON(w, status, body)

--- a/handler/proxy/search_test.go
+++ b/handler/proxy/search_test.go
@@ -3,6 +3,7 @@ package proxyhandler
 import (
 	"fmt"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 )
 
@@ -24,7 +25,6 @@ func TestHandleSearch_Success(t *testing.T) {
 		t.Errorf("model = %v, want %s", m["model"], defaultSearchModel)
 	}
 }
-
 
 func TestHandleSearch_DefaultMaxResults(t *testing.T) {
 	req := makeProxyReq("POST", "/v1/search", `{"query":"test"}`)
@@ -120,10 +120,10 @@ func TestHandleSearch_Unauthorized(t *testing.T) {
 func toJSON(v any) string {
 	switch val := v.(type) {
 	case int:
-		return itoa(int64(val))
+		return strconv.FormatInt(int64(val), 10)
 	case float64:
 		if float64(int64(val)) == val {
-			return itoa(int64(val))
+			return strconv.FormatInt(int64(val), 10)
 		}
 		return fmt.Sprintf("%v", val)
 	case string:

--- a/handler/proxy/videos_gc_test.go
+++ b/handler/proxy/videos_gc_test.go
@@ -1,6 +1,7 @@
 package proxyhandler
 
 import (
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -180,7 +181,7 @@ func TestVideoTaskCache_SweepIsThrottledBetweenThresholds(t *testing.T) {
 	// 10 inserts inside the throttle window (1 s apart, counter below 256).
 	for i := 0; i < 10; i++ {
 		advance(time.Second)
-		SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_throttle_" + itoa(int64(i))})
+		SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_throttle_" + strconv.FormatInt(int64(i), 10)})
 	}
 
 	storedAt, inserts, lastSweep := videoTaskCacheSnapshotForTest()
@@ -217,7 +218,7 @@ func TestVideoTaskCache_CapacityGuardrailEvictsOldestFirst(t *testing.T) {
 
 	for i := 1; i <= 6; i++ {
 		advance(time.Second)
-		SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_cap_" + itoa(int64(i))})
+		SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_cap_" + strconv.FormatInt(int64(i), 10)})
 	}
 	// Throttled inserts may overshoot the guardrail; the bound is cap+256.
 	if storedAt, _, _ := videoTaskCacheSnapshotForTest(); len(storedAt) != 6 {
@@ -324,7 +325,7 @@ func TestVideoTaskCache_ConcurrentInsertTrimAndSweep(t *testing.T) {
 		go func(w int) {
 			defer wg.Done()
 			for i := 0; i < iterations; i++ {
-				id := "v_race_" + itoa(int64(w)) + "_" + itoa(int64(i))
+				id := "v_race_" + strconv.FormatInt(int64(w), 10) + "_" + strconv.FormatInt(int64(i), 10)
 				SaveProxyVideoTask(&ProxyVideoTask{PublicID: id, UpstreamVideoID: "up_" + id})
 				_ = GetProxyVideoTaskByPublicID(id)
 				if i%4 == 0 {

--- a/handler/proxy/videos_test.go
+++ b/handler/proxy/videos_test.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -388,7 +389,7 @@ func TestProxyVideoTask_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			id := "video_concurrent_" + itoa(int64(n))
+			id := "video_concurrent_" + strconv.FormatInt(int64(n), 10)
 			SaveProxyVideoTask(&ProxyVideoTask{PublicID: id})
 			_ = GetProxyVideoTaskByPublicID(id)
 			DeleteProxyVideoTaskByPublicID(id)

--- a/service/backup/export.go
+++ b/service/backup/export.go
@@ -153,10 +153,6 @@ func TablesForExportType(exportType string) (string, []string, error) {
 	}
 }
 
-func QueryTableAsJSON(db *sqlx.DB, table string) ([]map[string]any, error) {
-	return queryTableAsJSON(db, table, nil)
-}
-
 func queryTableAsJSON(db *sqlx.DB, table string, estimatedPayloadBytes *int64) ([]map[string]any, error) {
 	if !IsKnownTable(table) {
 		return nil, fmt.Errorf("unknown table: %s", table)

--- a/service/backup/export_internal_test.go
+++ b/service/backup/export_internal_test.go
@@ -1,0 +1,68 @@
+package backup
+
+// The exported QueryTableAsJSON wrapper is gone: nothing in production called
+// it, and its only caller was a test in the external test package, so the public
+// surface existed to be tested rather than to be used. The guard behind it is
+// still load-bearing -- a table name reaching queryTableAsJSON is interpolated
+// into the statement, and IsKnownTable is the only thing between it and the SQL
+// parser -- so it is proven here against the function production actually calls.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/jmoiron/sqlx"
+)
+
+func setupInternalBackupDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+	return db.DB
+}
+
+func TestQueryTableAsJSONRejectsUnknownTable(t *testing.T) {
+	db := setupInternalBackupDB(t)
+
+	for _, table := range []string{
+		"settings; DROP TABLE settings",
+		"settings--",
+		"settings WHERE 1=1",
+		"not_a_table",
+		"",
+	} {
+		rows, err := queryTableAsJSON(db, table, nil)
+		if err == nil {
+			t.Errorf("queryTableAsJSON(%q) returned %d rows and no error, want an unknown-table rejection", table, len(rows))
+			continue
+		}
+		if !strings.Contains(err.Error(), "unknown table") {
+			t.Errorf("queryTableAsJSON(%q) error = %v, want it to name the unknown table", table, err)
+		}
+	}
+}
+
+func TestQueryTableAsJSONReadsAKnownTable(t *testing.T) {
+	db := setupInternalBackupDB(t)
+
+	if _, err := db.Exec(`INSERT INTO settings (key, value) VALUES ('theme', '"dark"')`); err != nil {
+		t.Fatalf("seed setting: %v", err)
+	}
+
+	rows, err := queryTableAsJSON(db, "settings", nil)
+	if err != nil {
+		t.Fatalf("queryTableAsJSON(settings) = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want the one seeded row", len(rows))
+	}
+}

--- a/service/backup/export_test.go
+++ b/service/backup/export_test.go
@@ -103,15 +103,6 @@ func TestTablesForExportTypeRejectsInvalidType(t *testing.T) {
 	}
 }
 
-func TestQueryTableAsJSONRejectsUnknownTable(t *testing.T) {
-	db := setupBackupServiceTestDB(t)
-
-	_, err := backupsvc.QueryTableAsJSON(db.DB, "settings; DROP TABLE settings")
-	if err == nil {
-		t.Fatal("expected unknown table error")
-	}
-}
-
 func BenchmarkBuildPayloadPreferences(b *testing.B) {
 	db := setupBackupServiceTestDB(b)
 	if _, err := db.Exec("INSERT INTO settings (key, value) VALUES (?, ?)", "theme", `"dark"`); err != nil {


### PR DESCRIPTION
## 起点：一次机械普查，不是"看着像死码"

对全仓生产 `.go` 做单遍词频统计，找出**零非测试引用**的符号：导出符号 1400 个中 21 个，未导出符号中 1 个。19 个判定保留，2 个退役。

**保留的 19 个（判定写在这里，免得下一个人再普查一遍）**：`store/schema.go` 的 18 个表结构体 + 两个 nullable 列的 coercion 助手。前者是 `TestTableCount` 钉住的**绝对表清单**（加表/删表必须是刻意动作——正是 #1165/#1172 那一族事故的防线），后者是 `*bool` / `*float64` 列在 TS 迁移行里可能为 NULL 时的**安全出口**：删掉它们，裸 deref 就成了唯一选项。

## 退役的两处

**1. `handler/proxy/messages.go` 里手写的 int64 格式化函数**，零生产调用者。仓库里还有 5 份同功能实现，**其它 5 份全在测试文件里**（`service/checkin`、`service`、`docs`、`handler/admin` ×2）——只有这一份住在生产文件里，而 `strconv.FormatInt` 干的是同一件事。删除，6 个测试调用点改用标准库，`TestItoa` 随之删除：它拿本地字面量去断言一个没有产品代码调用的函数，与 v0.18.0 删掉的四个 vacuous 测试同形。

**2. `service/backup.QueryTableAsJSON`**：一个三行导出包装，包着 `BuildPayload` 真正调用的那个未导出函数。它唯一的调用者是外部测试包里的一个测试——**这个导出符号存在的意义是被测试，而不是被使用**。删除。

它暴露的守卫不但保留，而且比原来证明得更实：新增 `export_internal_test.go` 在**包内**直接调 `queryTableAsJSON`，用五个敌意表名（语句终止符 `settings; DROP TABLE settings`、注释 `settings--`、谓词 `settings WHERE 1=1`、未知表名、空串）要求每一个都被判为 unknown table，外加一个已知表读回它播种的那一行。原来那个测试只喂一个字符串、只要求 error 非 nil——注入面被"守住"了，但守到什么程度没人知道。

## 证明

- `go build ./...` 干净，`go vet` 两个包干净，`go test ./service/backup ./handler/proxy -count=1` 绿；
- 新守卫测试的变异探针 **2/2 红**：① 撤掉 `IsKnownTable` 调用 → 五个敌意表名逐条被点名（错误变成 SQLite 的 `no such table`，而不是拒绝）；② 把 `IsKnownTable` 改成恒真（守卫还在但不再守卫）→ 同样红。两次都逐字节还原后基线复绿。

**零行为变化**：没有任何产品代码路径失去它在用的符号。
