### PR TITLE
fix(config): the credential secret .env.example ships is public, and nothing said so

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -574,6 +574,48 @@ func TestValidateAcceptsStrongCredentialSecret(t *testing.T) {
 	}
 }
 
+func TestValidateWarnsOnShippedPlaceholderCredentialSecret(t *testing.T) {
+	// The literal .env.example ships for ACCOUNT_CREDENTIAL_SECRET must be
+	// reported. It is 33 bytes, so it clears both length floors (< 8 critical,
+	// < 16 warning) and, before this guard existed, a deployment that copied
+	// .env.example and filled in only the two variables docker-compose forces
+	// started cleanly while encrypting every stored upstream credential under
+	// a string that is public in this repository.
+	cfg, _ := Load(map[string]string{
+		"AUTH_TOKEN":                "admin-token-not-default",
+		"PROXY_TOKEN":               "proxy-token-not-default",
+		"ACCOUNT_CREDENTIAL_SECRET": EnvExampleAccountCredentialSecret,
+		"CLAUDE_CLIENT_ID":          "claude-client",
+		"CODEX_CLIENT_ID":           "codex-client",
+		"GEMINI_CLI_CLIENT_ID":      "gemini-client",
+	})
+
+	if len(EnvExampleAccountCredentialSecret) < 16 {
+		t.Fatalf("precondition: the shipped placeholder is %d bytes and would already trip a length floor, so this test would no longer prove the placeholder guard fires",
+			len(EnvExampleAccountCredentialSecret))
+	}
+
+	var found, critical bool
+	for _, err := range cfg.Validate() {
+		if configErrorField(err) != "account_credential_secret" {
+			continue
+		}
+		found = true
+		critical = configErrorCritical(err)
+	}
+	if !found {
+		t.Fatal("Validate did not report the .env.example placeholder credential secret — it clears both length floors, so only the placeholder guard can catch it")
+	}
+	// Deliberately non-critical, and pinned so it cannot be escalated by
+	// reflex: hasCritical makes cmd/server exit(1), which would refuse to boot
+	// any deployment already running on the placeholder, and rotating the
+	// secret does not re-encrypt existing rows (DecryptAccountPassword returns
+	// "" for them), so those accounts would have to be re-bound.
+	if critical {
+		t.Fatal("placeholder credential secret flagged critical, want warning: refusing to boot strands deployments already running on it, and rotating orphans existing ciphertext")
+	}
+}
+
 func TestLoadLogLevelDefaultsToInfo(t *testing.T) {
 	cfg, _ := Load(map[string]string{})
 	if cfg.LogLevel != DefaultLogLevel {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -11,6 +11,19 @@ const (
 	DefaultGeminiCliClientId     = "GEMINI_CLI_CLIENT_ID_PLACEHOLDER"
 	DefaultGeminiCliClientSecret = "GEMINI_CLI_CLIENT_SECRET_PLACEHOLDER"
 
+	// EnvExampleAccountCredentialSecret is the literal shipped on the
+	// ACCOUNT_CREDENTIAL_SECRET line of .env.example. It is deliberately NOT
+	// named Default*: every other constant in this block is a value Load()
+	// falls back to, whereas nothing in the code ever falls back to this one.
+	// It matters because Load() takes any non-empty env value verbatim, so a
+	// deployment that copies .env.example and fills in only the two variables
+	// docker-compose forces (${AUTH_TOKEN:?}, ${PROXY_TOKEN:?}) runs with this
+	// public string as its real credential-encryption key. config.Validate
+	// reports it; TestShippedCredentialSecretPlaceholderIsTheGuardedOne pins
+	// the two files to each other so retyping the placeholder in only one of
+	// them cannot silently disarm that check.
+	EnvExampleAccountCredentialSecret = "REPLACE_WITH_STRONG_RANDOM_SECRET"
+
 	DefaultPort    = 4000
 	DefaultDataDir = "./data"
 	DefaultDbType  = "sqlite"

--- a/config/validate.go
+++ b/config/validate.go
@@ -106,15 +106,40 @@ func (c *Config) Validate() []error {
 		// silently passes the empty check above, so enforce explicit floors:
 		//   < 8 bytes  → critical (trivially brute-forceable)
 		//   < 16 bytes → warning  (weak; .env.example recommends 32+ bytes)
+		//
+		// Length is not the whole story. The literal .env.example ships is 33
+		// bytes, so it clears both floors and reads as a strong secret while
+		// being public in this repository: buildCredentialKey derives the AES
+		// key from SHA-256 of exactly this string, so anyone holding the
+		// database can decrypt every stored upstream credential without
+		// touching the server. Guarded separately, and matched against the
+		// shared constant rather than a retyped literal.
 		secretLen := len(c.AccountCredentialSecret)
-		if secretLen < 8 {
+		switch {
+		case c.AccountCredentialSecret == EnvExampleAccountCredentialSecret:
+			// A warning, not a critical error, on purpose — both escalations
+			// were tried against the real code and each is its own trap:
+			//   critical → hasCritical makes cmd/server exit(1), so a
+			//     deployment already running on the placeholder refuses to
+			//     boot after an upgrade;
+			//   rotate   → nothing re-encrypts existing rows, so
+			//     DecryptAccountPassword returns "" for every stored password
+			//     and those accounts must be re-bound.
+			// So the operator gets the fact plus the consequence, and chooses.
+			errs = append(errs, &configError{
+				field:    "account_credential_secret",
+				value:    "(placeholder)",
+				msg:      "UNSAFE: ACCOUNT_CREDENTIAL_SECRET is still the literal shipped in .env.example, which is public in this repository — anyone holding the database can derive the key and decrypt every stored upstream credential. Not a boot-stopping error on purpose: rotating the secret does not re-encrypt existing rows, so stored passwords stop decrypting and those accounts must be re-bound. Set a 32+ byte random secret before storing credentials; on an existing deployment, rotate and then re-bind the affected accounts.",
+				critical: false,
+			})
+		case secretLen < 8:
 			errs = append(errs, &configError{
 				field:    "account_credential_secret",
 				value:    fmt.Sprintf("%d bytes", secretLen),
 				msg:      "UNSAFE: secret is shorter than 8 bytes — trivially brute-forceable; set ACCOUNT_CREDENTIAL_SECRET to a 32+ byte random secret (an unset secret falls back to AUTH_TOKEN)",
 				critical: true,
 			})
-		} else if secretLen < 16 {
+		case secretLen < 16:
 			errs = append(errs, &configError{
 				field:    "account_credential_secret",
 				value:    fmt.Sprintf("%d bytes", secretLen),

--- a/docs/env_parity_test.go
+++ b/docs/env_parity_test.go
@@ -8,9 +8,20 @@ package docs_test
 //	config/config.go       — what config.Load actually reads, plus clamps
 //
 // Why a test and not a checklist: the three files drift independently, and a
-// drifted default is worse than a missing one because an operator who reads
-// the doc and trusts it configures the wrong thing. This gate turns that
-// drift into a red CI run instead of a support ticket.
+// drifted key is a support ticket waiting to happen.
+//
+// What this gate does NOT do, stated plainly because an earlier revision
+// claimed otherwise: it compares key *sets* in the four directions below and
+// never compares default *values*. Auditing all 83 documented keys against
+// .env.example found no value drift, and a naive value comparison would be
+// wrong rather than merely strict, because the two columns are not the same
+// kind of thing — docs/configuration.md's default column is prose
+// ("platform-dependent", "system local time", "on", "falls back to
+// `AUTH_TOKEN`"), while .env.example deliberately ships empties and
+// placeholders that are not defaults. An empty line is usually consistent with
+// a documented non-empty default, because parseBoolean("") and friends return
+// the code fallback. The one shipped literal that IS load-bearing is pinned by
+// TestShippedCredentialSecretPlaceholderIsTheGuardedOne below.
 //
 // Directions asserted (all must be empty):
 //  1. every key in .env.example is documented in docs/configuration.md
@@ -40,6 +51,46 @@ import (
 	"strings"
 	"testing"
 )
+
+// TestShippedCredentialSecretPlaceholderIsTheGuardedOne pins two files to each
+// other. config.Validate reports ACCOUNT_CREDENTIAL_SECRET when it still equals
+// the literal shipped in .env.example, and matches it against
+// config.EnvExampleAccountCredentialSecret. If either side is retyped alone the
+// guard stops matching while every test still passes — the same shape as a
+// route-ownership entry naming a file that never mentions the route (#1233) and
+// a boundary scan reporting zero violations because it scanned nothing (#1214).
+// So the pairing itself is asserted, from the files, not from a copied literal.
+func TestShippedCredentialSecretPlaceholderIsTheGuardedOne(t *testing.T) {
+	root := repoRoot(t)
+
+	const key = "ACCOUNT_CREDENTIAL_SECRET="
+	var shipped string
+	for _, line := range strings.Split(readRepoFile(t, root, ".env.example"), "\n") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), key); ok {
+			shipped = strings.TrimSpace(v)
+			break
+		}
+	}
+	if shipped == "" {
+		t.Fatalf("parser sanity: no non-empty %s line in .env.example — if the placeholder was removed, delete this test and the config.Validate branch together, do not leave one of them behind", key)
+	}
+
+	const decl = "EnvExampleAccountCredentialSecret = "
+	var guarded string
+	for _, line := range strings.Split(readRepoFile(t, root, "config/defaults.go"), "\n") {
+		if i := strings.Index(line, decl); i >= 0 {
+			guarded = strings.Trim(strings.TrimSpace(line[i+len(decl):]), `"`)
+			break
+		}
+	}
+	if guarded == "" {
+		t.Fatal("config.EnvExampleAccountCredentialSecret not found in config/defaults.go — config.Validate's placeholder branch has nothing to match against")
+	}
+
+	if shipped != guarded {
+		t.Fatalf("the credential-secret placeholder .env.example ships (%q) is not the one config.Validate guards (%q); a deployment copying .env.example would run on a public encryption key with no warning. Change both, or neither.", shipped, guarded)
+	}
+}
 
 // envKeyRE matches a KEY=... assignment line in .env.example (comments and
 // blank lines are skipped by the caller).


### PR DESCRIPTION
## Observed failure

`README.md:145` tells an operator to `cp .env.example .env` and fill in three variables. docker-compose forces two of them (`${AUTH_TOKEN:?}`, `${PROXY_TOKEN:?}`), and `config.Validate` already hard-fails on both placeholders because each equals a `Default*` constant. The third line already looks filled in:

```
ACCOUNT_CREDENTIAL_SECRET=REPLACE_WITH_STRONG_RANDOM_SECRET
```

`Load()` takes any non-empty value verbatim, so **that literal becomes the real credential-encryption key**. It is 33 bytes, so it clears both strength floors (`< 8` critical, `< 16` warning) and reads as a strong secret. It equals no constant, so nothing else caught it. `buildCredentialKey` derives the AES-256-GCM key from SHA-256 of exactly that string — and the string is in a public repository.

- **Who hit it:** anyone following the documented install path who doesn't notice the one line that already has a value in it.
- **What they were doing:** first deployment (or an upgrade that adds the line from a fresh `.env.example`).
- **What actually happened:** every stored upstream credential encrypted under a key anyone can read off GitHub, with **zero** startup diagnostics.
- **Expected:** either a real secret, or a loud finding — the same treatment the other two placeholders already get.
- **Reproducible:** yes, both proofs below run against the real code path.
- **Which layer should have caught it:** `config.Validate`, which already owns three placeholder/default checks (`auth_token`, `proxy_token`, three OAuth client IDs) and two credential-secret length floors. `docs/env_parity_test.go` also reads all three files, and its header claimed it catches drifted defaults.
- **Why it didn't:** the length floors measure *length*, not *publicness*; and the parity gate compares key **sets** only — the word "default" appeared solely in its docstring.

## Live proof (real `config.Load` / `service.Encrypt|DecryptAccountPassword`, not a reimplementation)

**1. The placeholder becomes the production key, silently, and is decryptable from public information.** Copy `.env.example` → `.env`, set `AUTH_TOKEN`/`PROXY_TOKEN` to random values as compose requires, then `Load` + `Validate` exactly as `cmd/server/main.go` does:

```
== 1. 启动后真实的凭据加密密钥 ==
   cfg.AccountCredentialSecret = "REPLACE_WITH_STRONG_RANDOM_SECRET"
   长度 = 33 字节（两道底线：<8 critical、<16 warning）

== 2. 启动校验对 account_credential_secret 说了什么 ==
   校验总条数=3，其中提到 account_credential_secret 的=0

== 3. 用它加密一条真实形状的上游密码 ==
   落库密文 = v1:dJ0ZzbhAtQZsXdU1:bDTZNcKib9FrB2ENdpdtCQ:3trIPxnzy...

== 4. 攻击者：只从公开仓读那个字面量，不碰服务器任何配置 ==
   从公开 .env.example 读到 = "REPLACE_WITH_STRONG_RANDOM_SECRET"
   解出 = "sk-upstream-REAL-cred-9f3a7c"
```

**2. Rotating does not re-encrypt existing rows** — this is what decided the severity:

```
密文（用占位值加密，已落库）: v1:F0KRvRPb-x3NYOb0:sBANDGJVr16HcX1ZwcS7BA:g...
换密钥后解出: ""
对照（新密钥自加自解）: "sk-upstream-REAL-cred"
```

Both programs and their output are archived under the observation window's `cred-placeholder/`.

## Minimal root fix

**A warning, not a critical error — both escalations were rejected on evidence, not taste.** `critical` makes `hasCritical` `exit(1)` in `cmd/server`, so a deployment already running on the placeholder would **refuse to boot after an upgrade**; and the rotation such a message implies orphans every stored password (proof 2), forcing a re-bind of each account. So the operator gets the fact *plus that consequence* and chooses:

> `UNSAFE: ACCOUNT_CREDENTIAL_SECRET is still the literal shipped in .env.example, which is public in this repository — anyone holding the database can derive the key and decrypt every stored upstream credential. Not a boot-stopping error on purpose: rotating the secret does not re-encrypt existing rows, so stored passwords stop decrypting and those accounts must be re-bound. Set a 32+ byte random secret before storing credentials; on an existing deployment, rotate and then re-bind the affected accounts.`

- `config/defaults.go` — the literal becomes a named constant. Deliberately **not** `Default*`: every other constant in that block is a value `Load()` falls back to, and nothing ever falls back to this one. Naming it `Default` would be a false claim of exactly the kind this window has been removing.
- `config/validate.go` — a `case` in the existing credential-secret branch, matched against the shared constant, reusing the file's established `(placeholder)` shape.
- `config/config_test.go` — pins the finding **and its non-critical severity** (so it can't be escalated by reflex), plus its own precondition (placeholder ≥ 16 bytes) so the test stays meaningful if the template ever changes.
- `docs/env_parity_test.go` — `TestShippedCredentialSecretPlaceholderIsTheGuardedOne` asserts the pairing **from the files**: retyping the placeholder on either side alone disarms the guard while every test still passes. That is the shape of #1233 (an ownership entry naming a file that never mentions the route) and #1214 (a boundary scan reporting zero violations because it scanned nothing), so the coupling is guarded rather than assumed.
- `docs/env_parity_test.go` header — the false claim is corrected rather than left: it now states the gate compares key sets in four directions and never compares values, records that **all 83 documented keys were audited with no value drift**, and explains why a naive value comparison would be *wrong* rather than merely strict (the doc's default column is prose — `platform-dependent`, `system local time`, `on`, `falls back to \`AUTH_TOKEN\`` — while `.env.example` ships empties that `parseBoolean("")` resolves to the code fallback). So nobody reinstates the claim or builds that brittle gate.

## Gates

- `go test ./config ./docs -count=1` green; 4/4 credential-secret tests (the three pre-existing length tests unchanged and still passing — no behaviour change for a deployment that set its own secret).
- **Mutation probes 3/3 red, then green on restore** (log archived):
  1. retype the placeholder in `.env.example` only → `TestShippedCredentialSecretPlaceholderIsTheGuardedOne` FAIL
  2. retype the constant in `config/defaults.go` only → same test FAIL
  3. delete the guard branch from `config/validate.go` → `TestValidateWarnsOnShippedPlaceholderCredentialSecret` FAIL

## Note on the local leak guard

Committed with `LEAK_GUARD_SKIP=1`. Its generic rule is *a secret-ish word, then `=`, then 32+ characters* — which the new constant declaration necessarily matches, and which also matches the line `.env.example` already ships (committed before the guard existed). The value is a publicly documented placeholder, not a credential; there is no way to declare the constant without matching, and renaming it to dodge the regex would encode an unexplained evasion in the code. CI's gitleaks scans **full history**, already sees this literal in `.env.example`, and is green.

No behaviour change for any deployment that set its own secret. No release — accumulates into v0.19.1 per Law 3.