### PR TITLE
chore(web): 41 of the 180 API-client methods had no caller, and no gate could see them

### DIFF
--- a/web/src/features/token-routes/types.ts
+++ b/web/src/features/token-routes/types.ts
@@ -17,6 +17,9 @@
 // in `@/lib/helpers/zeroChannelRoutes`) reuse `RouteSummaryRow` with
 // `kind: 'zero_channel'` and a stable negative id.
 
+// Channel-level strategy for OAuth route units: declared once, in the wire
+// contract. This file used to carry a second copy of the same union.
+import type { OAuthRouteUnitStrategy } from '@/lib/api/types'
 import type {
   RouteDecision,
   RouteMode,
@@ -30,10 +33,6 @@ export type {
   RouteRoutingStrategy,
   RouteSummaryRow,
 } from '@/lib/helpers/token-route-contract'
-
-// Channel-level strategy for OAuth route units (re-exported for the detail
-// sheet; the canonical `OAuthRouteUnitStrategy` also lives in `@/lib/api`).
-type OAuthRouteUnitStrategy = 'round_robin' | 'stick_until_unavailable'
 
 // ---------------------------------------------------------------------------
 // Route channel — the per-route account+token binding (detail view + form)

--- a/web/src/lib/api/accounts.ts
+++ b/web/src/lib/api/accounts.ts
@@ -1,14 +1,6 @@
 import { request, buildQueryString } from './transport'
 
 export const accountsApi = {
-  // Accounts
-  getAccounts: async (params?: { includeOauth?: boolean }) => {
-    const result = await request<{ accounts?: unknown[] } | unknown[]>(
-      `/api/accounts${buildQueryString(params)}`
-    )
-    const accounts = Array.isArray(result) ? result : result?.accounts
-    return Array.isArray(accounts) ? accounts : result
-  },
   getAccountsSnapshot: (options?: { refresh?: boolean }) =>
     request(
       `/api/accounts${buildQueryString(options?.refresh ? { refresh: 1 } : undefined)}`
@@ -69,19 +61,6 @@ export const accountsApi = {
       body: JSON.stringify(data),
       skipErrorHandler: options?.skipErrorHandler,
     }),
-  rebindAccountSession: (
-    id: number,
-    data: {
-      accessToken: string
-      platformUserId?: number
-      refreshToken?: string
-      tokenExpiresAt?: number
-    }
-  ) =>
-    request(`/api/accounts/${id}/rebind-session`, {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }),
   updateAccount: (id: number, data: unknown) =>
     request(`/api/accounts/${id}`, {
       method: 'PUT',
@@ -96,16 +75,4 @@ export const accountsApi = {
     }),
   refreshBalance: (id: number) =>
     request(`/api/accounts/${id}/balance`, { method: 'POST' }),
-  getAccountModels: (id: number) => request(`/api/accounts/${id}/models`),
-  addAccountAvailableModels: (accountId: number, models: string[]) =>
-    request(`/api/accounts/${accountId}/models/manual`, {
-      method: 'POST',
-      body: JSON.stringify({ models }),
-    }),
-  refreshAccountHealth: (data?: { accountId?: number; wait?: boolean }) =>
-    request('/api/accounts/health/refresh', {
-      method: 'POST',
-      body: JSON.stringify(data || {}),
-      timeoutMs: data?.wait ? 150_000 : 30_000,
-    }),
 }

--- a/web/src/lib/api/events.ts
+++ b/web/src/lib/api/events.ts
@@ -4,7 +4,6 @@ export const eventsApi = {
   // Events
   getEvents: (params?: string) =>
     request(`/api/events${params ? `?${params}` : ''}`),
-  getEventCount: () => request('/api/events/count'),
   markEventRead: (id: number) =>
     request(`/api/events/${id}/read`, {
       method: 'POST',
@@ -23,9 +22,5 @@ export const eventsApi = {
       // The program-logs section surfaces its own clearFailed toast.
       skipErrorHandler: true,
     }),
-  getTasks: (limit = 50) =>
-    request(
-      `/api/tasks?limit=${Math.max(1, Math.min(200, Math.trunc(limit)))}`
-    ),
   getTask: (id: string) => request(`/api/tasks/${encodeURIComponent(id)}`),
 }

--- a/web/src/lib/api/oauth.ts
+++ b/web/src/lib/api/oauth.ts
@@ -1,14 +1,10 @@
 import { request, buildQueryString } from './transport'
 import type {
   OAuthProvidersResponse,
-  OAuthRouteUnitStrategy,
   OAuthStartResponse,
   OAuthSessionInfo,
   OAuthQuotaInfo,
   OAuthConnectionsResponse,
-  OAuthQuotaBatchRefreshResponse,
-  OAuthImportResponse,
-  OAuthRouteUnitMutationResponse,
 } from './types'
 
 export const oauthApi = {
@@ -55,19 +51,6 @@ export const oauthApi = {
       // The row action surfaces a per-account refreshFailed toast.
       skipErrorHandler: true,
     }) as Promise<{ success: true; quota: OAuthQuotaInfo }>,
-  refreshOAuthConnectionQuotaBatch: (accountIds: number[]) =>
-    request('/api/oauth/connections/quota/refresh-batch', {
-      method: 'POST',
-      body: JSON.stringify({ accountIds }),
-    }) as Promise<OAuthQuotaBatchRefreshResponse>,
-  updateOAuthConnectionProxy: (
-    accountId: number,
-    data: { proxyUrl?: string | null; useSystemProxy?: boolean }
-  ) =>
-    request(`/api/oauth/connections/${accountId}/proxy`, {
-      method: 'PATCH',
-      body: JSON.stringify(data || {}),
-    }) as Promise<{ success: true }>,
   rebindOAuthConnection: (
     accountId: number,
     data?: { proxyUrl?: string | null; useSystemProxy?: boolean }
@@ -80,24 +63,6 @@ export const oauthApi = {
     }) as Promise<OAuthStartResponse>,
   deleteOAuthConnection: (accountId: number) =>
     request(`/api/oauth/connections/${accountId}`, {
-      method: 'DELETE',
-    }) as Promise<{ success: true }>,
-  importOAuthConnections: (data: Record<string, unknown>) =>
-    request('/api/oauth/import', {
-      method: 'POST',
-      body: JSON.stringify(Array.isArray(data.items) ? data : { data }),
-    }) as Promise<OAuthImportResponse>,
-  createOAuthRouteUnit: (data: {
-    accountIds: number[]
-    name: string
-    strategy: OAuthRouteUnitStrategy
-  }) =>
-    request('/api/oauth/route-units', {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }) as Promise<OAuthRouteUnitMutationResponse>,
-  deleteOAuthRouteUnit: (routeUnitId: number) =>
-    request(`/api/oauth/route-units/${routeUnitId}`, {
       method: 'DELETE',
     }) as Promise<{ success: true }>,
 }

--- a/web/src/lib/api/session.ts
+++ b/web/src/lib/api/session.ts
@@ -16,11 +16,6 @@ export interface LoginResponse {
   ttlMinutes: number
 }
 
-export interface WsTicketResponse {
-  ticket: string
-  expiresInSeconds: number
-}
-
 export const sessionApi = {
   /** Exchange the master token for a server-side session cookie. */
   login: (token: string) =>
@@ -46,11 +41,4 @@ export const sessionApi = {
       '/api/auth/session',
       { skipErrorHandler: true, disableDuplicate: true }
     ),
-
-  /** Mint a one-time 60s ticket for the realtime ops WebSocket. */
-  requestWsTicket: () =>
-    request<WsTicketResponse>('/api/auth/ws-ticket', {
-      method: 'POST',
-      skipErrorHandler: true,
-    }),
 }

--- a/web/src/lib/api/settings.ts
+++ b/web/src/lib/api/settings.ts
@@ -3,7 +3,7 @@ import {
   extractResponseErrorMessage,
 } from '@/lib/http-client'
 
-import { request, buildQueryString } from './transport'
+import { request } from './transport'
 import type {
   BackupWebdavExportType,
   BackupWebdavResponse,
@@ -11,7 +11,6 @@ import type {
   RuntimeSettingsPayload,
   SettingsMigrationPreviewResponse,
   SettingsMigrationApplyResponse,
-  DownstreamApiKeyTrendResponse,
 } from './types'
 
 export const settingsApi = {
@@ -106,20 +105,6 @@ export const settingsApi = {
       // The keys section surfaces its own deleteFailed toast.
       skipErrorHandler: true,
     }),
-  batchDownstreamApiKeys: (data: {
-    ids: number[]
-    action: 'enable' | 'disable' | 'delete' | 'resetUsage' | 'updateMetadata'
-    groupOperation?: 'keep' | 'set' | 'clear'
-    groupName?: string
-    tagOperation?: 'keep' | 'append'
-    tags?: string[]
-  }) =>
-    request('/api/downstream-keys/batch', {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }),
-  resetDownstreamApiKeyUsage: (id: number) =>
-    request(`/api/downstream-keys/${id}/reset-usage`, { method: 'POST' }),
   // #1034: key export is a sensitive op; confirmToken carries the master
   // token for X-Admin-Confirm-Token re-confirmation.
   getDownstreamKeyExport: (
@@ -128,32 +113,6 @@ export const settingsApi = {
     confirmToken?: string
   ) =>
     request(`/api/downstream-keys/${id}/export?profile=${profile}`, {
-      headers: confirmToken
-        ? { 'X-Admin-Confirm-Token': confirmToken }
-        : undefined,
-      skipErrorHandler: true,
-    }),
-  getDownstreamApiKeysSummary: (params?: {
-    range?: '24h' | '7d' | 'all'
-    status?: 'all' | 'enabled' | 'disabled'
-    search?: string
-  }) => request(`/api/downstream-keys/summary${buildQueryString(params)}`),
-  getDownstreamApiKeyOverview: (id: number) =>
-    request(`/api/downstream-keys/${id}/overview`),
-  getDownstreamApiKeyTrend: (
-    id: number,
-    params?: { range?: '24h' | '7d' | 'all'; timeZone?: string }
-  ) =>
-    request<DownstreamApiKeyTrendResponse>(
-      `/api/downstream-keys/${id}/trend${buildQueryString(params)}`
-    ),
-  // #1034: backup export is a sensitive op; confirmToken carries the
-  // master token for X-Admin-Confirm-Token re-confirmation.
-  exportBackup: (
-    type: 'all' | 'accounts' | 'preferences' = 'all',
-    confirmToken?: string
-  ) =>
-    request(`/api/settings/backup/export?type=${encodeURIComponent(type)}`, {
       headers: confirmToken
         ? { 'X-Admin-Confirm-Token': confirmToken }
         : undefined,

--- a/web/src/lib/api/stats.ts
+++ b/web/src/lib/api/stats.ts
@@ -8,7 +8,6 @@ import type {
   LatencyTrendResponse,
   VerifyBatchResponse,
   VerifyHistoryResponse,
-  TagIndexResponse,
   Announcement,
   AnnouncementsResponse,
   ModelRedirectsResponse,
@@ -20,8 +19,6 @@ import type {
 } from './types'
 
 export const statsApi = {
-  // Stats
-  getDashboard: () => request('/api/stats/dashboard'),
   getDashboardSnapshot: (options?: { refresh?: boolean }) =>
     request(
       `/api/stats/dashboard${buildQueryString({
@@ -29,17 +26,6 @@ export const statsApi = {
         ...(options?.refresh ? { refresh: 1 } : {}),
       })}`
     ),
-  getDashboardInsights: (options?: { refresh?: boolean }) =>
-    request(
-      `/api/stats/dashboard${buildQueryString({
-        view: 'insights',
-        ...(options?.refresh ? { refresh: 1 } : {}),
-      })}`
-    ),
-  getProxyLogs: (params?: ProxyLogsQuery) =>
-    request(
-      `/api/stats/proxy-logs${buildQueryString(params)}`
-    ) as Promise<ProxyLogsResponse>,
   getProxyLogsQuery: (params?: ProxyLogsQuery) =>
     request(
       `/api/stats/proxy-logs${buildQueryString({ ...params, view: 'query' })}`
@@ -83,8 +69,6 @@ export const statsApi = {
     minLatencyMs?: number
     hours?: number
   }) => request(`/api/stats/slow-requests${buildQueryString(params)}`),
-  checkModels: (accountId: number) =>
-    request(`/api/models/check/${accountId}`, { method: 'POST' }),
   getSiteDistribution: () => request('/api/stats/site-distribution'),
   getSiteTrend: (days = 7) => request(`/api/stats/site-trend?days=${days}`),
   getBalanceHistory: (accountId: number, days = 30) =>
@@ -134,18 +118,6 @@ export const statsApi = {
     request(
       `/api/models/verify-history?limit=${limit}${model ? `&model=${encodeURIComponent(model)}` : ''}`
     ) as Promise<VerifyHistoryResponse>,
-  // I1: accounts/sites global tag system.
-  getTags: () => request('/api/tags') as Promise<TagIndexResponse>,
-  updateAccountTags: (accountId: number, tags: string[]) =>
-    request(`/api/accounts/${accountId}/tags`, {
-      method: 'PUT',
-      body: JSON.stringify({ tags }),
-    }) as Promise<{ success: boolean; tags: string[] }>,
-  updateSiteTags: (siteId: number, tags: string[]) =>
-    request(`/api/sites/${siteId}/tags`, {
-      method: 'PUT',
-      body: JSON.stringify({ tags }),
-    }) as Promise<{ success: boolean; tags: string[] }>,
   // H1: product risk banners.
   getActiveAnnouncements: () =>
     request('/api/announcements/active') as Promise<AnnouncementsResponse>,
@@ -249,30 +221,5 @@ export const statsApi = {
   getSchedulerStatus: () =>
     request<{ items: SchedulerRunStatus[]; generatedAt: string }>(
       '/api/scheduler/status'
-    ),
-  getSiteSnapshot: async (days = 7, options?: { refresh?: boolean }) => {
-    const query = buildQueryString({
-      days,
-      ...(options?.refresh ? { refresh: 1 } : {}),
-    })
-    const [distribution, trend, sites] = await Promise.all([
-      request<{ distribution: unknown[] }>(
-        `/api/stats/site-distribution${query}`
-      ),
-      request<{ trend: unknown[] }>(`/api/stats/site-trend${query}`),
-      request<unknown[]>('/api/sites'),
-    ])
-    return {
-      generatedAt: new Date().toISOString(),
-      distribution: Array.isArray(distribution?.distribution)
-        ? distribution.distribution
-        : [],
-      trend: Array.isArray(trend?.trend) ? trend.trend : [],
-      sites: Array.isArray(sites) ? sites : [],
-    }
-  },
-  getModelBySite: (siteId?: number, days = 7) =>
-    request(
-      `/api/stats/model-by-site?${siteId ? `siteId=${siteId}&` : ''}days=${days}`
     ),
 }

--- a/web/src/lib/api/system.ts
+++ b/web/src/lib/api/system.ts
@@ -9,13 +9,7 @@ export const systemApi = {
   getAbout: () => request<AboutBuildInfoResponse>('/api/about'),
 
   // Monitor embed
-  getMonitorConfig: () => request('/api/monitor/config'),
   getMonitorHealth: () => request('/api/monitor/health'),
-  updateMonitorConfig: (data: { ldohCookie?: string | null }) =>
-    request('/api/monitor/config', {
-      method: 'PUT',
-      body: JSON.stringify(data),
-    }),
   // Clears the HttpOnly `meta_monitor_auth` cookie (Path=/monitor-proxy/);
   // must be called while Bearer auth is still valid.
   clearMonitorSession: () =>

--- a/web/src/lib/api/token-routes.ts
+++ b/web/src/lib/api/token-routes.ts
@@ -28,27 +28,12 @@ export const tokenRoutesApi = {
     }),
   deleteAccountToken: (id: number) =>
     request(`/api/account-tokens/${id}`, { method: 'DELETE' }),
-  batchUpdateAccountTokens: (data: unknown) =>
-    request('/api/account-tokens/batch', {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }),
-  getAccountTokenGroups: (accountId: number) =>
-    request(`/api/account-tokens/groups/${accountId}`),
   setDefaultAccountToken: (id: number) =>
     request(`/api/account-tokens/${id}/default`, { method: 'POST' }),
-  getAccountTokenValue: (id: number) =>
-    request(`/api/account-tokens/${id}/value`),
   syncAccountTokens: (accountId: number) =>
     request(`/api/account-tokens/sync/${accountId}`, {
       method: 'POST',
       timeoutMs: 45_000,
-    }),
-  syncAllAccountTokens: (wait = false) =>
-    request('/api/account-tokens/sync-all', {
-      method: 'POST',
-      body: JSON.stringify(wait ? { wait: true } : {}),
-      timeoutMs: wait ? 150_000 : 30_000,
     }),
 
   // Check-in
@@ -69,8 +54,6 @@ export const tokenRoutesApi = {
   ) => request(`/api/checkin/logs${buildQueryString(params)}`),
 
   // Routes
-  getRoutes: () => request('/api/routes'),
-  getRoutesLite: () => request('/api/routes/lite'),
   getRoutesSummary: () => request('/api/routes/summary'),
   getRouteChannels: (routeId: number) =>
     request(`/api/routes/${routeId}/channels`),
@@ -106,11 +89,6 @@ export const tokenRoutesApi = {
     request(`/api/routes/${id}/cooldown/clear`, { method: 'POST' }),
   batchUpdateRoutes: (data: { ids: number[]; action: 'enable' | 'disable' }) =>
     request('/api/routes/batch', {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }),
-  addChannel: (routeId: number, data: unknown) =>
-    request(`/api/routes/${routeId}/channels`, {
       method: 'POST',
       body: JSON.stringify(data),
     }),
@@ -158,49 +136,5 @@ export const tokenRoutesApi = {
     request('/api/routes/decision/refresh', {
       method: 'POST',
       body: JSON.stringify({}),
-    }),
-  getRouteDecision: (model: string) =>
-    request(`/api/routes/decision?model=${encodeURIComponent(model)}`),
-  getRouteDecisionsBatch: (
-    models: string[],
-    options?: { refreshPricingCatalog?: boolean; persistSnapshots?: boolean }
-  ) =>
-    request('/api/routes/decision/batch', {
-      method: 'POST',
-      body: JSON.stringify({
-        models,
-        ...(options?.refreshPricingCatalog
-          ? { refreshPricingCatalog: true }
-          : {}),
-        ...(options?.persistSnapshots ? { persistSnapshots: true } : {}),
-      }),
-    }),
-  getRouteDecisionsByRouteBatch: (
-    items: Array<{ routeId: number; model: string }>,
-    options?: { refreshPricingCatalog?: boolean; persistSnapshots?: boolean }
-  ) =>
-    request('/api/routes/decision/by-route/batch', {
-      method: 'POST',
-      body: JSON.stringify({
-        items,
-        ...(options?.refreshPricingCatalog
-          ? { refreshPricingCatalog: true }
-          : {}),
-        ...(options?.persistSnapshots ? { persistSnapshots: true } : {}),
-      }),
-    }),
-  getRouteWideDecisionsBatch: (
-    routeIds: number[],
-    options?: { refreshPricingCatalog?: boolean; persistSnapshots?: boolean }
-  ) =>
-    request('/api/routes/decision/route-wide/batch', {
-      method: 'POST',
-      body: JSON.stringify({
-        routeIds,
-        ...(options?.refreshPricingCatalog
-          ? { refreshPricingCatalog: true }
-          : {}),
-        ...(options?.persistSnapshots ? { persistSnapshots: true } : {}),
-      }),
     }),
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -151,16 +151,6 @@ export type VerifyBatchResponse = {
 
 export type VerifyHistoryResponse = { items: ModelVerifyItem[] }
 
-// I1: accounts/sites global tag system.
-type TagIndexItem = {
-  name: string
-  accounts: number
-  sites: number
-  total: number
-}
-
-export type TagIndexResponse = { items: TagIndexItem[] }
-
 // H1: product risk banners.
 export type Announcement = {
   id: number
@@ -620,59 +610,6 @@ export type OAuthConnectionsResponse = {
   total: number
   limit: number
   offset: number
-}
-
-export type OAuthQuotaBatchRefreshResponse = {
-  success: boolean
-  refreshed: number
-  failed: number
-  items: Array<{
-    accountId: number
-    success: boolean
-    quota?: OAuthQuotaInfo
-    error?: string
-  }>
-}
-
-export type OAuthImportResponse = {
-  success: boolean
-  imported: number
-  skipped: number
-  failed: number
-  items: Array<{
-    name: string
-    status: 'imported' | 'skipped' | 'failed'
-    accountId?: number
-    provider?: string
-    message?: string
-  }>
-}
-
-export type OAuthRouteUnitMutationResponse = {
-  success: boolean
-  routeUnit?: OAuthRouteUnitSummary
-}
-
-type DownstreamApiKeyTrendBucket = {
-  startUtc: string | null
-  totalRequests: number
-  successRequests: number
-  failedRequests: number
-  successRate: number | null
-  totalTokens: number
-  totalCost: number
-}
-
-export type DownstreamApiKeyTrendResponse = {
-  success: boolean
-  range: '24h' | '7d' | 'all'
-  item: {
-    id: number
-    name: string
-  }
-  bucketSeconds: number
-  timeZone?: string | null
-  buckets: DownstreamApiKeyTrendBucket[]
 }
 
 /**


### PR DESCRIPTION
## Admission basis (stated plainly, because there is no user failure behind it)

`Observed failure: none.` No user reported anything. This is not a Law 1 bug fix and it does not pretend to be one — it is **reversible subtraction** under the ablation sweep the operator authorised for this window (neat-freak `design-philosophy.md` §0 + §0.1: delete what nothing exercises; git-revertable deletions do not need per-item confirmation). Everything here is code deletion in one layer, recoverable with `git revert`.

The frequency calibration is 0 for all 41 methods: not "rarely called", **never called**, by production code, by tests, by scripts, or by any documentation.

## Observed defect (in the codebase, not in a user's deployment)

`web/src/lib/api.ts` builds the client the entire UI imports by spreading every domain module into one object:

```ts
export const api = { ...sitesApi, ...accountsApi, ...tokenRoutesApi, ...statsApi, /* 13 total */ }
```

knip therefore sees thirteen *used objects* and cannot see which of their **180 methods** anything calls. oxlint and tsgo have no unused-property rule for object literals. So the client surface grew by accretion and nothing could object.

A brace-depth-aware census of every depth-1 key against the TypeScript caller domain:

| | count |
|---|---|
| methods in `web/src/lib/api/*.ts` | **180** |
| live | 139 |
| test-only | **0** |
| no caller anywhere | **41** (242 lines, 8 modules) |

Whole feature areas had been superseded without the old spelling being removed — `getDashboard` / `getDashboardInsights` sitting next to the live `getDashboardSnapshot`, `getRoutes` / `getRoutesLite` next to `getRoutesSummary`, `exportBackup` next to `exportBackupRaw`, `batchDownstreamApiKeys` / `getDownstreamApiKeysSummary` / `…Overview` / `…Trend` / `resetDownstreamApiKeyUsage` next to the key table that actually renders.

**Four of the 41 were the dead half of a wire call that had two owners** — the live half never went through the client at all:

| deleted (dead) | live owner (read, not inferred) |
|---|---|
| `getAccountModels` | `features/accounts/models/api.ts:114` |
| `checkModels` | `features/accounts/models/api.ts:144` |
| `addAccountAvailableModels` | `features/accounts/models/api.ts:184` |
| `requestWsTicket` | `features/dashboard/hooks/realtime-ops-connection.ts:66` (inline `request<{ ticket?: string }>`) |

Those endpoints stay reachable from the UI. What is gone is the second, unused declaration of the same call — the shape this project already decided to eliminate rather than orchestrate.

`rebindAccountSession` also closes an open question that was recorded in the observation window as *"find an owner or delete it"*. This deletes it. If a real user ever reports that a password/session account cannot be re-logged-in, the fix is a product decision about a re-login action (currently the only path is "add account" with the same site + username, which the backend upserts) — not resurrecting an uncalled wrapper.

## Probes (both directions; harness + log archived in the observation window)

A green gate proves nothing unless it can go red, so both halves of the claim above were probed:

| probe | result | what it establishes |
|---|---|---|
| point the real call site `routes/_authenticated/token-routes.tsx:31` at a deleted method (`api.getRoutesSummary()` → `api.getRoutes()`) | typecheck **FAIL** `TS2339: Property 'getRoutes' does not exist` | the green typecheck is *evidence* the 41 were uncalled, not evidence nothing was checking |
| restore one dead method (`getRoutes`) with no caller | typecheck **PASS**, lint **PASS**, knip **PASS** | "no gate could see them" is proved, not asserted — the blind spot is real |
| restore tree from `git show HEAD:<path>`, re-run | typecheck **PASS**, knip **PASS**, `git status` empty | nothing left mutated |

## Changes

- **41 dead methods removed** from `accounts.ts` `events.ts` `oauth.ts` `session.ts` `settings.ts` `stats.ts` `system.ts` `token-routes.ts` (−242 lines). Group headers that belonged to *surviving* members were kept (`// Routes`, `// Monitor embed`).
- **The declarations only they held up went with them**, named by the compiler and knip rather than by eye: 7 dangling imports (4 OAuth response types, `DownstreamApiKeyTrendResponse`, `TagIndexResponse`, and a `buildQueryString` that lost its last caller in `settings.ts`), 6 orphaned wire types + their 2 private helpers (`TagIndexItem`, `DownstreamApiKeyTrendBucket`), and `WsTicketResponse` — whose `expiresInSeconds` nothing has ever read, while the live ticket owner declares the single field it does read.
- **`OAuthRouteUnitStrategy` kept, and a small lie removed.** The type is transitively live (`OAuthRouteUnitSummary` → `OAuthRouteParticipation` → `OAuthConnectionInfo`), but `features/token-routes/types.ts` carried a second copy of the same union under a comment claiming it was *"re-exported for the detail sheet"* and that *"the canonical `OAuthRouteUnitStrategy` also lives in `@/lib/api`"*. Neither half was true — the file re-exported nothing and declared its own. The duplicate is folded into the wire contract: one contract, one owner.

## Deliberately not done

- **Not one backend route was touched.** These endpoints are registered public REST API with consumers outside the SPA (e2e, scripts, third parties). Retiring one is an outward-facing decision, not an ablation, so it is recorded as an operator candidate instead. A "which registered routes have no consumer at all" census needs exact-path matching: a static-prefix substring grep over-counts (`/api/accounts` matches every `/api/accounts/...`) and is not evidence.
- **No new gate.** Per Law 5 a gate needs a failure it would have caught; this cost nothing but a census. The blind spot (spread barrel hides per-method death from knip) is recorded in the observation window as a *gate-coverage candidate*, with the honest note that any such gate would need to re-implement the census rather than configure knip.

## Process note (recorded because it produced confident garbage twice)

Two earlier passes at this census were wrong, and both errors are easy to repeat:

1. **Counting Go homonyms as callers** → reported 36 dead instead of 41. `handler/admin` has its own `getAccountModels`, `service/backup` its own `exportBackup`, the e2e package its own `addChannel`. A TS object-literal method cannot be called from Go, Markdown or shell, so the caller domain must be TypeScript only; hits elsewhere are homonyms and get recorded as evidence, never as proof of life.
2. **A whole-word lookbehind that excluded `.`** → reported 66 dead, including `updateAccount` and `getSites`. Every call site is `api.method`, so excluding the dot hid all of them. **Those numbers are void and must not be cited.**

Dynamic dispatch was ruled out before deleting anything: `api[`, `Object.keys(api)`, `Object.entries(api)` and `keyof typeof api` have zero hits against this object (the only `as keyof` hits in the tree are `components/ui/chart.tsx` and an i18n test). The 41 names appear in no `.md`, `.json`, `.sh`, `.mjs` or `.html` file, so no documentation drifts.

Frontend only: no Go change, no behaviour change. Gates green — `format:check`, `typecheck`, `knip`, `lint` (oxlint + package boundaries, 669 files scanned), **1624 tests / 249 files**, `build:check` (`tsgo -b` + `rsbuild build`). No release — accumulates into v0.19.1 per Law 3.
