### PR TITLE
fix(platform): a failed upstream call was reported as an empty, zero, or false answer

### DIFF
--- a/platform/antigravity.go
+++ b/platform/antigravity.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -38,7 +39,11 @@ func (a *AntigravityAdapter) GetModels(ctx context.Context, baseURL string, acce
 
 	resp, err := fetchJSON(ctx, normalized+"/v1internal:fetchAvailableModels", "POST", map[string]interface{}{}, headers, proxy)
 	if err != nil {
-		return []string{}, nil
+		// Propagate: service.classifyModelRefreshError turns this into an
+		// actionable reason. Returning an empty list here made an unreachable or
+		// unauthorized upstream indistinguishable from "no models", which is
+		// reported to the operator as empty_models (#1232 family).
+		return nil, fmt.Errorf("fetch available models: %w", err)
 	}
 
 	return extractAntigravityModelNames(resp), nil

--- a/platform/antigravity_test.go
+++ b/platform/antigravity_test.go
@@ -2,6 +2,8 @@ package platform
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -68,6 +70,51 @@ func TestAntigravityAdapter_GetBalanceZero(t *testing.T) {
 	}
 	if bi.Balance != 0 || bi.Used != 0 || bi.Quota != 0 {
 		t.Error("Antigravity balance should be all zeros")
+	}
+}
+
+// TestAntigravityAdapter_GetModels pins both directions of the model-discovery
+// contract. A failed fetch must come back as an error so
+// service.classifyModelRefreshError can name the reason; returning an empty list
+// instead made an unreachable or unauthorized upstream indistinguishable from "no
+// models", which reaches the operator as the single word empty_models (#1232
+// family). An upstream that answers with no models is still a legitimate empty.
+func TestAntigravityAdapter_GetModels(t *testing.T) {
+	a := &AntigravityAdapter{StandardAdapter: NewStandardAdapter("antigravity")}
+	ctx := context.Background()
+
+	models, err := a.GetModels(ctx, unreachableBaseURL(t), "token", nil, nil)
+	if err == nil {
+		t.Error("GetModels must report an unreachable upstream, not an empty model list")
+	}
+	if len(models) != 0 {
+		t.Errorf("expected no models when the fetch failed, got %v", models)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":{"gemini-2.5-pro":{},"claude-sonnet-4":{}}}`))
+	}))
+	defer srv.Close()
+	models, err = a.GetModels(ctx, srv.URL, "token", nil, nil)
+	if err != nil {
+		t.Fatalf("GetModels against an answering upstream: %v", err)
+	}
+	if len(models) != 2 {
+		t.Errorf("expected 2 models, got %v", models)
+	}
+
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":{}}`))
+	}))
+	defer empty.Close()
+	models, err = a.GetModels(ctx, empty.URL, "token", nil, nil)
+	if err != nil {
+		t.Errorf("an answered listing with no models is not an error: %v", err)
+	}
+	if len(models) != 0 {
+		t.Errorf("expected zero models, got %v", models)
 	}
 }
 

--- a/platform/donehub.go
+++ b/platform/donehub.go
@@ -27,7 +27,11 @@ func (d *DoneHubAdapter) GetBalance(ctx context.Context, baseURL, accessToken st
 	headers := authBearerHeaders(accessToken)
 	resp, err := fetchJSON(ctx, baseURL+"/api/user/self", "GET", nil, headers, proxy)
 	if err != nil {
-		return &BalanceInfo{}, nil
+		// Propagate. A zero BalanceInfo with a nil error is stored as the
+		// account's balance, and service/balance drives runtime health, the
+		// token-expired alert and the auto-relogin retry from err != nil — so
+		// swallowing here wrote balance=0 and skipped all three.
+		return nil, fmt.Errorf("fetch balance: %w", err)
 	}
 
 	balance := parseOneApiStyleBalance(resp, 500000, true)

--- a/platform/donehub_test.go
+++ b/platform/donehub_test.go
@@ -61,6 +61,13 @@ func TestDoneHubAdapter_CheckinUnspported(t *testing.T) {
 	}
 }
 
+// TestDoneHubAdapter_BalanceQuotaIsRemaining reads a real one-api-style payload
+// and checks the semantics its name claims: for DoneHub `quota` is the REMAINING
+// allowance and the total is quota+used, at a 500,000 divisor.
+//
+// It used to point GetBalance at an unreachable URL and assert Balance == 0, which
+// passes for any divisor and any formula — it never tested quota-is-remaining, and
+// it pinned the adapter reporting a failed fetch as a legitimate zero balance.
 func TestDoneHubAdapter_BalanceQuotaIsRemaining(t *testing.T) {
 	d := &DoneHubAdapter{
 		OneHubAdapter: &OneHubAdapter{
@@ -70,13 +77,24 @@ func TestDoneHubAdapter_BalanceQuotaIsRemaining(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	// DoneHub balance on unreachable URL returns empty BalanceInfo
-	bi, err := d.GetBalance(ctx, unreachableBaseURL(t), "token", nil, nil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"quota":1000000,"used_quota":250000}}`))
+	}))
+	defer srv.Close()
+
+	bi, err := d.GetBalance(ctx, srv.URL, "token", nil, nil)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("GetBalance against a answering upstream: %v", err)
 	}
-	if bi.Balance != 0 {
-		t.Errorf("Balance on unreachable should be 0, got %f", bi.Balance)
+	if bi == nil {
+		t.Fatal("GetBalance returned nil BalanceInfo with no error")
+	}
+	// quota is remaining: Balance = 1_000_000/500_000 = 2.0
+	// Used = 250_000/500_000 = 0.5 ; Quota(total) = 2.0 + 0.5 = 2.5
+	if bi.Balance != 2.0 || bi.Used != 0.5 || bi.Quota != 2.5 {
+		t.Errorf("balance = (%g, %g, %g), want (2, 0.5, 2.5) for quota-is-remaining at 500k",
+			bi.Balance, bi.Used, bi.Quota)
 	}
 }
 

--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -276,12 +276,16 @@ func (o *OneApiAdapter) GetAPITokens(ctx context.Context, baseURL, accessToken s
 	headers := authBearerHeaders(accessToken)
 	resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, headers, proxy)
 	if err != nil {
-		return []ApiTokenInfo{}, nil
+		// Propagate: an unreachable or unauthorized token listing is not the same
+		// fact as "this account has no tokens". Returning an empty list here made
+		// a failed sync report zero tokens and no error, so the operator saw a
+		// successful sync of nothing.
+		return nil, fmt.Errorf("list upstream tokens: %w", err)
 	}
 
 	items := parseTokenItemsFromMap(resp)
 	if len(items) == 0 {
-		return []ApiTokenInfo{}, nil
+		return []ApiTokenInfo{}, nil // the upstream answered: genuinely no tokens
 	}
 	return normalizeTokenItems(items), nil
 }
@@ -290,7 +294,10 @@ func (o *OneApiAdapter) GetAPITokens(ctx context.Context, baseURL, accessToken s
 func (o *OneApiAdapter) GetAPIToken(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) (*string, error) {
 	tokens, err := o.GetAPITokens(ctx, baseURL, accessToken, platformUserId, proxy)
 	if err != nil {
-		return nil, nil
+		// Propagate: GetAPITokens now distinguishes "the upstream answered with no
+		// tokens" (nil, nil below) from "we could not ask". Returning nil, nil here
+		// re-hid the failure one level up, which is why the empty answer survived.
+		return nil, err
 	}
 	return findFirstEnabledToken(tokens), nil
 }

--- a/platform/oneapi_test.go
+++ b/platform/oneapi_test.go
@@ -2,6 +2,8 @@ package platform
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -39,31 +41,67 @@ func TestOneApiAdapter_DoubleDeleteStrategy(t *testing.T) {
 	}
 }
 
+// answeringTokenServer serves a well-formed one-api token listing with no rows.
+func answeringTokenServer(body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// Both directions are pinned on purpose: "the upstream answered and there are no
+// tokens" is a legitimate empty result, while "we could not ask the upstream" is a
+// failure the caller has to hear about. Asserting only the second is how the first
+// gets reported as a successful sync of nothing.
 func TestOneApiAdapter_GetAPIToken(t *testing.T) {
 	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	tok, err := o.GetAPIToken(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err == nil {
+		t.Error("GetAPIToken must report an unreachable upstream, not a missing token")
 	}
 	if tok != nil {
-		t.Error("GetAPIToken should return nil for unreachable URL")
+		t.Error("GetAPIToken should return no token when the listing failed")
+	}
+
+	srv := answeringTokenServer(`{"success":true,"data":[]}`)
+	defer srv.Close()
+	tok, err = o.GetAPIToken(ctx, srv.URL, "token", nil, nil)
+	if err != nil {
+		t.Errorf("the upstream answered with no tokens; that is not an error: %v", err)
+	}
+	if tok != nil {
+		t.Errorf("expected no token, got %q", *tok)
 	}
 }
 
+// Both directions are pinned on purpose: "the upstream answered and there are no
+// tokens" is a legitimate empty result, while "we could not ask the upstream" is a
+// failure the caller has to hear about. Asserting only the second is how the first
+// gets reported as a successful sync of nothing.
 func TestOneApiAdapter_GetAPITokens(t *testing.T) {
 	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	tokens, err := o.GetAPITokens(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err == nil {
+		t.Error("GetAPITokens must report an unreachable upstream, not an empty token list")
 	}
 	if len(tokens) != 0 {
-		t.Error("GetAPITokens should return empty for unreachable URL")
+		t.Error("GetAPITokens should return no tokens when the listing failed")
+	}
+
+	srv := answeringTokenServer(`{"success":true,"data":[]}`)
+	defer srv.Close()
+	tokens, err = o.GetAPITokens(ctx, srv.URL, "token", nil, nil)
+	if err != nil {
+		t.Errorf("the upstream answered with an empty list; that is not an error: %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Errorf("expected zero tokens, got %d", len(tokens))
 	}
 }
 
@@ -109,13 +147,13 @@ func TestBuildDefaultTokenPayload(t *testing.T) {
 
 	// Custom options
 	opts := &CreateAPITokenOptions{
-		Name:            "custom-key",
-		UnlimitedQuota:  false,
-		RemainQuota:     100.5,
-		ExpiredTime:     1735689600,
-		AllowIPs:        "1.2.3.4",
-		ModelLimits:     "gpt-4:100",
-		Group:           "vip",
+		Name:               "custom-key",
+		UnlimitedQuota:     false,
+		RemainQuota:        100.5,
+		ExpiredTime:        1735689600,
+		AllowIPs:           "1.2.3.4",
+		ModelLimits:        "gpt-4:100",
+		Group:              "vip",
 		ModelLimitsEnabled: true,
 	}
 	p2 := buildDefaultTokenPayload(opts)

--- a/platform/sub2api.go
+++ b/platform/sub2api.go
@@ -233,7 +233,7 @@ func (s *Sub2ApiAdapter) GetModels(ctx context.Context, baseURL, apiToken string
 func (s *Sub2ApiAdapter) GetAPITokens(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) ([]ApiTokenInfo, error) {
 	items, err := s.listAPIKeys(ctx, normalizeBaseURL(baseURL), accessToken, proxy)
 	if err != nil {
-		return []ApiTokenInfo{}, nil
+		return nil, err
 	}
 
 	result := make([]ApiTokenInfo, 0, len(items))
@@ -255,7 +255,10 @@ func (s *Sub2ApiAdapter) GetAPITokens(ctx context.Context, baseURL, accessToken 
 func (s *Sub2ApiAdapter) GetAPIToken(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) (*string, error) {
 	tokens, err := s.GetAPITokens(ctx, baseURL, accessToken, platformUserId, proxy)
 	if err != nil {
-		return nil, nil
+		// Propagate: GetAPITokens now distinguishes "the upstream answered with no
+		// tokens" (nil, nil below) from "we could not ask". Returning nil, nil here
+		// re-hid the failure one level up, which is why the empty answer survived.
+		return nil, err
 	}
 	for _, t := range tokens {
 		if t.Enabled {
@@ -277,7 +280,7 @@ func (s *Sub2ApiAdapter) GetAPIToken(ctx context.Context, baseURL, accessToken s
 func (s *Sub2ApiAdapter) getAPITokenForGroup(ctx context.Context, baseURL, accessToken, group string, platformUserId *int, proxy *ProxyConfig) (*string, error) {
 	tokens, err := s.GetAPITokens(ctx, baseURL, accessToken, platformUserId, proxy)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return pickKeyForGroup(tokens, group), nil
 }
@@ -665,19 +668,31 @@ func (s *Sub2ApiAdapter) listAPIKeys(ctx context.Context, baseURL, accessToken s
 	}
 
 	headers := authBearerHeaders(accessToken)
+	// terminalError mirrors GetUserGroups: the two endpoints exist because sub2api
+	// versions expose different paths, so one failing is expected. Both failing is
+	// a fetch failure, and returning an empty list for it made "cannot reach the
+	// upstream" indistinguishable from "this account has no keys".
+	terminalError := ""
+	answered := false
 	for _, endpoint := range endpoints {
 		resp, err := fetchJSON(ctx, baseURL+endpoint, "GET", nil, headers, proxy)
 		if err != nil {
+			terminalError = err.Error()
 			continue
 		}
 		rawData, err := s.parseSub2ApiEnvelopeRaw(resp, endpoint)
 		if err != nil {
+			terminalError = err.Error()
 			continue
 		}
+		answered = true
 		items := s.parseTokenItems(rawData)
 		if len(items) > 0 {
 			return items, nil
 		}
+	}
+	if !answered && terminalError != "" {
+		return nil, fmt.Errorf("list upstream keys: %s", terminalError)
 	}
 
 	return nil, nil

--- a/platform/sub2api_test.go
+++ b/platform/sub2api_test.go
@@ -361,16 +361,32 @@ func TestSub2ApiAdapter_GetSiteAnnouncements(t *testing.T) {
 	}
 }
 
+// Both directions, because sub2api lists keys from two version-dependent endpoints:
+// one of them failing is expected, both failing is a fetch failure, and both
+// answering with zero keys is a legitimate empty result.
 func TestSub2ApiAdapter_GetAPIToken(t *testing.T) {
 	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
 	ctx := context.Background()
 
 	tok, err := s.GetAPIToken(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err == nil {
+		t.Error("GetAPIToken must report an unreachable upstream, not a missing token")
 	}
 	if tok != nil {
-		t.Error("GetAPIToken on unreachable should return nil")
+		t.Error("GetAPIToken should return no token when the listing failed")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":[]}`))
+	}))
+	defer srv.Close()
+	tok, err = s.GetAPIToken(ctx, srv.URL, "token", nil, nil)
+	if err != nil {
+		t.Errorf("both endpoints answered with no keys; that is not an error: %v", err)
+	}
+	if tok != nil {
+		t.Errorf("expected no token, got %q", *tok)
 	}
 }
 

--- a/platform/veloera.go
+++ b/platform/veloera.go
@@ -69,7 +69,11 @@ func (v *VeloeraAdapter) GetBalance(ctx context.Context, baseURL, accessToken st
 	headers := veloeraHeaders(accessToken, platformUserId)
 	resp, err := fetchJSON(ctx, baseURL+"/api/user/self", "GET", nil, headers, proxy)
 	if err != nil {
-		return &BalanceInfo{}, nil
+		// Propagate. A zero BalanceInfo with a nil error is stored as the
+		// account's balance, and service/balance drives runtime health, the
+		// token-expired alert and the auto-relogin retry from err != nil — so
+		// swallowing here wrote balance=0 and skipped all three.
+		return nil, fmt.Errorf("fetch balance: %w", err)
 	}
 
 	balance := parseOneApiStyleBalance(resp, 1000000, false)

--- a/platform/veloera_test.go
+++ b/platform/veloera_test.go
@@ -2,6 +2,8 @@ package platform
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -82,18 +84,37 @@ func TestVeloeraAdapter_CheckinWithUserID(t *testing.T) {
 	}
 }
 
+// TestVeloeraAdapter_GetBalance_1MDivisor reads a real payload and checks the
+// divisor its name claims: Veloera divides by 1,000,000 (NOT one-api's 500,000)
+// and its `quota` is the TOTAL, so Balance = quota - used.
+//
+// It used to point GetBalance at an unreachable URL and assert Balance == 0, which
+// is what any divisor returns for a failed fetch — the 1M divisor was never
+// exercised here (TestVeloeraAdapter_DivisorIs1M does the arithmetic on literals),
+// and it pinned the adapter reporting a failed fetch as a legitimate zero balance.
 func TestVeloeraAdapter_GetBalance_1MDivisor(t *testing.T) {
 	v := &VeloeraAdapter{BaseAdapter: NewBaseAdapter("veloera")}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	bi, err := v.GetBalance(ctx, unreachableBaseURL(t), "token", nil, nil)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"quota":2000000,"used_quota":500000}}`))
+	}))
+	defer srv.Close()
+
+	bi, err := v.GetBalance(ctx, srv.URL, "token", nil, nil)
 	if err != nil {
-		t.Errorf("GetBalance should not error: %v", err)
+		t.Fatalf("GetBalance against an answering upstream: %v", err)
 	}
-	// Returns empty BalanceInfo on failure
-	if bi.Balance != 0 {
-		t.Errorf("Balance on unreachable should be 0, got %f", bi.Balance)
+	if bi == nil {
+		t.Fatal("GetBalance returned nil BalanceInfo with no error")
+	}
+	// 1M divisor, quota is total: Quota = 2.0, Used = 0.5, Balance = 1.5.
+	// At one-api's 500k these would be 4.0 / 1.0 / 3.0.
+	if bi.Quota != 2.0 || bi.Used != 0.5 || bi.Balance != 1.5 {
+		t.Errorf("balance = (%g, %g, %g), want (1.5, 0.5, 2.0) for a 1M divisor",
+			bi.Balance, bi.Used, bi.Quota)
 	}
 }
 

--- a/service/balance/balance_upstream_failure_test.go
+++ b/service/balance/balance_upstream_failure_test.go
@@ -1,0 +1,88 @@
+package balance
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// TestRefreshBalance_UpstreamFailureIsNotStoredAsZeroBalance covers the two facts
+// an operator depends on when a balance refresh cannot reach the upstream:
+//
+//  1. the stored balance is left alone. A failed fetch used to come back as a zero
+//     BalanceInfo with a nil error, which was then written to accounts.balance /
+//     balance_used / quota — so one unreachable upstream silently reported the
+//     account as having no funds left.
+//  2. the failure is visible. Every recovery path in this package (runtime health,
+//     the token-expired alert, the auto-relogin retry) is driven by err != nil, so
+//     a swallowed fetch error skipped all three and left the account marked healthy.
+//
+// veloera and done-hub are the two adapters that returned the zero value; both are
+// registered platforms reachable from platform.GetAdapter.
+func TestRefreshBalance_UpstreamFailureIsNotStoredAsZeroBalance(t *testing.T) {
+	for _, platformName := range []string{"veloera", "done-hub"} {
+		t.Run(platformName, func(t *testing.T) {
+			db, err := store.Open(store.DialectSQLite, ":memory:", false)
+			if err != nil {
+				t.Fatalf("open sqlite: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			if err := store.AutoMigrate(db); err != nil {
+				t.Fatalf("migrate: %v", err)
+			}
+
+			now := time.Now().UTC().Format(time.RFC3339)
+			siteRes, err := db.Exec(
+				"INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?)",
+				platformName+" unreachable", "http://127.0.0.1:1", platformName, now, now,
+			)
+			if err != nil {
+				t.Fatalf("insert site: %v", err)
+			}
+			siteID, err := siteRes.LastInsertId()
+			if err != nil {
+				t.Fatalf("site LastInsertId: %v", err)
+			}
+
+			// A real stored balance, so "left alone" is distinguishable from "zeroed".
+			accountRes, err := db.Exec(
+				`INSERT INTO accounts (site_id, username, access_token, status, balance, balance_used, quota, checkin_enabled, created_at, updated_at)
+				 VALUES (?, ?, ?, 'active', 5, 1, 10, ?, ?, ?)`,
+				siteID, "balance-owner", "session-token", false, now, now,
+			)
+			if err != nil {
+				t.Fatalf("insert account: %v", err)
+			}
+			accountID, err := accountRes.LastInsertId()
+			if err != nil {
+				t.Fatalf("account LastInsertId: %v", err)
+			}
+
+			if _, err := RefreshBalance(&config.Config{}, db.DB, accountID); err == nil {
+				t.Fatal("RefreshBalance reported success against an unreachable upstream")
+			}
+
+			var balance, used, quota float64
+			if err := db.QueryRow(
+				"SELECT balance, balance_used, quota FROM accounts WHERE id = ?", accountID,
+			).Scan(&balance, &used, &quota); err != nil {
+				t.Fatalf("read stored balance: %v", err)
+			}
+			if balance != 5 || used != 1 || quota != 10 {
+				t.Errorf("stored balance became (%g, %g, %g), want (5, 1, 10) — a failed fetch must not write a zero balance",
+					balance, used, quota)
+			}
+
+			var extra *string
+			if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extra); err != nil {
+				t.Fatalf("read extra_config: %v", err)
+			}
+			if extra == nil || !strings.Contains(*extra, "runtimeHealth") {
+				t.Errorf("no runtime health was recorded for a failed refresh (extra_config=%v)", extra)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Observed failure

Law 6: a fetch failure and a legitimately empty answer must be two different values. Five adapter methods on the read path made them one, and each had a consequence an operator could see.

| method | on fetch failure it returned | what the operator got |
|---|---|---|
| `VeloeraAdapter.GetBalance` | `&BalanceInfo{}, nil` | **a zero balance written over the real one** — `service/balance` stores `balance` / `balance_used` / `quota` from that struct |
| `DoneHubAdapter.GetBalance` | `&BalanceInfo{}, nil` | same |
| `AntigravityAdapter.GetModels` | `[]string{}, nil` | `empty_models` — `classifyModelRefreshError` never ran |
| `OneApiAdapter.GetAPITokens` | `[]ApiTokenInfo{}, nil` | a token sync reporting "0 tokens, nothing to do" |
| `Sub2ApiAdapter.listAPIKeys` | `nil, nil` | same, and `GetAPIToken` / `getAPITokenForGroup` re-hid it with `return nil, nil` |

The balance one is worse than a bad message. Every recovery path in `service/balance` is driven by `err != nil` — the runtime-health marking, the token-expired alert, and the auto-relogin retry built for #1210 — so swallowing the error skipped all three **and** stored `balance = 0`. One unreachable upstream therefore produced an account that looked healthy, had no funds, and never tried to recover.

`empty_models` is the ambiguity #1232 is an open report about on another platform: one phrase covering "the upstream turned off `/v1/models`", "the account really has no models", "the credential has no dashboard" and "the credential is dead".

## Why this survived: the tests pinned it

`TestOneApiAdapter_GetAPITokens`, `TestOneApiAdapter_GetAPIToken` and `TestSub2ApiAdapter_GetAPIToken` each pointed the adapter at an unreachable URL and asserted `err == nil` with an empty result, under the comment *"should be idempotent"*. Idempotence is a statement about a token that is **already absent upstream**; it says nothing about being unable to ask. All three now pin both directions separately.

Two more were vacuous with respect to their own names:

- `TestDoneHubAdapter_BalanceQuotaIsRemaining` — named for the quota-is-remaining semantics, fetched an unreachable URL and asserted `Balance == 0`. Any divisor and any formula satisfy that.
- `TestVeloeraAdapter_GetBalance_1MDivisor` — named for the 1,000,000 divisor, same shape. (Their siblings `_BalanceFormula` / `_DivisorIs1M` do arithmetic on literals, so the divisor was covered — just not by the test named for it.)

Both now read a real payload and assert the numbers their names claim. That rewrite is also what exposed the defect: a zero balance was indistinguishable from a failed fetch precisely because the test could not distinguish them either.

## Probes (harness + log in the observation window)

Only the five production files were swapped back to master; the tests stayed as committed. So "before" is master's adapters judged by these tests.

| test | master's adapters | this branch |
|---|---|---|
| `TestRefreshBalance_UpstreamFailureIsNotStoredAsZeroBalance` (new) | **FAIL** | PASS |
| `TestAntigravityAdapter_GetModels` (new — the method had no test at all) | **FAIL** | PASS |
| `TestOneApiAdapter_GetAPITokens` | **FAIL** | PASS |
| `TestOneApiAdapter_GetAPIToken` | **FAIL** | PASS |
| `TestSub2ApiAdapter_GetAPIToken` | **FAIL** | PASS |
| `TestDoneHubAdapter_BalanceQuotaIsRemaining` | PASS | PASS |
| `TestVeloeraAdapter_GetBalance_1MDivisor` | PASS | PASS |

The last two passing on both is the point: master's arithmetic was already correct, so a formula test could never have caught this. The *failure handling* is pinned by the service-level test, which fails on master on all three of its assertions — refresh reported success, the stored balance was overwritten with zeros, and no runtime health was recorded.

## Changes

- **Five methods propagate** instead of manufacturing an empty answer.
- **`listAPIKeys` needed care, not a blanket propagate**: it tries two endpoints because sub2api versions expose different paths, so one failing is expected. It now tracks a terminal error the way `GetUserGroups` in the same package already does, and reports failure only when **no** endpoint answered. An answered listing with zero keys is still `[]ApiTokenInfo{}, nil` — that is a true statement about the account.
- **New service-level test** owns the user-visible consequence rather than the adapter contract: seed a real stored balance (5 / 1 / 10), point the site at an unreachable URL, assert the refresh fails, the stored balance is **unchanged**, and runtime health was recorded. Both platforms.
- **New `TestAntigravityAdapter_GetModels`** pins all three cases: unreachable, answered with models, answered with none.

## Adjudicated and deliberately not changed

- **`BaseAdapter.GetUserInfo` / `Sub2ApiAdapter.GetUserInfo`** still return `(nil, nil)` on a failed session probe. That nil is the verify ladder's *"not this credential kind"* signal — `BaseAdapter.VerifyToken` continues to the API-key path on it — not a report to an operator. Making it an error would change which credential kinds verify, and no observed failure asks for that.
- **`StandardAdapter.GetBalance`** returns a hardcoded zero **without any fetch**, so it is a capability statement ("this platform has no balance API"), not a swallowed failure. Whether the UI should say "unavailable" instead of "0" is a product decision — recorded as a candidate, not changed here.
- **`Detect` → `false, nil`** is a probe whose safe answer is "not this platform"; the caller tries the others.
- **`Checkin` → `&CheckinResult{Success:false, Message: err.Error()}`** already surfaces the failure in the payload the operator reads.

## Follow-up, deliberately not in this PR

The write path has the same defect and is worse: `OneApiAdapter.DeleteAPIToken` and `Sub2ApiAdapter.DeleteAPIToken` return `nil` when the upstream call fails, so `deleteTokenWithUpstream`'s existing guard (`failed to delete the upstream token`) never fires and **the local row is deleted while the upstream key stays live** — an operator believes a leaked key was revoked. `NewApiAdapter.DeleteAPIToken` already returns an error there, so the semantics currently differ by platform. `OneApiAdapter.CreateAPIToken` returns `false, nil` for a create that never reached the upstream. Both are fixed next, separately, because sub2api's delete depends on the `listAPIKeys` ladder changed here.

Gates: `gofmt` on every touched file, `go build ./...` exit 0, `go vet ./...` clean, `go test ./platform/... ./service/... ./handler/...` green. No release — accumulates into v0.19.1 per Law 3.
