### PR TITLE
test(docs): the storefront link gate could be emptied by the predicates it shares

### DIFF
--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -227,6 +227,7 @@ func itoa(n int) string {
 func TestStorefrontDoesNotLinkInternalDocs(t *testing.T) {
 	root := repoRoot(t)
 	var findings []string
+	linksChecked := 0
 
 	for name := range storefrontMarkdown {
 		path := filepath.Join(root, name)
@@ -241,6 +242,7 @@ func TestStorefrontDoesNotLinkInternalDocs(t *testing.T) {
 				if isExternalLinkTarget(target) {
 					continue
 				}
+				linksChecked++
 				resolved := resolveLinkTarget(root, name, target)
 				if strings.HasPrefix(resolved, "docs/internal/") {
 					findings = append(findings, formatFinding(name, i+1, "storefront link into docs/internal/", line))
@@ -249,6 +251,16 @@ func TestStorefrontDoesNotLinkInternalDocs(t *testing.T) {
 		}
 	}
 
+	// Reading two named files defends the *input* surface — a missing README is
+	// already fatal above. It says nothing about the *predicate* surface: this
+	// gate shares markdownLinkRE and isExternalLinkTarget with
+	// TestRelativeMarkdownLinksResolve, and narrowing either one empties this
+	// gate while both files still read fine. Probed both ways before adding the
+	// counter; measured 23 + 24 links examined across the two READMEs. Same
+	// reason the sibling counts links rather than files (#1233, #1238).
+	if linksChecked == 0 {
+		t.Fatal("gate would pass vacuously: no storefront links were examined — markdownLinkRE or isExternalLinkTarget changed shape")
+	}
 	if len(findings) > 0 {
 		t.Fatalf("storefront docs must not link maintainer-internal docs:\n%s", strings.Join(findings, "\n"))
 	}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -116,8 +116,14 @@ Three things about that command, each paid for once already:
   counter whose author never wrote the word "vacuous" is invisible to any grep —
   there is no keyword to find. If you need the real set rather than a floor, read
   what this prints plus the reconciliation gates in `docs/`.
-- **A gate that reads two or three *named* files needs no counter** — failing to
-  read them is already fatal, as in `TestStorefrontDoesNotLinkInternalDocs`.
+- **A gate that reads two or three *named* files is defended against a missing
+  input** — failing to read them is already fatal. That defence covers the input
+  surface only. If the gate then filters what it read through a predicate, it
+  still needs the examined-count: `TestStorefrontDoesNotLinkInternalDocs` reads
+  two named READMEs *and* shares `markdownLinkRE` / `isExternalLinkTarget` with
+  its sibling, so narrowing either predicate emptied it while both files kept
+  reading fine. This bullet used to say such a gate "needs no counter", which is
+  how the gap survived the pass that wrote the rule.
 
 ## Golden snapshot suites (protocol conversion)
 


### PR DESCRIPTION
## Observed failure

#1241 finished the two PostgreSQL gates and left an explicit candidate: *how many reconciliation gates have neither defence shape?* This answers it by census rather than by reading, and the census found exactly one gate left — which was not an oversight but a **documented, deliberate exemption that told the next reader not to fix it**.

**Census scope (mechanical, read-only):**

| | count |
|---|---|
| `*_test.go` files in the repo | 483 |
| …that walk a tree or parse an AST | 8 |
| …that already carry a vacuity defence (`vacuous` in a failure message) | 10 |
| union = census scope | **14 files / 15 gate functions** |
| reconciliation-shaped files *outside* that union (reads ≥2 artifacts and compares sets) | **0** |

The union of 14 independently agrees with the census command #1241 corrected in `docs/testing.md` an hour ago — a structural classification and a keyword grep landing on the same set is the cross-check that neither is a mirage. So this was the last gate, not one of many.

**Fourteen of fifteen were defended.** The exception is `TestStorefrontDoesNotLinkInternalDocs`.

## Why the exemption was wrong

#1238 considered this gate and exempted it on purpose. `docs/testing.md` still says:

> A gate that reads two or three *named* files needs no counter — failing to read them is already fatal, as in `TestStorefrontDoesNotLinkInternalDocs`.

and the #1238 commit body adds that this was recorded "so the next reader does not 'fix' it".

The reasoning is right about one surface and silent about the other:

- **Input surface** — it reads `README.md` and `README_EN.md` by name and `t.Fatalf`s on a read error. A missing input *is* already fatal. Correct.
- **Predicate surface** — it then filters what it read through `markdownLinkRE` and `isExternalLinkTarget`, **the same two predicates its sibling `TestRelativeMarkdownLinksResolve` uses**. Narrow either and this gate examines zero links while both files still read fine.

That second surface is precisely why #1238 gave the sibling the stronger defence. Two paragraphs *above* the exemption, the same document says the examined-count shape "also catches a parser or predicate that changed shape and now matches nothing". The document contradicted itself, and the contradiction resolved in favour of leaving the gap open with a note forbidding its closure.

## Probes (harness + log archived in the observation window)

| mutation | before: storefront gate | after: storefront gate | sibling (already had the counter) |
|---|---|---|---|
| baseline, no mutation | PASS | PASS | PASS |
| `isExternalLinkTarget` forced true | **PASS** (silent) | **FAIL** | FAIL |
| `markdownLinkRE` narrowed to absolute URLs | **PASS** (silent) | **FAIL** | FAIL |

**6/6 as claimed.** Two mutations emptied one gate while the gate next to it — sharing both predicates — caught them every time. The counter is not a false-red risk on a clean tree: measured input today is **23 links examined in `README.md` + 24 in `README_EN.md` = 47**, none of them into `docs/internal/`. Versions re-materialised with `git show <rev>:<path> > <path>` before every run (never `git checkout --`); tree verified clean afterwards, full `./docs` package green on restore.

## Changes

- **`docs/doc_hygiene_test.go`** — the gate counts links examined and fails on zero, copying the sibling's idiom verbatim rather than inventing a second one. The comment states both surfaces and the measured number, so the floor is real rather than aspirational.
- **`docs/testing.md`** — the exemption bullet is **corrected, not deleted**, because the distinction is worth keeping: named files do defend the input surface, and a gate that reads three named files and compares them needs nothing more. What the bullet says now is that the defence stops where a predicate starts, with this gate as the worked example.

## Worth naming: the third written adjudication that was itself the wrong thing

- **#1236** — the CHANGELOG's writing contract described *itself* untrue in three places.
- **#1241** — `docs/testing.md` published a census command whose output contradicted the same section (10 files printed, 14 implementing the rule).
- **This** — an exemption that stopped a correction instead of preventing re-litigation.

An adjudication written down to end a question also ends the evidence's ability to reopen it. So it has to state **which surface it covered**. All three now do.

Tests and docs only: no production code, no behaviour change. `gofmt` clean, `go test ./docs/...` ok. No release — accumulates into v0.19.1 per Law 3.
