### PR TITLE
refactor(web): the balance-history response was declared twice, so changing one copy was silent

### DIFF
--- a/web/src/features/dashboard/components/today-snapshot.tsx
+++ b/web/src/features/dashboard/components/today-snapshot.tsx
@@ -26,6 +26,7 @@ import { formatCurrency, formatInt, formatTimeOfDay } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
 import { useRealtimeOps } from '../hooks/use-realtime-ops'
+import type { BalanceHistoryResponse } from '../types'
 
 /** Summary-view dashboard snapshot (GET /api/stats/dashboard?view=summary). */
 type DashboardSnapshot = {
@@ -36,15 +37,6 @@ type DashboardSnapshot = {
     skipped: number
     failed: number
   }
-}
-
-/** Aggregate balance history (GET /api/stats/balance-history?accountId=0). */
-type BalanceHistoryResponse = {
-  series: Array<{
-    accountId: number
-    points: Array<{ day: string; balance: number }>
-  }>
-  days: number
 }
 
 /** Attention response (GET /api/stats/attention?limit=20). */

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -62,6 +62,7 @@ import { AnnouncementBanner } from '../../components/announcement-banner'
 import { OnboardingChecklist } from '../../components/onboarding-checklist'
 import { StatCard } from '../../components/stat-card'
 import { TodaySnapshotStrip } from '../../components/today-snapshot'
+import type { BalanceHistoryResponse } from '../../types'
 
 /** Icon-badge tone for the today-checkin card — derived from the data, so a
  * 0% success day no longer reads as success-green. */
@@ -93,15 +94,6 @@ type DashboardSnapshot = {
     totalCost: number
   }
   performance?: { requestsPerMinute: number; tokensPerMinute: number }
-}
-
-/** Aggregate balance history (GET /api/stats/balance-history?accountId=0). */
-type BalanceHistoryResponse = {
-  series: Array<{
-    accountId: number
-    points: Array<{ day: string; balance: number }>
-  }>
-  days: number
 }
 
 /** Tone + label for a scheduler job last-status value. */

--- a/web/src/features/dashboard/types.ts
+++ b/web/src/features/dashboard/types.ts
@@ -37,10 +37,19 @@ export type DashboardSection = {
 // ---------------------------------------------------------------------------
 // Chart data shapes — contracts for the dashboard chart components. Aligned
 // with the response types of the corresponding api.ts methods
-// (getBalanceIncomeOutcome, getSiteTrend, getSiteDistribution,
-// getModelCostDistribution). Kept minimal so the recharts chart components
+// (getBalanceIncomeOutcome, getBalanceHistory, getSiteTrend,
+// getSiteDistribution, getModelCostDistribution). Kept minimal so the recharts chart components
 // can be wired now and fed real data without reshaping.
 // ---------------------------------------------------------------------------
+
+/** Aggregate balance history (GET /api/stats/balance-history?accountId=0). */
+export type BalanceHistoryResponse = {
+  series: Array<{
+    accountId: number
+    points: Array<{ day: string; balance: number }>
+  }>
+  days: number
+}
 
 /** Long-format row for the income vs outcome grouped bar chart. */
 export type IncomeOutcomePoint = {


### PR DESCRIPTION
## Observed defect

`today-snapshot.tsx` and `sections/overview/overview-section.tsx` both call

```ts
api.getBalanceHistory(0, 8) as Promise<BalanceHistoryResponse>
```

— same endpoint, same arguments, same cast — and **each carried its own byte-identical declaration** of that response, doc comment included. Two owners for one wire contract.

## Probes (harness + log archived in the observation window)

"Two owners" is only a defect if the second one really cannot hear a change, so that was measured rather than asserted. Mutation: `balance: number` → `balance: string` in the response shape. Both components read `.series[].points[].balance`, so both are real consumers.

| | files the compiler flags |
|---|---|
| baseline, no mutation | none (both versions green) |
| **before**: mutate one local copy | `today-snapshot.tsx` **only** — `overview-section.tsx` keeps compiling against a contract that changed |
| **after**: mutate the single owner | `today-snapshot.tsx` **and** `overview-section.tsx` |

The middle row is the whole argument: the silence is not hypothetical, it is what the compiler does today. Versions re-materialised with `git show <rev>:<path> > <path>` before every run; tree verified clean afterwards, typecheck green again.

## Change

The type now lives once in `features/dashboard/types.ts`, next to the other dashboard wire shapes whose section header already claims to be *"aligned with the response types of the corresponding api.ts methods"* — `getBalanceHistory` is added to that list, since the file now actually covers it. Both components import it.

## Census this came out of (recorded so it does not get run again)

Every `type` / `interface` name in `web/src` was collected and checked for declarations in more than one file: **556 distinct names, 13 declared twice, 1 real duplicate.** The other twelve were left alone on purpose:

| verdict | names | why |
|---|---|---|
| **derived, not copied** | `OAuthStartInstructions`, `RouteChannelAccount`, `OAuthQuotaWindow`, `ProxyLogDetail`, `SiteFormValues` | indexed access / `Pick` / `extends` / `z.infer` of a *different* schema — one owner already |
| **narrow local projection** | `DashboardSnapshot`, `AttentionResponse`, `Site` (in `features/accounts`) | each declares only the fields that component reads, and the shapes genuinely differ; same deliberate pattern as the ws-ticket owner found in #1239 |
| **distinct types, generic name** | `ProbeSummary`, `StatusBadgeProps`, `GetTaskResponse`, `AllowlistFormValues` | different components / different tasks / different settings (`adminIpAllowlist` vs `globalAllowedModels`) |

**`Site` was considered for a rename and not done**: `features/accounts` exports a 5-field projection used to parse the site nested inside an account row, while `features/sites` exports the 28-field entity. Two exported types, one name, different widths — a reading hazard. But TypeScript is structural, so importing the wrong one fails at the use site rather than silently; there is no observed incident; and a rename touches ~8 files for a cognitive gain. That is churn without a failure, which is what Law 4 is for.

Type-only: no runtime change, no Go change. Gates green — `format:check`, `typecheck`, `knip`, `lint` (oxlint + package boundaries, 669 files), and the **121 dashboard tests across 21 files**. No release — accumulates into v0.19.1 per Law 3.
