### PR TITLE
test(docs): the two PostgreSQL literal gates could pass having scanned nothing

### DIFF
--- a/docs/pg_boolean_gate_test.go
+++ b/docs/pg_boolean_gate_test.go
@@ -91,6 +91,9 @@ func TestPgBooleanLiteralGateNoIntComparison(t *testing.T) {
 	repoRoot := filepath.Dir(filepath.Dir(thisFile)) // docs/ → repo root
 	dirs := []string{"app", "auth", "cmd", "config", "e2e", "handler", "platform", "proxy", "routing", "scheduler", "service", "store", "transform"}
 	var violations []string
+	var scannedFiles, examinedLines int
+	dirsReached := map[string]bool{}
+	saw := map[string]bool{}
 
 	for _, dir := range dirs {
 		root := filepath.Join(repoRoot, dir)
@@ -105,6 +108,14 @@ func TestPgBooleanLiteralGateNoIntComparison(t *testing.T) {
 			if err != nil {
 				return nil
 			}
+			rel, relErr := filepath.Rel(repoRoot, path)
+			if relErr != nil {
+				return nil
+			}
+			scannedFiles++
+			dirsReached[dir] = true
+			saw[rel] = true
+
 			content := string(src)
 			for _, line := range strings.Split(content, "\n") {
 				// Skip comment lines — doc comments may legitimately mention
@@ -113,6 +124,10 @@ func TestPgBooleanLiteralGateNoIntComparison(t *testing.T) {
 				if strings.HasPrefix(trimmed, "//") {
 					continue
 				}
+				if trimmed == "" {
+					continue
+				}
+				examinedLines++
 				for _, m := range coalesceBoolIntRe.FindAllString(line, -1) {
 					violations = append(violations, path+": "+m+
 						" — use COALESCE(<col>, false) = true instead (PG 42804)")
@@ -126,6 +141,31 @@ func TestPgBooleanLiteralGateNoIntComparison(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatalf("walk %s: %v", dir, err)
+		}
+	}
+
+	// A renamed directory (WalkDir on a missing root hands the callback an error,
+	// which the callback swallows), a broadened `_test.go` filter, or a comment
+	// predicate that swallows real code all narrow this gate to silence while it
+	// stays green. Count the input before trusting the verdict — docs/testing.md.
+	if len(dirsReached) != len(dirs) {
+		var missing []string
+		for _, d := range dirs {
+			if !dirsReached[d] {
+				missing = append(missing, d)
+			}
+		}
+		t.Fatalf("walk never reached %s — a renamed or missing directory silently empties this gate", strings.Join(missing, ", "))
+	}
+	if scannedFiles < 100 {
+		t.Fatalf("walk examined %d production .go files; the scan surface is broken, not clean", scannedFiles)
+	}
+	if examinedLines < 10000 {
+		t.Fatalf("examined %d non-comment lines; the comment predicate is swallowing real code, not skipping prose", examinedLines)
+	}
+	for _, probe := range []string{"service/model_redirects.go", "store/setting_store.go"} {
+		if !saw[probe] {
+			t.Fatalf("walk never examined %s; the scan surface is broken", probe)
 		}
 	}
 

--- a/docs/pg_rebind_gate_test.go
+++ b/docs/pg_rebind_gate_test.go
@@ -51,6 +51,9 @@ func TestPgRebindGateNoBareQuestionMarks(t *testing.T) {
 	repoRoot := filepath.Dir(filepath.Dir(thisFile)) // docs/ → repo root
 	dirs := []string{"app", "auth", "cmd", "config", "e2e", "handler", "platform", "proxy", "routing", "scheduler", "service", "store", "transform"}
 	var violations []string
+	var scannedFiles, sqlxFiles int
+	dirsReached := map[string]bool{}
+	saw := map[string]bool{}
 
 	for _, dir := range dirs {
 		root := filepath.Join(repoRoot, dir)
@@ -65,10 +68,18 @@ func TestPgRebindGateNoBareQuestionMarks(t *testing.T) {
 			if err != nil {
 				return nil
 			}
+			rel, relErr := filepath.Rel(repoRoot, path)
+			if relErr != nil {
+				return nil
+			}
+			scannedFiles++
+			dirsReached[dir] = true
 			// Only files that handle a bare *sqlx.DB can hit the wrapper bypass.
 			if !bareSqlxDBRe.Match(src) {
 				return nil
 			}
+			sqlxFiles++
+			saw[rel] = true
 			content := string(src)
 			for _, line := range strings.Split(content, "\n") {
 				for _, re := range []*regexp.Regexp{dbCallRe, ctxDBCallRe} {
@@ -91,6 +102,32 @@ func TestPgRebindGateNoBareQuestionMarks(t *testing.T) {
 		}
 	}
 
+	// Three surfaces can narrow this gate to silence while it stays green: a
+	// renamed directory (WalkDir on a missing root hands the callback an error,
+	// which the callback swallows), a broadened `_test.go` filter, and
+	// bareSqlxDBRe itself, which decides the scan surface. Assert all three
+	// before trusting a clean result — docs/testing.md, "count the input".
+	if len(dirsReached) != len(dirs) {
+		var missing []string
+		for _, d := range dirs {
+			if !dirsReached[d] {
+				missing = append(missing, d)
+			}
+		}
+		t.Fatalf("walk never reached %s — a renamed or missing directory silently empties this gate", strings.Join(missing, ", "))
+	}
+	if scannedFiles < 100 {
+		t.Fatalf("walk examined %d production .go files; the scan surface is broken, not clean", scannedFiles)
+	}
+	if sqlxFiles < 20 {
+		t.Fatalf("%d files matched bareSqlxDBRe; the scan surface is broken, not clean", sqlxFiles)
+	}
+	for _, probe := range []string{"service/model_redirects.go", "store/open.go", "store/factory_reset.go"} {
+		if !saw[probe] {
+			t.Fatalf("scan surface never admitted %s, which handles a bare *sqlx.DB", probe)
+		}
+	}
+
 	if len(violations) > 0 {
 		t.Fatalf(
 			"bare `?` placeholder through *sqlx.DB (PostgreSQL would 42601). "+
@@ -102,7 +139,20 @@ func TestPgRebindGateNoBareQuestionMarks(t *testing.T) {
 
 // TestPgRebindGateRegexpSanity locks the matcher behaviour: a bare call must be
 // flagged, a Rebind-wrapped call must not, and URL query strings must not.
+//
+// It also locks bareSqlxDBRe, which the gate above uses to decide *which files it
+// looks at*. The two violation regexps were already locked; the scan-surface
+// filter was not, so narrowing it emptied the gate while both this test and the
+// gate stayed green — the same split that let two doc gates pass having scanned
+// nothing (#1238).
 func TestPgRebindGateRegexpSanity(t *testing.T) {
+	if !bareSqlxDBRe.MatchString("func (s *Store) expire(db *sqlx.DB, id int64) error {") {
+		t.Fatal("bareSqlxDBRe must match a *sqlx.DB parameter: it decides which files the gate scans")
+	}
+	if bareSqlxDBRe.MatchString("package store\n\nfunc now() time.Time { return time.Now() }\n") {
+		t.Fatal("bareSqlxDBRe matches a file with no database handle; the scan surface is not what the gate claims")
+	}
+
 	bare := `db.Exec("UPDATE accounts SET status = 'expired' WHERE id = ?", 1)`
 	if !dbCallRe.MatchString(bare) {
 		t.Fatalf("regexp must match bare call: %s", bare)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -93,13 +93,31 @@ Two shapes are in use; copy whichever fits.
   a parser or predicate that changed shape and now matches nothing.
 
 The census is deliberately not written down here, because a hand-copied list of
-gates drifts the same way a hand-copied table list does (#1165, #1172). Run
-`grep -rlni vacuous --include="*_test.go" .` for the gates that currently
-implement it (case-insensitive: half of them carry it in a test name spelled
-`...IsNotAVacuousPass`, which a case-sensitive grep silently drops — 9 files
-instead of 10). A gate that reads two or three *named* files needs no counter —
-failing to read them is already fatal, as in
-`TestStorefrontDoesNotLinkInternalDocs`.
+gates drifts the same way a hand-copied table list does (#1165, #1172). Run this
+instead:
+
+```sh
+grep -rlniE 'vacuous|^func Test\w*Sanity' --include='*_test.go' .
+```
+
+Three things about that command, each paid for once already:
+
+- **Both halves are load-bearing.** The convention shows up under two shapes: an
+  inline assertion whose failure message says the gate "would pass vacuously",
+  and a named self-proof test. The version published here first was
+  `grep -rlni vacuous`, which found only the first shape and silently dropped
+  four files — including the two PostgreSQL literal gates in this very directory,
+  whose self-proofs are named `...RegexpSanity`, two paragraphs above being named
+  as implementations of the rule. Dropping the `-i` loses three more, because
+  half the named ones are spelled `...IsNotAVacuousPass`. A section about claims
+  matching reality should not publish a command whose output contradicts it.
+- **What it prints is still a floor.** The `Sanity` half is anchored on a
+  function declaration, so a future `...PredicateSanity` is caught, but an inline
+  counter whose author never wrote the word "vacuous" is invisible to any grep —
+  there is no keyword to find. If you need the real set rather than a floor, read
+  what this prints plus the reconciliation gates in `docs/`.
+- **A gate that reads two or three *named* files needs no counter** — failing to
+  read them is already fatal, as in `TestStorefrontDoesNotLinkInternalDocs`.
 
 ## Golden snapshot suites (protocol conversion)
 


### PR DESCRIPTION
## Observed failure

#1240 (merged an hour ago) found that `docs/env_parity_test.go`'s anti-vacuity self-proof exercised a comparator the real gate never called. That made the rest of the convention worth **checking rather than assuming**, so all eight named self-proofs were audited mechanically: *does the proof touch the same predicate the real gate runs?*

**Seven do.** `api_inventory_parity` shares `compareRouteSets` / `normalizeDocKeys` / `normalizeRoutePath`; both PG `RegexpSanity` tests share the package-level regexps; `internal/httpclient` shares `auditSource`; the three in `store/settings_rehydration_gate_test.go` share their matchers — the repo-write one transitively (the gate calls `settingsGateRepoWriteSites`, which calls the `settingsGatePackageWriteSites` the proof feeds samples to) and that gate additionally asserts `parsedFiles >= 100` plus three named probe files, which is the exemplar this PR copies.

**The two PostgreSQL literal gates in `docs/` are missing the other half of the defence.** Both walk the same 13 hardcoded directories behind a `.go` / `_test.go` filter and both end with:

```go
if len(violations) > 0 { t.Fatalf(...) }
```

So each reports "clean" both when every call site is safe **and when it examined nothing at all**. Three surfaces produce the second case:

| surface | gate | what narrowing it does |
|---|---|---|
| `bareSqlxDBRe` | `pg_rebind` | decides *which files* are looked at; narrow it and all 65 files handling a bare `*sqlx.DB` are skipped |
| comment-skip predicate | `pg_boolean` | decides *which lines* are examined; broaden `HasPrefix(trimmed, "//")` and real code stops being read |
| `dirs` list + `WalkDir` | both | `WalkDir` on a missing root hands the callback an error, and both callbacks swallow errors (`if err != nil \|\| d.IsDir() { return nil }`) — a renamed directory is invisible |

`pg_rebind`'s `RegexpSanity` sibling locked the two **violation** regexps and not the **scan-surface** filter, so the proof stayed green through that one too.

This is the shape #1238 gave a written owner two commits ago — in the same directory as the two gates that never got one — and the shape behind the worst incident here: four required shards selecting zero packages while roughly thirty release tags went green having run zero tests (#1175).

## Probes (harness + log archived in the observation window)

Four mutations, each narrowing one of those surfaces, run against both versions:

| mutation | before (master) | after (this branch) |
|---|---|---|
| M1 narrow `bareSqlxDBRe` | gate **PASS**, sanity **PASS** | gate **FAIL**, sanity **FAIL** |
| M2 rename a walked directory (`pg_rebind`) | gate **PASS** | gate **FAIL** |
| M3 comment predicate swallows real code (`pg_boolean`) | gate **PASS** | gate **FAIL** |
| M4 rename a walked directory (`pg_boolean`) | gate **PASS** | gate **FAIL** |

**8/8 as claimed.** The "before" column is the defect: four ways to empty both gates while CI stays green, one of which also leaves the self-proof green. Baseline with no mutation passes on both versions, so nothing here is a false red. Files re-materialised with `git show <rev>:<path> > <path>` before every run (never `git checkout --`, which restores HEAD and silently swaps the version under test); tree verified clean afterwards, full `./docs` package green on restore.

## Changes

- **Both gates count their input before trusting the verdict** — directories reached must equal directories listed, files walked must clear a floor, and named probe files must have been seen. `pg_boolean` additionally counts **non-comment lines examined**, which is the stronger of the two shapes in `docs/testing.md` for a predicate that swallows contents rather than files: counting files walked would not notice it.
- **Floors set against measured values**, far enough down not to flap and far enough up that "scanned nothing" cannot pass: 13/13 directories, **355** production `.go` files, **65** matching `bareSqlxDBRe`, **73,530** non-comment lines.
- **`bareSqlxDBRe` locked in the sanity test, both directions**: it must match a `*sqlx.DB` parameter (that is the scan surface) and must not match a file with no database handle.
- **`docs/testing.md`'s census command was itself wrong**, which is how these two went unnoticed. `grep -rlni vacuous` prints **10** files; the convention lives in **14**. The four it cannot see are named `...RegexpSanity` / `...MatcherSanity` — two shapes the same document names, two paragraphs earlier, as implementations of the rule. Replaced with a command verified by running it verbatim, and the section now says plainly that the result is **still a floor**: an inline counter whose author never wrote the word "vacuous" has no keyword for any grep to find.

## Process note (it recurred inside the fix for it)

The first replacement command written into `docs/testing.md` was `RegexSanity`, which does not match `RegexpSanity` — it still missed both PG gates. Executing the documented command verbatim instead of reading it is the only thing that caught it. That is the same lesson #1238 recorded about its own pointer, one commit later, in the paragraph replacing it; both are now written down where the next reader will hit them.

Tests and docs only: no production code, no behaviour change. Gates green — `go vet ./docs/...` clean, `go test ./docs/...` ok. No release — accumulates into v0.19.1 per Law 3.
