### PR TITLE
test(docs): two reconciliation gates could pass without looking at anything

### DIFF
--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -33,6 +33,7 @@ var storefrontMarkdown = map[string]bool{
 func TestPublicMarkdownHygiene(t *testing.T) {
 	root := repoRoot(t)
 	var findings []string
+	scanned := 0
 
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
@@ -52,6 +53,7 @@ func TestPublicMarkdownHygiene(t *testing.T) {
 		if filepath.Ext(path) != ".md" {
 			return nil
 		}
+		scanned++
 
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -80,6 +82,13 @@ func TestPublicMarkdownHygiene(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	// A hygiene gate that scans nothing and reports no violations is not a
+	// lenient gate, it is an absent one: the skip list above or the .md
+	// extension check could each narrow it to silence. Same invariant as
+	// TestPackageBoundaries — see docs/testing.md.
+	if scanned == 0 {
+		t.Fatal("gate would pass vacuously: no markdown files were scanned")
 	}
 	if len(findings) > 0 {
 		t.Fatalf("public Markdown hygiene violations:\n%s", strings.Join(findings, "\n"))
@@ -252,6 +261,7 @@ func TestStorefrontDoesNotLinkInternalDocs(t *testing.T) {
 func TestRelativeMarkdownLinksResolve(t *testing.T) {
 	root := repoRoot(t)
 	var findings []string
+	scanned, linksChecked := 0, 0
 
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
@@ -268,6 +278,7 @@ func TestRelativeMarkdownLinksResolve(t *testing.T) {
 		if filepath.Ext(path) != ".md" {
 			return nil
 		}
+		scanned++
 
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -289,6 +300,7 @@ func TestRelativeMarkdownLinksResolve(t *testing.T) {
 				if isExternalLinkTarget(target) {
 					continue
 				}
+				linksChecked++
 				resolved := filepath.Join(root, filepath.FromSlash(resolveLinkTarget(root, rel, target)))
 				if _, err := os.Stat(resolved); err != nil {
 					findings = append(findings, formatFinding(rel, i+1, "dead relative link -> "+target, line))
@@ -299,6 +311,16 @@ func TestRelativeMarkdownLinksResolve(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	// Two counters, not one: scanning files but examining no links is the
+	// failure mode of a regex or an exclusion predicate that quietly changed
+	// shape, which is how an ownership entry ends up naming a file that never
+	// mentions the thing it owns (#1233). See docs/testing.md.
+	if scanned == 0 {
+		t.Fatal("gate would pass vacuously: no markdown files were scanned")
+	}
+	if linksChecked == 0 {
+		t.Fatal("gate would pass vacuously: no relative markdown links were examined — markdownLinkRE or isExternalLinkTarget changed shape")
 	}
 	if len(findings) > 0 {
 		t.Fatalf("dead markdown links:\n%s", strings.Join(findings, "\n"))

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,6 +66,41 @@ while executing zero tests, from v0.14.0 through v0.17.0. `test-pg` (which
 runs `go test ./...` unsharded) was the only job actually executing the Go
 suite in that window, and it does not pass `-race`.
 
+## Gate anti-vacuity
+
+A gate that reconciles two artifacts — docs against registered routes,
+`.env.example` against `docs/configuration.md`, one package's imports against
+the allowed edges, a schema registry against the DDL — reports "no violations"
+in two very different situations: the artifacts agree, **or it looked at
+nothing**. The second is not a lenient gate, it is an absent one, and it is the
+shape that let roughly thirty release tags go green while their required test
+shards ran zero tests (#1175), and that let 33 of 42 route-ownership entries
+name a file which never mentioned the route (#1233).
+
+So every reconciliation gate asserts its own input was non-empty before its
+result is trusted, and the assertion is paired with a mutation probe: break the
+thing the gate claims to catch, watch it go red, restore, watch it go green. A
+gate added without both is incomplete work, not a smaller diff.
+
+Two shapes are in use; copy whichever fits.
+
+- **Count the input.** Assert a non-zero scanned-file count per domain, as
+  `TestPackageBoundaries` does for each of its boundary groups, rather than a
+  single total — a total hides one domain going silent.
+- **Feed it a known violation.** Assert the comparator detects deliberately
+  broken samples, as `TestEnvParityGateIsNotAVacuousPass` and the `*RegexpSanity`
+  / `*MatcherSanity` tests do. This is the stronger of the two: it also catches
+  a parser or predicate that changed shape and now matches nothing.
+
+The census is deliberately not written down here, because a hand-copied list of
+gates drifts the same way a hand-copied table list does (#1165, #1172). Run
+`grep -rlni vacuous --include="*_test.go" .` for the gates that currently
+implement it (case-insensitive: half of them carry it in a test name spelled
+`...IsNotAVacuousPass`, which a case-sensitive grep silently drops — 9 files
+instead of 10). A gate that reads two or three *named* files needs no counter —
+failing to read them is already fatal, as in
+`TestStorefrontDoesNotLinkInternalDocs`.
+
 ## Golden snapshot suites (protocol conversion)
 
 Multi-protocol conversion is the most regression-prone surface of the proxy, so


### PR DESCRIPTION
## Observed failure

`TestPublicMarkdownHygiene` and `TestRelativeMarkdownLinksResolve` both ended with the same two lines: *fail if there are findings*. A gate shaped like that reports "clean" in two very different situations — the artifacts agree, **or it examined nothing** — and nothing distinguished them.

Each walks the tree behind an explicit skip list and a `.md` extension filter, so broadening either narrows the gate to silence while CI stays green. The links gate has a second such surface: `markdownLinkRE` and `isExternalLinkTarget` decide what counts as a link, and a predicate that quietly changes shape leaves the walk intact while examining zero links.

**Proven, both directions** (harness + log archived in the observation window):

| mutation | pre-fix | post-fix |
|---|---|---|
| extension filter narrowed to `.markdown` (scan surface → 0) | `TestPublicMarkdownHygiene` **PASS** | **FAIL** |
| same | `TestRelativeMarkdownLinksResolve` **PASS** | **FAIL** |
| `isExternalLinkTarget` forced true (links examined → 0) | `TestRelativeMarkdownLinksResolve` **PASS** | **FAIL** |

6/6 probes behave as claimed; suite green on restore.

## Why this is not a speculative gate

This is the shape behind the worst incident in this repository's history: a shard-arithmetic typo inside an `if (( ))` condition — which `set -e` does not abort on — so four required shards selected zero packages and roughly thirty release tags went green having run zero tests (#1175). The same shape let 33 of 42 route-ownership entries name a file that never mentioned the route (#1233), and let `docs/env_parity_test.go` claim in its header that it turns drifted defaults into a red CI run while the word "default" appeared only in that comment (#1237).

The defence was already implemented in **18 places across 10 files** — `TestPackageBoundaries` counts scanned files per boundary group; `TestEnvParityGateIsNotAVacuousPass`, `TestRouteInventoryGateIsNotAVacuousPass` and the `*RegexpSanity` / `*MatcherSanity` tests feed known-violation samples through the real comparators. It simply had **no written owner**, which is the most likely reason these two siblings in the same package never got one.

## Changes

- **`docs/doc_hygiene_test.go`** — both gates assert their input was non-empty, using the stronger shape where it applies: the links gate counts relative links *examined*, not just files walked, because scanning files while examining no links is exactly a predicate that changed shape.
- **`docs/testing.md`** — the missing owner section: the rule, both shapes, which is stronger and why, and the two canonical implementations to copy.
- It deliberately does **not** enumerate the implementing gates. A hand-copied census drifts the way hand-copied table lists did here: #1165 shipped a factory-reset list nine tables short of the schema (including `admin_sessions`, so pre-reset admin cookies kept write access to an empty database), and #1172 shipped a dialect-copy list that moved 20 of 37 tables while every checksum matched. It points at a grep instead, so the census is derived.
- **That pointer was then executed verbatim rather than assumed, and it was wrong.** `grep -rn vacuous` misses every gate carrying the word in a test name spelled `...IsNotAVacuousPass`, returning 9 files instead of 10 and dropping `docs/api_inventory_parity_test.go` entirely. The documented command is case-insensitive now; re-running it lists exactly the 10 files claimed. A section about claims matching reality should not itself ship a claim that does not.
- **`TestStorefrontDoesNotLinkInternalDocs` left alone on purpose**: it reads two named files and already fails fatally if either is missing, so it cannot pass vacuously. Recorded in the new section so the next reader does not "fix" it.

## Process note (recorded, because it produced false results here)

The first probe harness restored the file with `git checkout --` *inside* each probe, which resets to `HEAD` — so after the first iteration the "pre-fix" block was silently testing post-fix code and reported two false reds. Before/after probes must re-materialise the target version (`git show <rev>:<path> > <path>`) before every run. This is a sibling of the existing lesson "commit before probing, because `git checkout --` destroys uncommitted work"; the new variant is that it also **swaps which version is under test**.

Tests and docs only: no production code, no behaviour change. No release — accumulates into v0.19.1 per Law 3.