### PR TITLE
docs(backend): the import rules had four copies and two of them had drifted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ golangci-lint run --timeout=3m        # Lint check
 | Path                                                       | Role                                                                           |
 | ---------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | `docs/architecture.md`                                     | As-built package map (proxy/transform/routing; not proxycore/protocol)         |
-| `docs/internal/design/BACKEND.md`                          | Backend philosophy, dependency rules, forbidden imports                        |
+| `docs/internal/design/BACKEND.md`                          | Backend principles + cross-cutting contracts (import edges: `docs/architecture.md` + `docs/package_boundary_test.go`) |
 | `docs/internal/design/DESIGN.md`                           | UI design system source of truth                                               |
 | `docs/testing.md`                                          | Test layers + sanitized real-platform testbed SOP                              |
 | `docs/api.md` / `docs/deployment.md` / `docs/migration.md` | API · deploy · migration                                                       |

--- a/docs/internal/design/BACKEND.md
+++ b/docs/internal/design/BACKEND.md
@@ -1,10 +1,12 @@
 # Backend Design Philosophy
 
-**Last updated**: 2026-08-16
+**Last updated**: 2026-09-04
 
-**Status**: architecture baseline — backend architecture truth
-**Authority**: package layout and import edges as they exist in this repo
-**Companion**: [`docs/architecture.md`](../../architecture.md) (as-built map)
+**Status**: contributor principles — how backend code should be written
+**Not the authority on import edges**: the boundary contract is
+[`docs/architecture.md`](../../architecture.md) §"Ownership and boundary map", and its
+executable form is [`docs/package_boundary_test.go`](../../package_boundary_test.go). When this
+file and those two disagree, those two are right and this file is stale.
 
 This document states the **non-negotiable backend principles** for metapi-go. Implementation work under backend architecture (package boundaries, concurrency, unified errors) must not violate these rules without an explicit design revision.
 
@@ -114,43 +116,37 @@ Rules of thumb:
 
 Arrows mean **“may import”**. Edges not shown are forbidden unless listed under exceptions.
 
-### 2.2 Dependency table (summary)
+### 2.2 The forbidden-import rules have one owner, and it is not this file
 
-| Package                         | May import (internal)                                                                                | Must not import                                                       |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `config`                        | —                                                                                                    | everything else                                                       |
-| `web`                           | —                                                                                                    | everything else                                                       |
-| `handler/shared`                | —                                                                                                    | domain packages                                                       |
-| `store`                         | `config`                                                                                             | `handler`, `proxy`, `router`, `scheduler`, `service`, `auth`          |
-| `platform`                      | — (leaf adapters)                                                                                    | `store`, `handler`, `proxy`, `router`, `scheduler`                    |
-| `transform/*`                   | `transform/shared`                                                                                   | `handler`, `store`, `proxy`, `routing`, `service`                     |
-| `proxy/types`, `proxy/profiles` | `proxy/types` only (profiles)                                                                        | upper layers                                                          |
-| `routing`                       | `config`, `store`                                                                                    | `handler`, `proxy`, `router`, `scheduler`, `service`                  |
-| `auth`                          | `config`, `store`                                                                                    | `handler`, `proxy`, `router`                                          |
-| `service` (+ subpackages)       | `config`, `store`, `platform`, other `service/*`                                                     | `handler`, `router`, `proxy` (keep domain free of HTTP/orchestration) |
-| `proxy`                         | `config`, `store`, `routing`, `service`, `proxy/*`                                                   | `handler`, `router`, `scheduler`                                      |
-| `handler/*`                     | `auth`, `config`, `store`, `service`, `proxy`, `routing`, `platform`, `app` (sparingly), `handler/*` | `router` (router mounts handlers, not reverse)                        |
-| `scheduler`                     | `config`, `store`, `service/*`                                                                       | `handler`, `router`, `proxy`                                          |
-| `app`                           | `config`, `store`, and wiring deps as needed                                                         | becoming a junk drawer for business logic                             |
-| `router`                        | `app`, `auth`, `config`, `handler/*`, `store`, `web`                                                 | `platform` internals, `transform` internals (handlers own surfaces)   |
-| `cmd/*`                         | composition root — may wire all layers                                                               | business logic bodies (keep `main` thin)                              |
+The diagram above is the *intent* — which direction is down. The contract is
+[`docs/architecture.md`](../../architecture.md) §"Ownership and boundary map": one row per
+package, the decision it owns, and what it must not import. Its executable form is
+[`docs/package_boundary_test.go`](../../package_boundary_test.go) — rules 1–8, every approved
+exception with the architecture section that justifies it, and an assertion that all twelve
+domains were really scanned, because a boundary gate that scans nothing and reports no
+violations is not a lenient gate but an absent one. That is not a hypothetical: it is the shape
+that let roughly thirty release tags stay green while their required shards ran zero tests.
 
-### 2.3 Forbidden imports (hard rules)
+This section used to carry a dependency table and the next one a list of hard rules. Both were
+copies and both had drifted, in opposite directions: the table forbade `routing → router` and
+`auth → handler/proxy/router`, which nothing enforces, while omitting `store ↛ routing` and
+`transform ↛ auth`, which are enforced; the rule list omitted `service ↛ proxy` and
+`scheduler ↛ handler/router/proxy` altogether. Two copies of one rule in a single file — three
+counting the gate — is how a contributor gets a stale answer to "may I import this?". Read the
+gate; its failure message names the rule number.
 
-1. **`store` must not import** `handler`, `proxy`, `routing`, `service`, `scheduler`, `router`, `auth`.
-2. **`platform` must not import** `store`, `handler`, `proxy`, `router`, `scheduler` (adapters stay I/O-shaped; persistence is caller-side).
-3. **`transform` must not import** `handler`, `store`, `proxy`, `routing`, `service`, `auth`.
-4. **`routing` must not import** `proxy` or `handler` (selection stays pure relative to HTTP orchestration).
-5. **`service` must not import** `handler` or `router` (no HTTP types in domain services).
-6. **`handler` must not import** `scheduler` for request-path business logic except explicit admin ops that trigger jobs (prefer service facades).
-7. **No new top-level package names** that revive TS layout (`proxycore`, `protocol`) — extend `proxy` / `transform` instead.
-8. **No import cycles.** If a cycle appears, extract a small types/ports package rather than merging layers.
+Two items from the old list are not the gate's business and stay here as principles:
 
-### 2.4 Composition root
+- **No import cycles.** The compiler already refuses them; if one appears, extract a small
+  types package rather than merging two layers.
+- **Prefer a service facade over `handler → scheduler`** for anything on a request path. The one
+  approved exception is admin-ops cron validation, and it is listed in the gate's header comment.
+
+### 2.3 Composition root
 
 Only `cmd/server` (and tests/e2e helpers) should construct the full graph: load config → open store → build services/router/schedulers → `app.Start`. Libraries under packages should accept dependencies via constructors/parameters, not hidden global grabs—except the existing `config.Get()` singleton pattern used for parity.
 
-**As-built inventory:** package ownership, public entrypoints, and documented exception edges (e.g. admin checkin schedule → `app`/`scheduler`, `app.ConfigureProxyUpstream` → `handler/proxy`) are recorded in the as-built package map [`docs/architecture.md`](../../architecture.md). New exceptions must be listed there (and justified against §2.3) rather than introduced silently.
+**As-built inventory:** package ownership, public entrypoints, and documented exception edges (e.g. admin checkin schedule → `app`/`scheduler`, `app.ConfigureProxyUpstream` → `handler/proxy`) are recorded in the as-built package map [`docs/architecture.md`](../../architecture.md). New exceptions must be listed there and in the gate's header comment, with a reason, rather than introduced silently.
 
 ---
 

--- a/docs/package_boundary_test.go
+++ b/docs/package_boundary_test.go
@@ -35,7 +35,7 @@ import (
 //   - handler/admin → app (checkin schedule lifecycle, §5.2)
 //   - app → handler/proxy (ConfigureProxyUpstream composition helper, §5.3)
 //   - platform → proxy/profiles (profile detection, §3.2)
-//   - handler/* → platform (thin admin/verify actions, §2.2 table)
+//   - handler/* → platform (thin admin/verify actions; docs/architecture.md boundary map)
 //   - handler/proxy → transform/* (one-way protocol wiring, §5.4)
 //   - auth → internal/sharedcount
 //   - (scheduler → handler/shared §5.11 exception RESOLVED 2026-07-31:


### PR DESCRIPTION
## 一个契约，四份副本，其中两份已经漂了

禁止 import 的边界契约同时存在于四处：`docs/architecture.md` 的 boundary map、它的可执行形态 `docs/package_boundary_test.go`、`docs/internal/design/BACKEND.md` §2.2 的依赖表、以及同一文件 §2.3 的"硬规则"清单。

`architecture.md` 自己已经写明谁赢（"the test is right and this page is stale"），而且它与门**逐行一致**。BACKEND.md 那两份与两者都不一致，且方向相反：

| 副本 | 漂移 |
| :-- | :-- |
| §2.2 表 | 禁止 `routing → router`、`auth → handler/proxy/router`（**没有任何东西在执行**）；同时漏掉 `store ↛ routing`、`transform ↛ auth`（**门在执行**） |
| §2.3 清单 | 完全漏掉 `service ↛ proxy` 与 `scheduler ↛ handler/router/proxy`；把 `handler → scheduler` 写成规则，而门里它是**已批准的例外** |

于是一个贡献者问"我能不能 import 这个"，在两个文件里能读到三种答案；而自称权威的那一份（BACKEND.md 头部写着 "Authority: package layout and import edges as they exist in this repo"）正是错的那一份。这句权威声明随副本一起删掉了。

## 改法：单一 owner + 指针，不是再抄一遍

- §2.2 保留**层次图**（它表达的是意图：哪个方向是"下"），其余改成指向契约（`architecture.md`）与可执行形态（`package_boundary_test.go`），并**把这次漂移写进正文**——免得下一个人再"为了方便"补一张表回来。顺带记下门为什么必须断言"十二个域都真的被扫到"：扫不到东西的门不是宽松的门，是不存在的门（约三十个 tag 必选分片跑 0 个测试仍全绿就是这个形状）。
- 旧清单里**确实不归门管**的两条留下当原则：无 import 环（编译器已经拒绝；真出现就抽一个小的 types 包，而不是合并两层）· 请求路径上优先用 service facade 而不是 `handler → scheduler`（唯一已批准的例外是 admin-ops cron 校验，就列在门的头注释里）。
- §2.4 重编号为 §2.3；那句"新例外要 against §2.3 论证"改指 boundary map 与门的头注释；门自己的注释不再引用"§2.2 table"；`AGENTS.md` 的索引行不再把 BACKEND.md 宣传成 forbidden imports 的去处。

## 门禁

`go test ./docs -count=1` 绿（含边界门与 markdown 卫生）；新加的 7 条相对链接全部可达；改动到的 Go 文件 `gofmt -l` 干净；BACKEND.md 15.9K → 13.1K 字节。**零行为变化**（改的是文档与一处注释）。
