### PR TITLE
fix(platform): the token write path reported a failed upstream call as a completed one

### DIFF
--- a/handler/admin/account_tokens_adapter_test.go
+++ b/handler/admin/account_tokens_adapter_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,19 @@ import (
 
 	"github.com/deliciousbuding/metapi-go/store"
 )
+
+// unreachableUpstreamURL returns a base URL whose port was just closed, so the dial
+// fails immediately instead of blackholing until the handler's 20s budget runs out.
+func unreachableUpstreamURL(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for an unreachable upstream: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return "http://" + addr
+}
 
 // fakeNewAPIUpstream simulates NewAPI token endpoints used by platform.NewApiAdapter.
 type fakeNewAPIUpstream struct {
@@ -257,6 +271,38 @@ func TestTokens_Delete_UpstreamFirst(t *testing.T) {
 	fake.mu.Unlock()
 	if stillThere {
 		t.Fatal("expected upstream token deleted")
+	}
+}
+
+// The user-visible consequence of an adapter reporting a failed upstream write as a
+// completed one: DELETE /api/account-tokens/{id} answered 200 and removed the local
+// row while the upstream key stayed live, so from then on nothing tracked that
+// credential. one-api and sub2api both returned nil for a failed fetch, which is why
+// deleteTokenWithUpstream's guard never fired on those two platforms; new-api already
+// returned an error and is pinned here so the family cannot drift apart again.
+func TestTokens_Delete_UpstreamFailureKeepsLocalRow(t *testing.T) {
+	for _, platformName := range []string{"one-api", "sub2api", "new-api"} {
+		t.Run(platformName, func(t *testing.T) {
+			db, r := setupTokensTest(t)
+			_, accountID := tokenFixtureWithPlatform(t, db, "Unreachable "+platformName, unreachableUpstreamURL(t), platformName)
+			tokID := createTokenFixture(t, db, accountID, "live-key", "sk-live-upstream-key", "default", true, true)
+
+			resp := doDelete(t, r, "/api/account-tokens/"+itoa(tokID))
+			if resp.Code == http.StatusOK {
+				t.Fatalf("delete against an unreachable upstream returned 200: %s", resp.Body.String())
+			}
+			if !strings.Contains(resp.Body.String(), "failed to delete the upstream token") {
+				t.Fatalf("the response should say the upstream delete failed, got %s", resp.Body.String())
+			}
+
+			var count int
+			if err := db.QueryRow("SELECT COUNT(*) FROM account_tokens WHERE id = ?", tokID).Scan(&count); err != nil {
+				t.Fatalf("count token rows: %v", err)
+			}
+			if count != 1 {
+				t.Fatalf("local rows = %d, want 1: the row may only go once the upstream key did", count)
+			}
+		})
 	}
 }
 

--- a/platform/newapi_tokens.go
+++ b/platform/newapi_tokens.go
@@ -165,12 +165,23 @@ func (n *NewApiAdapter) CreateAPIToken(ctx context.Context, baseURL, accessToken
 		resolvedUserID = n.discoverUserID(ctx, baseURL, accessToken, proxy)
 	}
 
+	// `answered` separates "the upstream refused" from "no attempt reached the
+	// upstream". Both end as a 502 in the caller, but only the second one is a
+	// failure to ask, and reporting it as a refusal left the operator with no
+	// reason and no WARN log.
+	answered := false
+	reason := ""
+
 	// Try Bearer auth
 	resp, err := fetchJSON(ctx, baseURL+"/api/token/", "POST", json.RawMessage(bodyBytes), n.authHeaders(accessToken, resolvedUserID), proxy)
-	if err == nil {
+	if err != nil {
+		reason = err.Error()
+	} else {
 		if success, _ := getBool(resp, "success"); success {
 			return true, nil
 		}
+		answered = true
+		reason = newApiRefusalReason(resp)
 	}
 
 	// Cookie fallback
@@ -185,14 +196,30 @@ func (n *NewApiAdapter) CreateAPIToken(ctx context.Context, baseURL, accessToken
 		}
 
 		resp, err := fetchJSON(ctx, baseURL+"/api/token/", "POST", json.RawMessage(bodyBytes), headers, proxy)
-		if err == nil {
-			if success, _ := getBool(resp, "success"); success {
-				return true, nil
-			}
+		if err != nil {
+			reason = err.Error()
+			continue
 		}
+		if success, _ := getBool(resp, "success"); success {
+			return true, nil
+		}
+		answered = true
+		reason = newApiRefusalReason(resp)
 	}
 
-	return false, nil
+	if answered {
+		return false, nil
+	}
+	return false, fmt.Errorf("create upstream token: %s", reason)
+}
+
+// newApiRefusalReason is the upstream's own verdict on a write it answered.
+func newApiRefusalReason(resp map[string]interface{}) string {
+	msg, _ := getString(resp, "message")
+	if strings.TrimSpace(msg) == "" {
+		return "upstream reported failure"
+	}
+	return msg
 }
 
 func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken, tokenKey string, platformUserId *int, proxy *ProxyConfig) error {
@@ -207,10 +234,18 @@ func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 	}
 
 	var tokenID *int
+	// listed separates "we read the listing and this key is not in it" (nothing to
+	// delete) from "we never read a listing" (cannot know). Both used to arrive at
+	// the same `tokenID == nil`, and the caller deletes the local row on nil.
+	listed := false
+	reason := ""
 
 	// Try Bearer auth list
 	resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, n.authHeaders(accessToken, resolvedUserID), proxy)
-	if err == nil {
+	if err != nil {
+		reason = err.Error()
+	} else {
+		listed = true
 		items := parseTokenItemsFromMap(resp)
 		tokenID = pickTokenID(items, targetKey)
 	}
@@ -218,10 +253,12 @@ func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 	if tokenID != nil {
 		// Try Bearer DELETE
 		delResp, err := fetchJSON(ctx, fmt.Sprintf("%s/api/token/%d", baseURL, *tokenID), "DELETE", nil, n.authHeaders(accessToken, resolvedUserID), proxy)
-		if err == nil {
-			if success, _ := getBool(delResp, "success"); success {
-				return nil
-			}
+		if err != nil {
+			reason = err.Error()
+		} else if success, _ := getBool(delResp, "success"); success {
+			return nil
+		} else {
+			reason = newApiRefusalReason(delResp)
 		}
 	}
 
@@ -240,7 +277,10 @@ func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 		// List if not already found
 		if tokenID == nil {
 			resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, headers, proxy)
-			if err == nil {
+			if err != nil {
+				reason = err.Error()
+			} else {
+				listed = true
 				items := parseTokenItemsFromMap(resp)
 				tokenID = pickTokenID(items, targetKey)
 			}
@@ -251,16 +291,22 @@ func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 		}
 
 		delResp, err := fetchJSON(ctx, fmt.Sprintf("%s/api/token/%d", baseURL, *tokenID), "DELETE", nil, headers, proxy)
-		if err == nil {
-			if success, _ := getBool(delResp, "success"); success {
-				return nil
-			}
+		if err != nil {
+			reason = err.Error()
+			continue
 		}
+		if success, _ := getBool(delResp, "success"); success {
+			return nil
+		}
+		reason = newApiRefusalReason(delResp)
 	}
 
-	// Already absent = safe
-	if tokenID == nil {
+	// Already absent upstream, and we know it because a listing answered.
+	if tokenID == nil && listed {
 		return nil
 	}
-	return fmt.Errorf("failed to delete token")
+	if tokenID == nil {
+		return fmt.Errorf("list upstream tokens: %s", reason)
+	}
+	return fmt.Errorf("delete upstream token %d: %s", *tokenID, reason)
 }

--- a/platform/newapi_tokens_test.go
+++ b/platform/newapi_tokens_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -226,6 +227,43 @@ func TestNewApiAdapter_CreateAPIToken_ValidationError(t *testing.T) {
 	}
 	if created {
 		t.Fatal("CreateAPIToken: got created=true, want false")
+	}
+}
+
+// TestNewApiAdapter_CreateAPIToken_Unreachable pins the other half of the create
+// contract: no attempt reached the upstream, so `false, nil` ("the upstream
+// refused") would be a statement about a call that never happened.
+func TestNewApiAdapter_CreateAPIToken_Unreachable(t *testing.T) {
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	created, err := n.CreateAPIToken(ctx, unreachableBaseURL(t), "bearer-token", &uid, &CreateAPITokenOptions{Name: "x"}, nil)
+	if err == nil {
+		t.Fatal("CreateAPIToken must report an unreachable upstream instead of a silent false")
+	}
+	if created {
+		t.Fatal("created = true for an upstream nobody reached")
+	}
+}
+
+// TestNewApiAdapter_DeleteAPIToken_Unreachable pins that "we could not read the
+// listing" is not the same answer as "the listing answered without this key". The
+// caller deletes the local row when this returns nil, so conflating them removed
+// the row while the upstream key stayed live.
+func TestNewApiAdapter_DeleteAPIToken_Unreachable(t *testing.T) {
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := n.DeleteAPIToken(ctx, unreachableBaseURL(t), "bearer-token", "sk-delete-me", &uid, nil)
+	if err == nil {
+		t.Fatal("DeleteAPIToken reported a completed delete for a call that never reached the upstream")
+	}
+	if !strings.Contains(err.Error(), "list upstream tokens") {
+		t.Fatalf("error should say which step failed: %v", err)
 	}
 }
 

--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -349,22 +349,34 @@ func (o *OneApiAdapter) tryGetGroups(ctx context.Context, url string, headers ma
 }
 
 // CreateAPIToken: POST /api/token/ (Bearer auth).
+//
+// A failed fetch is an error, not "not created". The caller answers 502 for both,
+// but only the error path logs the reason and puts it in the response, so
+// `false, nil` here reported "we asked and the upstream said no" for a call that
+// never reached anyone. An answered `success:false` stays (false, nil): that is
+// the upstream's own verdict.
 func (o *OneApiAdapter) CreateAPIToken(ctx context.Context, baseURL, accessToken string, platformUserId *int, options *CreateAPITokenOptions, proxy *ProxyConfig) (bool, error) {
 	payload := buildDefaultTokenPayload(options)
 	headers := authBearerHeaders(accessToken)
 	resp, err := fetchJSON(ctx, baseURL+"/api/token/", "POST", payload, headers, proxy)
 	if err != nil {
-		return false, nil
+		return false, fmt.Errorf("create upstream token: %w", err)
 	}
 	success, _ := getBool(resp, "success")
 	return success, nil
 }
 
 // DeleteAPIToken: list -> find key -> DELETE /api/token/{id} (with trailing-slash fallback).
+//
+// nil means "that key is gone upstream, or was never there". A failed listing and
+// a failed delete are both errors: the caller deletes the local row only when this
+// returns nil, so reporting success for a call that never landed left a live
+// upstream credential with no local row tracking it. NewApiAdapter.DeleteAPIToken
+// in this package already drew that line.
 func (o *OneApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken, tokenKey string, platformUserId *int, proxy *ProxyConfig) error {
 	targetKey := normalizeTokenKeyForCompare(tokenKey)
 	if targetKey == "" {
-		return nil
+		return nil // nothing to match upstream
 	}
 
 	headers := authBearerHeaders(accessToken)
@@ -372,33 +384,36 @@ func (o *OneApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 	// List tokens
 	resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, headers, proxy)
 	if err != nil {
-		return nil
+		return fmt.Errorf("list upstream tokens: %w", err)
 	}
 
 	items := parseTokenItemsFromMap(resp)
 	tokenID := pickTokenID(items, targetKey)
 	if tokenID == nil {
-		return nil // Already absent, safe
+		return nil // already absent upstream: nothing to delete
 	}
 
-	// Try DELETE without trailing slash
-	delResp, err := fetchJSON(ctx, fmt.Sprintf("%s/api/token/%d", baseURL, *tokenID), "DELETE", nil, headers, proxy)
-	if err == nil {
+	// Double-DELETE: OneApi serves this route with and without the trailing slash,
+	// so one of the two failing is expected. Both failing is not.
+	reason := ""
+	for _, url := range []string{
+		fmt.Sprintf("%s/api/token/%d", baseURL, *tokenID),
+		fmt.Sprintf("%s/api/token/%d/", baseURL, *tokenID),
+	} {
+		delResp, err := fetchJSON(ctx, url, "DELETE", nil, headers, proxy)
+		if err != nil {
+			reason = err.Error()
+			continue
+		}
 		if success, _ := getBool(delResp, "success"); success {
 			return nil
 		}
-	}
-
-	// Double-DELETE: trailing slash fallback (OneApi-specific)
-	delResp2, err := fetchJSON(ctx, fmt.Sprintf("%s/api/token/%d/", baseURL, *tokenID), "DELETE", nil, headers, proxy)
-	if err == nil {
-		success, _ := getBool(delResp2, "success")
-		if success {
-			return nil
+		reason, _ = getString(delResp, "message")
+		if strings.TrimSpace(reason) == "" {
+			reason = "upstream reported failure"
 		}
-		_ = success
 	}
-	return nil
+	return fmt.Errorf("delete upstream token %d: %s", *tokenID, reason)
 }
 
 func resolveGroupFetchErrorMessage(payload map[string]interface{}) string {

--- a/platform/oneapi_test.go
+++ b/platform/oneapi_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -23,22 +25,139 @@ func TestOneApiAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestOneApiAdapter_DoubleDeleteStrategy(t *testing.T) {
+// oneApiTokenUpstream serves the /api/token/ listing plus the per-id DELETE route
+// with and without the trailing slash, and records every call it received.
+type oneApiTokenUpstream struct {
+	mu         sync.Mutex
+	listBody   string
+	listStatus int
+	deleteOK   func(id string, trailingSlash bool) bool
+	calls      []string
+}
+
+func (f *oneApiTokenUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	f.calls = append(f.calls, r.Method+" "+r.URL.Path)
+	f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/token"):
+		w.WriteHeader(f.listStatus)
+		_, _ = w.Write([]byte(f.listBody))
+	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/token/"):
+		trimmed := strings.TrimPrefix(r.URL.Path, "/api/token/")
+		trailingSlash := strings.HasSuffix(trimmed, "/")
+		id := strings.TrimSuffix(trimmed, "/")
+		if f.deleteOK != nil && f.deleteOK(id, trailingSlash) {
+			_, _ = w.Write([]byte(`{"success":true}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"success":false,"message":"upstream refused the delete"}`))
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (f *oneApiTokenUpstream) callLog() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+// Both directions on purpose, because the caller deletes the local row only when
+// this returns nil. "The key is already gone upstream" is idempotence; "no request
+// reached the upstream" is a failure that used to be reported as the same nil, so
+// the row disappeared while the upstream key stayed live.
+func TestOneApiAdapter_DeleteAPIToken(t *testing.T) {
 	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// DeleteAPIToken should not error even with unreachable URL (returns nil)
-	err := o.DeleteAPIToken(ctx, unreachableBaseURL(t), "token", "sk-test", nil, nil)
-	if err != nil {
-		t.Errorf("DeleteAPIToken should be idempotent: %v", err)
-	}
+	t.Run("unreachable upstream is a failure, not an idempotent success", func(t *testing.T) {
+		if err := o.DeleteAPIToken(ctx, unreachableBaseURL(t), "token", "sk-test", nil, nil); err == nil {
+			t.Fatal("DeleteAPIToken reported a completed delete for a call that never reached the upstream")
+		}
+	})
 
-	// Empty tokenKey should return nil immediately
-	err = o.DeleteAPIToken(ctx, unreachableBaseURL(t), "token", "", nil, nil)
-	if err != nil {
-		t.Errorf("DeleteAPIToken with empty key: %v", err)
-	}
+	t.Run("empty key needs no upstream call", func(t *testing.T) {
+		f := &oneApiTokenUpstream{listBody: `{"success":true,"data":[]}`, listStatus: http.StatusOK}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		if err := o.DeleteAPIToken(ctx, srv.URL, "token", "", nil, nil); err != nil {
+			t.Fatalf("empty key: %v", err)
+		}
+		if got := f.callLog(); len(got) != 0 {
+			t.Fatalf("empty key made upstream calls: %v", got)
+		}
+	})
+
+	t.Run("key already absent upstream is idempotent", func(t *testing.T) {
+		f := &oneApiTokenUpstream{
+			listBody:   `{"success":true,"data":[{"id":1,"key":"sk-someone-else"}]}`,
+			listStatus: http.StatusOK,
+		}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		if err := o.DeleteAPIToken(ctx, srv.URL, "token", "sk-test", nil, nil); err != nil {
+			t.Fatalf("an answered listing without this key is not an error: %v", err)
+		}
+		if got := f.callLog(); len(got) != 1 {
+			t.Fatalf("expected only the listing call, got %v", got)
+		}
+	})
+
+	t.Run("a listing we could not read is a failure", func(t *testing.T) {
+		f := &oneApiTokenUpstream{
+			listBody:   `{"success":false,"message":"session expired"}`,
+			listStatus: http.StatusInternalServerError,
+		}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		err := o.DeleteAPIToken(ctx, srv.URL, "token", "sk-test", nil, nil)
+		if err == nil {
+			t.Fatal("without a readable listing we cannot know the key is gone")
+		}
+		if !strings.Contains(err.Error(), "list upstream tokens") {
+			t.Fatalf("error should say which step failed: %v", err)
+		}
+	})
+
+	t.Run("trailing-slash variant still completes the delete", func(t *testing.T) {
+		f := &oneApiTokenUpstream{
+			listBody:   `{"success":true,"data":[{"id":9,"key":"sk-test"}]}`,
+			listStatus: http.StatusOK,
+			deleteOK:   func(id string, trailingSlash bool) bool { return id == "9" && trailingSlash },
+		}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		if err := o.DeleteAPIToken(ctx, srv.URL, "token", "sk-test", nil, nil); err != nil {
+			t.Fatalf("double-delete strategy: %v", err)
+		}
+		got := f.callLog()
+		want := []string{"GET /api/token/", "DELETE /api/token/9", "DELETE /api/token/9/"}
+		if strings.Join(got, "|") != strings.Join(want, "|") {
+			t.Fatalf("calls = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("both delete variants refusing is a failure", func(t *testing.T) {
+		f := &oneApiTokenUpstream{
+			listBody:   `{"success":true,"data":[{"id":9,"key":"sk-test"}]}`,
+			listStatus: http.StatusOK,
+			deleteOK:   func(string, bool) bool { return false },
+		}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		err := o.DeleteAPIToken(ctx, srv.URL, "token", "sk-test", nil, nil)
+		if err == nil {
+			t.Fatal("neither DELETE landed, so the upstream key may still be live")
+		}
+		if !strings.Contains(err.Error(), "delete upstream token 9") ||
+			!strings.Contains(err.Error(), "upstream refused the delete") {
+			t.Fatalf("error should name the token and carry the upstream reason: %v", err)
+		}
+	})
 }
 
 // answeringTokenServer serves a well-formed one-api token listing with no rows.
@@ -118,17 +237,37 @@ func TestOneApiAdapter_GetUserGroupsDefault(t *testing.T) {
 	// Either way: error or ["default"] is acceptable
 }
 
+// `false, nil` means "the upstream answered and refused", which is why a failed
+// fetch may not use it: the caller answers 502 either way, but only the error path
+// carries the reason and writes the WARN log.
 func TestOneApiAdapter_CreateAPIToken(t *testing.T) {
 	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	created, err := o.CreateAPIToken(ctx, unreachableBaseURL(t), "token", nil, nil, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err == nil {
+		t.Error("CreateAPIToken must report an unreachable upstream instead of a silent false")
 	}
 	if created {
-		t.Error("CreateAPIToken should return false for unreachable URL")
+		t.Error("nothing was created")
+	}
+
+	srv := answeringTokenServer(`{"success":true,"data":{"id":1,"key":"sk-new"}}`)
+	defer srv.Close()
+	created, err = o.CreateAPIToken(ctx, srv.URL, "token", nil, nil, nil)
+	if err != nil || !created {
+		t.Fatalf("answered success = (%v, %v), want (true, nil)", created, err)
+	}
+
+	refusal := answeringTokenServer(`{"success":false,"message":"quota exceeded"}`)
+	defer refusal.Close()
+	created, err = o.CreateAPIToken(ctx, refusal.URL, "token", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("the upstream's own refusal is an answer, not a fetch failure: %v", err)
+	}
+	if created {
+		t.Fatal("created = true for a refused create")
 	}
 }
 

--- a/platform/sub2api.go
+++ b/platform/sub2api.go
@@ -356,17 +356,25 @@ func (s *Sub2ApiAdapter) CreateAPIToken(ctx context.Context, baseURL, accessToke
 
 	headers := authBearerHeaders(accessToken)
 	endpoints := []string{"/api/v1/keys", "/api/v1/api-keys"}
+	// Two endpoints because sub2api versions expose different paths, so one of them
+	// failing is expected — the same ladder listAPIKeys uses. When neither produced
+	// a key the caller has to hear why: `false, nil` reads as "the upstream refused",
+	// which is a different fact from "no request reached the upstream".
+	lastReason := ""
 	for _, endpoint := range endpoints {
 		resp, err := fetchJSON(ctx, normalized+endpoint, "POST", payload, headers, proxy)
 		if err != nil {
+			lastReason = err.Error()
 			continue
 		}
-		if err := s.parseSub2ApiEnvelope(resp, endpoint); err == nil {
-			return true, nil
+		if err := s.parseSub2ApiEnvelope(resp, endpoint); err != nil {
+			lastReason = err.Error()
+			continue
 		}
+		return true, nil
 	}
 
-	return false, nil
+	return false, fmt.Errorf("create upstream key: %s", lastReason)
 }
 
 // DeleteAPIToken: list -> find key -> DELETE /api/v1/keys/{id} + /api/v1/api-keys/{id}.
@@ -379,7 +387,9 @@ func (s *Sub2ApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToke
 	normalized := normalizeBaseURL(baseURL)
 	items, err := s.listAPIKeys(ctx, normalized, accessToken, proxy)
 	if err != nil {
-		return nil
+		// Cannot know whether the key exists upstream, so cannot claim it is gone.
+		// listAPIKeys already names the operation; wrapping it again stutters.
+		return err
 	}
 
 	var tokenID *int
@@ -392,7 +402,7 @@ func (s *Sub2ApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToke
 	}
 
 	if tokenID == nil {
-		return nil // Already absent, safe
+		return nil // already absent upstream: nothing to delete
 	}
 
 	headers := authBearerHeaders(accessToken)
@@ -400,17 +410,24 @@ func (s *Sub2ApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToke
 		fmt.Sprintf("/api/v1/keys/%d", *tokenID),
 		fmt.Sprintf("/api/v1/api-keys/%d", *tokenID),
 	}
+	// The caller deletes the local row only when this returns nil, so "neither
+	// variant worked" has to be an error: otherwise the row disappears while the
+	// upstream key stays live.
+	lastReason := ""
 	for _, endpoint := range endpoints {
 		resp, err := fetchJSON(ctx, normalized+endpoint, "DELETE", nil, headers, proxy)
 		if err != nil {
+			lastReason = err.Error()
 			continue
 		}
-		if err := s.parseSub2ApiEnvelope(resp, endpoint); err == nil {
-			return nil
+		if err := s.parseSub2ApiEnvelope(resp, endpoint); err != nil {
+			lastReason = err.Error()
+			continue
 		}
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("delete upstream key %d: %s", *tokenID, lastReason)
 }
 
 // GetSiteAnnouncements: GET /api/v1/announcements?page=1&page_size=100.

--- a/platform/sub2api_test.go
+++ b/platform/sub2api_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -319,33 +320,180 @@ func TestSub2ApiAdapter_GetUserGroups(t *testing.T) {
 	}
 }
 
-func TestSub2ApiAdapter_CreateAPIToken(t *testing.T) {
-	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
-	ctx := context.Background()
+// sub2apiKeyUpstream stands in for a sub2api version: `allow` decides which of the
+// two version-dependent endpoint families exists, and every other path 404s the way
+// a version without it would.
+type sub2apiKeyUpstream struct {
+	mu       sync.Mutex
+	allow    func(method, path string) bool
+	listBody string
+	writeOK  bool
+	calls    []string
+}
 
-	created, err := s.CreateAPIToken(ctx, unreachableBaseURL(t), "token", nil, nil, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+func (f *sub2apiKeyUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	f.calls = append(f.calls, r.Method+" "+r.URL.Path)
+	f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	if f.allow == nil || !f.allow(r.Method, r.URL.Path) {
+		http.NotFound(w, r)
+		return
 	}
-	if created {
-		t.Error("CreateAPIToken on unreachable should return false")
+	switch r.Method {
+	case http.MethodGet:
+		_, _ = w.Write([]byte(f.listBody))
+	case http.MethodPost:
+		if f.writeOK {
+			_, _ = w.Write([]byte(`{"code":0,"data":{"id":7,"key":"sk-new"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"code":1,"message":"upstream refused the create"}`))
+	case http.MethodDelete:
+		if f.writeOK {
+			_, _ = w.Write([]byte(`{"code":0,"data":null}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"code":1,"message":"upstream refused the delete"}`))
+	default:
+		http.NotFound(w, r)
 	}
 }
 
+func (f *sub2apiKeyUpstream) callLog() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+// onlyAPIKeys accepts the newer endpoint family and 404s the older one, which is
+// the version skew the two-endpoint ladder exists for.
+func onlyAPIKeys(method, path string) bool { return strings.HasPrefix(path, "/api/v1/api-keys") }
+
+func bothKeyFamilies(method, path string) bool {
+	return strings.HasPrefix(path, "/api/v1/keys") || strings.HasPrefix(path, "/api/v1/api-keys")
+}
+
+// A failed create must not come back as the same `false, nil` the caller reports as
+// "the upstream refused": an unreachable site never refused anything, and the
+// operator is left with a 502 that has no reason attached.
+func TestSub2ApiAdapter_CreateAPIToken(t *testing.T) {
+	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	created, err := s.CreateAPIToken(ctx, unreachableBaseURL(t), "token", nil, nil, nil)
+	if err == nil {
+		t.Error("CreateAPIToken must report an unreachable upstream instead of a silent false")
+	}
+	if created {
+		t.Error("nothing was created")
+	}
+
+	t.Run("the second endpoint family still creates", func(t *testing.T) {
+		f := &sub2apiKeyUpstream{allow: onlyAPIKeys, writeOK: true}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		created, err := s.CreateAPIToken(ctx, srv.URL, "token", nil, nil, nil)
+		if err != nil || !created {
+			t.Fatalf("create = (%v, %v), want (true, nil)", created, err)
+		}
+		got := f.callLog()
+		want := []string{"POST /api/v1/keys", "POST /api/v1/api-keys"}
+		if strings.Join(got, "|") != strings.Join(want, "|") {
+			t.Fatalf("calls = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("an answered refusal carries the upstream reason", func(t *testing.T) {
+		f := &sub2apiKeyUpstream{allow: bothKeyFamilies, writeOK: false}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		created, err := s.CreateAPIToken(ctx, srv.URL, "token", nil, nil, nil)
+		if created {
+			t.Fatal("created = true for a refused create")
+		}
+		if err == nil || !strings.Contains(err.Error(), "upstream refused the create") {
+			t.Fatalf("error should carry the upstream reason, got %v", err)
+		}
+	})
+}
+
+// Both directions on purpose, because the caller deletes the local row only when
+// this returns nil. "Already absent upstream" is idempotence; "no request reached
+// the upstream" is a failure that used to be reported as the same nil.
 func TestSub2ApiAdapter_DeleteAPIToken(t *testing.T) {
 	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	err := s.DeleteAPIToken(ctx, unreachableBaseURL(t), "token", "sk-test", nil, nil)
-	if err != nil {
-		t.Errorf("DeleteAPIToken should be idempotent: %v", err)
+	if err := s.DeleteAPIToken(ctx, unreachableBaseURL(t), "token", "sk-test", nil, nil); err == nil {
+		t.Fatal("DeleteAPIToken reported a completed delete for a call that never reached the upstream")
 	}
 
-	// Empty key
-	err = s.DeleteAPIToken(ctx, unreachableBaseURL(t), "token", "", nil, nil)
-	if err != nil {
-		t.Errorf("DeleteAPIToken with empty key: %v", err)
-	}
+	t.Run("empty key needs no upstream call", func(t *testing.T) {
+		f := &sub2apiKeyUpstream{allow: bothKeyFamilies, listBody: `{"code":0,"data":[]}`}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		if err := s.DeleteAPIToken(ctx, srv.URL, "token", "", nil, nil); err != nil {
+			t.Fatalf("empty key: %v", err)
+		}
+		if got := f.callLog(); len(got) != 0 {
+			t.Fatalf("empty key made upstream calls: %v", got)
+		}
+	})
+
+	t.Run("key already absent upstream is idempotent", func(t *testing.T) {
+		f := &sub2apiKeyUpstream{
+			allow:    onlyAPIKeys,
+			listBody: `{"code":0,"data":[{"id":1,"key":"sk-someone-else"}]}`,
+		}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		if err := s.DeleteAPIToken(ctx, srv.URL, "token", "sk-test", nil, nil); err != nil {
+			t.Fatalf("an answered listing without this key is not an error: %v", err)
+		}
+	})
+
+	t.Run("the second endpoint family still deletes", func(t *testing.T) {
+		f := &sub2apiKeyUpstream{
+			allow:    onlyAPIKeys,
+			listBody: `{"code":0,"data":[{"id":7,"key":"sk-test"}]}`,
+			writeOK:  true,
+		}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		if err := s.DeleteAPIToken(ctx, srv.URL, "token", "sk-test", nil, nil); err != nil {
+			t.Fatalf("delete across the version skew: %v", err)
+		}
+		got := f.callLog()
+		want := []string{
+			"GET /api/v1/keys", "GET /api/v1/api-keys",
+			"DELETE /api/v1/keys/7", "DELETE /api/v1/api-keys/7",
+		}
+		if strings.Join(got, "|") != strings.Join(want, "|") {
+			t.Fatalf("calls = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("both delete variants refusing is a failure", func(t *testing.T) {
+		f := &sub2apiKeyUpstream{
+			allow:    bothKeyFamilies,
+			listBody: `{"code":0,"data":[{"id":7,"key":"sk-test"}]}`,
+			writeOK:  false,
+		}
+		srv := httptest.NewServer(f)
+		defer srv.Close()
+		err := s.DeleteAPIToken(ctx, srv.URL, "token", "sk-test", nil, nil)
+		if err == nil {
+			t.Fatal("neither DELETE landed, so the upstream key may still be live")
+		}
+		if !strings.Contains(err.Error(), "delete upstream key 7") ||
+			!strings.Contains(err.Error(), "upstream refused the delete") {
+			t.Fatalf("error should name the key and carry the upstream reason: %v", err)
+		}
+	})
 }
 
 func TestSub2ApiAdapter_GetSiteAnnouncements(t *testing.T) {


### PR DESCRIPTION
**Observed failure: none.** 没有用户报过这一条。准入依据是 Law 6（取回失败与合法答案必须是两个值）＋ 产出 #1244 的那次普查：同一形状还留在**写路径**上，而写路径的后果比仪表盘上一个错数字更重。

## 用户可见后果

`deleteTokenWithUpstream` 只在 adapter 返回 nil 时删本地行。而 `OneApiAdapter.DeleteAPIToken` 与 `Sub2ApiAdapter.DeleteAPIToken` 在**列不出令牌**或**删除请求没打通**时也返回 nil：

> 一个不可达的上游 ⇒ `DELETE /api/account-tokens/{id}` 回 200、本地行消失、**上游那把 key 仍然活着且可用** ——从此没有任何东西在跟踪这枚凭据，而这一切发生在"用来删凭据的那个页面"上。

`OneApiAdapter.CreateAPIToken` / `Sub2ApiAdapter.CreateAPIToken` 在取回失败时返回 `false, nil`。调用方对 `!created` 本来就回 502，所以没人被告知"创建成功了"；丢掉的是**原因和那条 WARN 日志**（两者都挂在 `createErr != nil` 上）。这是 #1210 的形状：服务端知道为什么，运营只拿到 `upstream reported failure`。

`NewApiAdapter` 本来是仓里"这里要返回 error"的先例，而它自己也是半坏的：只有在**找到了 key 且删除失败**时才报错，列举失败会走到 `tokenID == nil` 然后回 "already absent = safe"。这是 handler 级测试抓出来的——所以那个测试覆盖三个平台，而不只是正在修的两个。

## 划的线（与 #1244 给 `listAPIKeys` 划的同一条）

| 情形 | 返回 |
|---|---|
| tokenKey 为空（无可匹配，且不发任何上游请求） | `nil` |
| 列举**有应答**且里面没有这把 key | `nil`（真的不在了） |
| 上游对一次它应答了的 create 明确拒绝 | `false, nil`（上游自己的裁决） |
| 请求根本没到上游，或到了但读不出来 | **error**，点明是哪一步并带上游原因 |

两端点阶梯（sub2api `/api/v1/keys` + `/api/v1/api-keys`、one-api 的带/不带尾斜杠 DELETE）里**一个变体失败仍然是预期的**，只有"全都没成"才算失败。测试现在也钉住阶梯顺序，免得版本兼容行为跟着这次吞没一起被悄悄删掉。

## 裁决后保留（未改）

`AnyRouterAdapter` 与 `BaseAdapter` 的这两个方法**不发任何请求**就返回 `false, nil` / nil。那是能力声明（"这个平台没有令牌写接口"），不是被吞掉的失败；`TestAnyRouterAdapter_TokenManagementDoesNotCallNewApiEndpoints` 已经把"0 次上游调用"钉住了。

## 测试

**改写的四个正是让这件事活下来的原因**——它们都把 adapter 指向一个不可达 URL 并断言无 error，注释写着 "should be idempotent"：`TestOneApiAdapter_DoubleDeleteStrategy`、`TestOneApiAdapter_CreateAPIToken`、`TestSub2ApiAdapter_DeleteAPIToken`、`TestSub2ApiAdapter_CreateAPIToken`。幂等是对**上游已经不在的 key** 的陈述，对"问不到"什么都没说。四个现在都分别钉住两个方向。

新增：new-api 的不可达 create / delete、sub2api 的"应答拒绝要带上游原因"、以及 `TestTokens_Delete_UpstreamFailureKeepsLocalRow`——它拥有的是用户可见后果而不是 adapter 契约：三个平台各要求非 200、响应里说明是上游删除失败、**且本地行还在**。

## 变异探针（三臂）

只换三个生产文件，测试保持不变；每臂都用 `git show <rev>:<path> > <path>` 重新物化，不用 `git checkout --`。

| | ARM A 三个文件全退回 master | ARM B 全为 HEAD | ARM C 只退回 `newapi_tokens.go` |
|---|---|---|---|
| `TestOneApiAdapter_DeleteAPIToken` | FAIL | PASS | PASS |
| `TestOneApiAdapter_CreateAPIToken` | FAIL | PASS | PASS |
| `TestSub2ApiAdapter_DeleteAPIToken` | FAIL | PASS | PASS |
| `TestSub2ApiAdapter_CreateAPIToken` | FAIL | PASS | PASS |
| `TestNewApiAdapter_CreateAPIToken_Unreachable` | FAIL | PASS | FAIL |
| `TestNewApiAdapter_DeleteAPIToken_Unreachable` | FAIL | PASS | FAIL |
| handler `…KeepsLocalRow/one-api` | FAIL | PASS | PASS |
| handler `…KeepsLocalRow/sub2api` | FAIL | PASS | PASS |
| handler `…KeepsLocalRow/new-api` | FAIL | PASS | **FAIL** |

ARM C 是判别力证明：只弄坏 new-api 时，只有 new-api 那两行红——这个门不是"随便哪个 adapter 坏了都会红"的糊状断言。脚本与日志在观察窗 `law6-census/write-path/`，探针结束后工作树 clean。

## 本地门禁

`go vet ./...` 干净 · `go test ./platform/ ./handler/... ./service/... -count=1` 全绿。

不发版 —— 按 Law 3 累积进 v0.19.1。
