### PR TITLE
docs(changelog): three things this file asserted about itself were untrue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to Metapi-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
-**写作契约**（CI 把 `## [vX.Y.Z]` 段直接抽成 GitHub release body：这里写的就是发布说明）：
+**写作契约**（打 tag 时 CI 把 `## [vX.Y.Z]` 段逐字抽成该版本的 GitHub release body。**那是快照，不是引用**：tag 之后再改这里的段落，已发布版本的发布页不会跟着变，两处从此分叉）：
 
 - 读者是**部署和调用 Metapi 的人**。写「行为怎么变了、我要不要动手」，不写「我们怎么查出来的」。
 - 一条 = 一行结论 + 至多两句因果 + `(#PR)`。取证过程、测试与门禁的形状、行数增减、内部文件清单留在 commit body 与 PR 里（`git log --grep '#1210'` 一步到达）。
 - **需要运维动手的必须显式写出来**：升级后要重新登录、环境变量默认值变了、备份不再含某张表、某个端点删了。这是本文件唯一不可省略的部分。
 - 编号写成 `#问题 → #PR`：前者是报障/立项的 issue，后者是落地它的 PR（commit subject 带的是 PR 号，`git log --grep '#1211'` 直达）。只有一个编号时它就是 PR。
-- 分节固定为 `安全` `修复` `变更` `移除` `开发者可见` `文档` `已知遗留`，空节不写。v0.16.23 及更早沿用当年的 `Added/Changed/Fixed/…` 与措辞，不回填重写。
+- 分节固定为 `安全` `修复` `变更` `移除` `开发者可见` `文档` `已知遗留`，空节不写。**v0.16.17 及更早逐字保留**；v0.16.18–v0.16.23 只保留当年的 `Added/Changed/Fixed/…` 分节名，措辞已按本契约压缩。
 
 ## [v0.19.0] — 2026-09-04
 
@@ -110,7 +110,7 @@ All notable changes to Metapi-Go will be documented in this file.
 ### 修复
 
 - **流式请求的中断、截断与空内容不再记成功（#1159）**：此前流式路径只区分「idle 超时」与「其它一律正常结束」，内容级判定只写日志不参与记账，于是上游中途断连、被 `PROXY_MAX_STREAM_RESPONSE_BYTES` 截断、或返回命中 `PROXY_ERROR_KEYWORDS` 的错误体时，渠道健康度、`proxy_logs` 与终端指标全部按成功记账。现在流结束原因分五类（正常 / idle 超时 / 上游故障 / 被截断 / 客户端断开），状态、原因与指标 outcome 由同一个所有者决定。
-- **恢复出厂设置真的恢复到出厂（#1165）**：`POST /api/settings/maintenance/factory-reset` 此前遍历一份手抄表清单，它已经比 schema 少 9 张表——其中包含 `admin_sessions`。会话校验每个请求都读这张表，所以它没被清空意味着**重置前签发的每一个 admin cookie 仍然对一个空库有写权限**；`admin_audit_logs`、`model_probe_results` 等同样幸存。现在表清单从 schema 注册表派生，唯一排除项是 additive 迁移日志 `schema_migrations`。
+- **恢复出厂设置真的恢复到出厂（#1165）**：`POST /api/settings/maintenance/factory-reset` 此前遍历一份手抄表清单，它已经比 schema 少 9 张表——其中包含 `admin_sessions`。会话校验每个请求都读这张表，所以它没被清空意味着**重置前签发的每一个 admin cookie 仍然对一个空库有写权限**；`admin_audit_logs`、`model_probe_results` 等同样幸存。现在表清单从 schema 注册表派生，唯一排除项是 additive 迁移日志 `schema_migrations`。**重置成功后必须重新登录**（`admin_sessions` 也在清理集里，重置前签发的 cookie 一律失效）。
 - **`cmd/migrate` 不再静默丢表（#1165）**：方言迁移（SQLite ↔ PostgreSQL）此前按另一份手抄清单拷贝，37 张表里只拷了 20 张——命令正常退出、checksum 全部匹配，但 17 张表的数据根本没被搬运。现在拷贝集、清空序、逐表列规格与建表序全部从同一个注册表派生，加一张表只需在注册表加一行。源库里存在而 Go schema 未声明的列现在会在拷贝前逐表打 Warning（丢弃不可避免，但不再静默）。
 - **`checkin_interval_hours` 的越界值不再被静默丢弃（#1166）**：库内该键此前走「范围检查不通过就不赋值、不告警、还算已处理」，而环境变量 `CHECKIN_INTERVAL_HOURS` 走双侧钳制 ⇒ 库里存一个 `30`，进程留在环境变量的值，`GET /api/settings/runtime` 回显的也是那个值，三者互不相同。
 - **`GET /api/channels` 的快照缓存此前几乎从不命中（#1167）**：缓存只有一个槽位，而键空间是多键的（仪表盘无界视图 + 每个分页/状态筛选视图各一键），于是 `page=1` 与 `page=2` 互相逐出，10s TTL 从来没吸收掉它存在是为了吸收的轮询，那条 fleet-wide 5-way JOIN 照跑。现在是有界多键缓存（至多 16 个键，FIFO 淘汰）；TTL、`?refresh=true` 绕过、`x-channels-snapshot-cache` 响应头、并发去重与「数据变了就整体失效」的语义一字未改。


### PR DESCRIPTION
## Observed failure

`CHANGELOG.md` states a writing contract at the top. Three of its claims are mechanically false, and one of them means **#1231 did not reach the surface it was written for**.

Diffed all nine published GitHub release bodies against the section CI extracted them from:

| version | release page (bytes) | CHANGELOG section (bytes) | identical to `56fb3acb^`? |
|---|---|---|---|
| v0.19.0 | 15,200 | 6,642 | yes (±1 trailing newline) |
| v0.18.0 | 26,431 | 8,839 | yes |
| v0.17.1 | 10,071 | 5,853 | yes |
| v0.17.0 | 11,308 | 7,858 | yes |
| v0.16.23 | 10,425 | 4,428 | yes |
| v0.16.22 | 10,241 | 4,839 | yes |
| v0.16.21 | 4,497 | 3,098 | yes |
| v0.16.19 | 4,546 | 3,742 | yes |
| v0.16.18 | 3,221 | 2,596 | yes |

**Who hit it:** anyone clicking the README release badge. **What they were doing:** deciding whether to upgrade. **What happened:** they read the pre-#1231 forensic text — the exact thing #1231 was opened to retire. **Expected:** the release note is the section, as the contract's first line asserts. **Reproducible:** yes, `gh api repos/:owner/:repo/releases/tags/v0.19.0 --jq .body`. **Which layer should have caught it:** none — `go test ./docs` walks the working tree, and the extraction runs only inside the tag pipeline. **Why it didn't:** the contract described the extraction as a live reference; it is a one-time snapshot.

## The three false claims

**1. "CI 把 `## [vX.Y.Z]` 段直接抽成 GitHub release body：这里写的就是发布说明"**

True only at tag time. `.github/workflows/main.yml` extracts once, inside the release job. Editing a section afterwards leaves the published page unchanged, so all nine rewritten sections diverged from their releases the moment #1231 merged. Now says *snapshot, not reference*.

**2. "v0.16.23 及更早沿用当年的 `Added/Changed/Fixed/…` 与措辞，不回填重写"**

False for six versions. v0.16.18–v0.16.23 were all rewritten — 0 to 2 bullets per version survived verbatim (v0.16.20: 0/35). What they kept is the English *section names*. The measured boundary is **v0.16.17**: 28 versions from there down are byte-identical. Now states the real boundary.

**3. v0.17.0 lost an operator action the contract calls non-omittable**

The rewrite dropped `**调用方在重置成功后必须重新登录**`. The contract's third bullet names "升级后要重新登录" as *the one thing that may not be omitted*. The fact is still true and still owned by `docs/api/settings.md` ("**Sign in again after a successful factory reset.**"), so nothing broke — the release note simply stopped telling the operator. Restored, with the reason inline.

## What deliberately did not come back

v0.17.0's published body also carried `需要保留审计/探测历史请先 GET /api/settings/backup/export`. v0.17.1 (#1172) publicly retracted that as **false when written** — backups have never contained `admin_audit_logs` or `model_probe_results`. That retracted escape hatch stays retracted; only the true half returns. This is worth noting because the false instruction is *still live on the v0.17.0 release page*.

## Conservation audit (mechanical, not by eye)

Across all nine rewritten sections: every `#NNNN`, every `ALL_CAPS` env var, and the four operator-action categories (re-login / changed default / table no longer backed up / endpoint removed) inventoried before and after.

- **#NNNN**: v0.18.0, v0.17.1, v0.17.0 all conserved 28/28, 4/4, 12/12. v0.19.0 dropped 5 (`#625`, `#1034`, `#1186`, `#1192`, `#1194`) — all internal cross-references to earlier PRs, reachable via `git log --grep`.
- **env vars**: remaining deltas are SQL/build noise (`INSERT`, `SELECT`, `WHERE`, `PHONY`) plus `PROXY_STREAM_IDLE_TIMEOUT_SEC`, which has three live doc owners (`docs/configuration.md:127`, `docs/deployment.md:151`, `docs/api/proxy.md:165`) and is still introduced in the v0.16.18 entry.
- **Two entries that looked deleted** from v0.16.19 (`### Performance`, `### Internal`) were only *moved* into `### Changed` — `#1054`, `#1058`, `internal/httpclient` and the `17.9ms → 0.5ms` figure all survive.
- `X-Real-IP`/`RemoteAddr` fallback semantics: owned by `docs/api/proxy.md` header policy.

## Gates

- `go test ./docs -count=1` → `ok` (includes `TestPublicMarkdownHygiene`, `TestRelativeMarkdownLinksResolve`)
- 38 version headings, 38 unique
- `scripts/release.sh`'s `grep -q "^## \[$tag\]"` and the workflow's `awk` both still extract a non-empty body for every section (v0.19.0 → 6,642 B, v0.17.0 → 7,980 B)
- release-notes vocabulary filter: 0 hits file-wide, and 0 hits on each of the nine sections individually

## No new gate, and why

Law 5: a gate must correspond to a failure existing CI should have caught, and must go red on a mutation probe. Nothing in the current tree *can* see a published release body — the only shape that would is a scheduled job calling the GitHub API to compare bodies against sections. That is a real candidate, but it needs a backfill decision first (see below), and adding it now would just be permanently red or permanently skipped. Recorded as a candidate instead.

## Decision this PR does not make

Backfilling the nine published release bodies from their current sections is **not** done here — it rewrites public, already-announced release pages. Prepared and reversible (all nine originals archived byte-for-byte), awaiting a call. Note the one with a correctness argument rather than a tidiness one: **v0.17.0's page still tells operators to export a backup to preserve audit history, which does not work.**

Docs only: no code, no behaviour, no test changes. No release.