### PR TITLE
fix(platform): one-api was the last adapter storing a zero balance for an upstream it never reached

### DIFF
--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -194,16 +194,29 @@ func (o *OneApiAdapter) Checkin(ctx context.Context, baseURL, accessToken string
 
 // GetBalance: quota=total, balance=quota-used, divisor=500000. Bearer auth
 // first; session-cookie credentials fall back to a Cookie header.
+//
+// A failed fetch is an error, mirroring NewApiAdapter.GetBalance below in this
+// package: service/balance stores whatever struct comes back as the account's
+// balance and drives runtime health, the token-expired alert and the auto-relogin
+// retry from err != nil. Returning a zero BalanceInfo with a nil error therefore
+// wrote balance=0 over the real one and skipped all three. #1244 fixed the same
+// shape in veloera and done-hub; one-api and the one-hub adapter that embeds it
+// were the last two holding it.
 func (o *OneApiAdapter) GetBalance(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) (*BalanceInfo, error) {
 	headers := authBearerHeaders(accessToken)
+	var failureMessage string
+
 	resp, err := fetchJSON(ctx, baseURL+"/api/user/self", "GET", nil, headers, proxy)
-	if err == nil {
+	if err != nil {
+		failureMessage = err.Error()
+	} else {
 		if success, _ := getBool(resp, "success"); success {
 			if data, ok := getMap(resp, "data"); ok {
 				balance := parseOneApiStyleBalance(data, 500000, false)
 				return &balance, nil
 			}
 		}
+		failureMessage = extractResponseMessage(resp)
 	}
 
 	if isCookieCredential(accessToken) {
@@ -214,9 +227,15 @@ func (o *OneApiAdapter) GetBalance(ctx context.Context, baseURL, accessToken str
 				return &balance, nil
 			}
 		}
+		if cookieErr != nil && failureMessage == "" {
+			failureMessage = cookieErr.Error()
+		}
 	}
 
-	return &BalanceInfo{}, nil
+	if failureMessage == "" {
+		failureMessage = "failed to fetch balance"
+	}
+	return nil, fmt.Errorf("%s", failureMessage)
 }
 
 // fetchSelfByCookie fetches /api/user/self with the credential sent as a

--- a/platform/oneapi_test.go
+++ b/platform/oneapi_test.go
@@ -25,6 +25,92 @@ func TestOneApiAdapter_Detect(t *testing.T) {
 	}
 }
 
+// Both directions, because a zero BalanceInfo with a nil error is not a neutral
+// answer: service/balance stores it as the account's balance and every recovery
+// path there hangs off err != nil. Asserting only the happy path is how one-api
+// (and the one-hub adapter that embeds it) kept writing balance=0 for an upstream
+// nobody reached.
+func TestOneApiAdapter_GetBalance(t *testing.T) {
+	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.Run("unreachable upstream is an error, not a zero balance", func(t *testing.T) {
+		bi, err := o.GetBalance(ctx, unreachableBaseURL(t), "token", nil, nil)
+		if err == nil {
+			t.Fatal("GetBalance reported a balance for a call that never reached the upstream")
+		}
+		if bi != nil {
+			t.Errorf("a failed fetch must not hand back a storable zero balance, got %+v", bi)
+		}
+	})
+
+	t.Run("an answered balance keeps the one-api divisor and quota-is-total semantics", func(t *testing.T) {
+		srv := answeringTokenServer(`{"success":true,"data":{"quota":1000000,"used_quota":250000}}`)
+		defer srv.Close()
+		bi, err := o.GetBalance(ctx, srv.URL, "token", nil, nil)
+		if err != nil {
+			t.Fatalf("GetBalance against an answering upstream: %v", err)
+		}
+		if bi == nil {
+			t.Fatal("GetBalance returned no BalanceInfo and no error")
+		}
+		// quota is the total here: Quota = 1_000_000/500_000 = 2.0,
+		// Used = 250_000/500_000 = 0.5, Balance = 2.0 - 0.5 = 1.5
+		if bi.Balance != 1.5 || bi.Used != 0.5 || bi.Quota != 2.0 {
+			t.Errorf("balance = (%g, %g, %g), want (1.5, 0.5, 2) for quota-is-total at 500k",
+				bi.Balance, bi.Used, bi.Quota)
+		}
+	})
+
+	t.Run("an answered zero balance is a real answer, not a failure", func(t *testing.T) {
+		srv := answeringTokenServer(`{"success":true,"data":{"quota":0,"used_quota":0}}`)
+		defer srv.Close()
+		bi, err := o.GetBalance(ctx, srv.URL, "token", nil, nil)
+		if err != nil {
+			t.Fatalf("an account that genuinely has no funds must not be reported as a fetch failure: %v", err)
+		}
+		if bi == nil {
+			t.Fatal("GetBalance returned no BalanceInfo and no error")
+		}
+		if bi.Balance != 0 || bi.Used != 0 || bi.Quota != 0 {
+			t.Errorf("balance = (%g, %g, %g), want (0, 0, 0)", bi.Balance, bi.Used, bi.Quota)
+		}
+	})
+
+	t.Run("an answered refusal carries the upstream reason", func(t *testing.T) {
+		srv := answeringTokenServer(`{"success":false,"message":"session expired"}`)
+		defer srv.Close()
+		bi, err := o.GetBalance(ctx, srv.URL, "token", nil, nil)
+		if err == nil {
+			t.Fatal("an upstream that refused the read must not come back as a balance")
+		}
+		if bi != nil {
+			t.Errorf("refused read returned %+v, want nil", bi)
+		}
+		if !strings.Contains(err.Error(), "session expired") {
+			t.Errorf("error should carry the upstream reason, got %v", err)
+		}
+	})
+}
+
+// one-hub embeds the one-api adapter, so it inherits whichever contract that one
+// has. Pinned separately because "inherits" is exactly the assumption that let the
+// swallow survive a fix to its siblings.
+func TestOneHubAdapter_GetBalancePropagatesUpstreamFailure(t *testing.T) {
+	o := &OneHubAdapter{OneApiAdapter: &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-hub")}}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	bi, err := o.GetBalance(ctx, unreachableBaseURL(t), "token", nil, nil)
+	if err == nil {
+		t.Fatal("one-hub reported a balance for an unreachable upstream")
+	}
+	if bi != nil {
+		t.Errorf("a failed fetch must not hand back a storable zero balance, got %+v", bi)
+	}
+}
+
 // oneApiTokenUpstream serves the /api/token/ listing plus the per-id DELETE route
 // with and without the trailing slash, and records every call it received.
 type oneApiTokenUpstream struct {

--- a/service/balance/balance_upstream_failure_test.go
+++ b/service/balance/balance_upstream_failure_test.go
@@ -20,10 +20,11 @@ import (
 //     the token-expired alert, the auto-relogin retry) is driven by err != nil, so
 //     a swallowed fetch error skipped all three and left the account marked healthy.
 //
-// veloera and done-hub are the two adapters that returned the zero value; both are
-// registered platforms reachable from platform.GetAdapter.
+// veloera and done-hub returned the zero value until #1244; one-api was the last
+// adapter still holding the same shape and one-hub embeds it, so both are pinned
+// here too. All four are registered platforms reachable from platform.GetAdapter.
 func TestRefreshBalance_UpstreamFailureIsNotStoredAsZeroBalance(t *testing.T) {
-	for _, platformName := range []string{"veloera", "done-hub"} {
+	for _, platformName := range []string{"veloera", "done-hub", "one-api", "one-hub"} {
 		t.Run(platformName, func(t *testing.T) {
 			db, err := store.Open(store.DialectSQLite, ":memory:", false)
 			if err != nil {


### PR DESCRIPTION
**Observed failure: none.** 没有用户报过这一条。准入依据是 Law 6 ＋ #1244 之后那次**穷尽普查**：#1244 修掉了 veloera 与 done-hub 的这个形状，而普查显示 one-api 还留着它。

## 普查本身（以及它自己错了两版）

`ast-census`（观察窗内，可重跑）遍历 `platform/` 全部非测试 Go 文件：**247 个函数 → 111 个以 error 结尾 → 67 处「哨兵字面量 + nil error」返回 → 其中 52 处在会发上游请求的函数里**（31 个函数），另 15 处是不发请求的能力声明。

判据是机械的三条同时成立：① 最后一个返回值是 error；② 存在一个 return 的 error 位是字面 `nil`、前面的位是哨兵字面量（`nil` / `false` / `0` / 空复合字面量 / 编造内容的字面量如 `[]string{"default"}`）；③ 该函数会发请求——直接调 fetch helper，或调用同包里某个会发请求的函数（**传递闭包**）。

**前两版普查自己是错的**，错法和本项目反复犯的同一类：

1. 方法调用点只看得到 selector 的方法名，而函数按限定名（`Recv.Method`）索引 ⇒ 所有「方法调方法」的传递链断掉，`sub2api.GetUserGroups` / `GetModels` 被判成「不发请求的能力声明」。
2. 闭包只索引以 error 结尾的函数 ⇒ 调一个**不返 error 的取数 helper**（`listGroups`）的函数同样被误判。

两版都修了，工具留在观察窗（`law6-census/ast-census/`），下一轮不必重造。

## 这次落地的发现：one-api 是最后一个把「没问到」存成「余额 0」的 adapter

`OneApiAdapter.GetBalance` 在 bearer 读取失败且凭据不是 cookie 会话时返回 `&BalanceInfo{}, nil`。于是**站点不可达、凭据过期、上游 `success:false` 三种事实都变成"余额 0 且没有错误"**。而 `service/balance` 是：

- 用返回的 struct 写 `balance` / `balance_used` / `quota`；
- 用 `err != nil` 驱动运行时健康标记、凭据过期告警、自动重登重试。

⇒ 一次失败的刷新**把 0 写进真实余额之上**，同时跳过全部三条恢复路径，账号显示健康、余额为 0。`OneHubAdapter` 内嵌这个 adapter，one-hub 一起继承。

修法**抄同包的 `NewApiAdapter.GetBalance`**（它早就是这个形状），不造新东西：收集原因（fetch error，或对应答了的拒绝用 `extractResponseMessage`），凭据是 cookie 会话时再走 cookie 那一档，没有任何一档拿到余额就 `nil, error`。

**上游答了一个真的 0 余额仍然是真话**，照旧返回零值 + nil error——这条有自己的子测试钉住，因为把"这个账号确实没钱"报成失败，是同一个缺陷换了张脸。

## 测试

- `TestOneApiAdapter_GetBalance`：四个方向全钉（不可达 → error 且不给可存储的零值 · 应答余额 → one-api 的 500k 除数与 quota-is-total 语义 1.5/0.5/2.0 · 应答 0 → 真话 · 应答拒绝 → 带上游原因）。
- `TestOneHubAdapter_GetBalancePropagatesUpstreamFailure`：内嵌 adapter 单独钉——**"它会继承修复"正是让这个漏网活过兄弟修复的那个假设**。
- `TestRefreshBalance_UpstreamFailureIsNotStoredAsZeroBalance`（#1244 建的服务级门）扩到 one-api / one-hub，注释同时点名四个平台；它拥有的是用户可见后果：存储余额保持 5/1/10 不变 + 运行时健康有记录。
- 既有的 `TestOneApiAdapter_GetBalance_CookieFallback` 一字未改仍然通过。

## 变异探针（三臂）

只换 `platform/oneapi.go`，测试保持不变；每臂用 `git show <rev>:<path> > <path>` 重新物化。

| | ARM A 修前（master） | ARM B 修后（HEAD） |
|---|---|---|
| unreachable → error | **FAIL** | PASS |
| 应答余额 → 1.5/0.5/2.0 | PASS | PASS |
| 应答 0 → 真话（ARM C 单跑） | PASS | PASS |
| 应答拒绝 → 带原因 | **FAIL** | PASS |
| one-hub 继承 | **FAIL** | PASS |
| 服务级 one-api / one-hub | **FAIL / FAIL** | PASS / PASS |
| 服务级 veloera / done-hub（#1244 已修） | PASS / PASS | PASS / PASS |

ARM C 是"不是任何改动都会红"的证明：修前版本上单独跑「应答 0 余额」子测试仍然绿。红精确落在该红的断言上，而 #1244 已修的两个平台在两臂都绿。脚本与日志在 `law6-census/oneapi-balance/`，探针后工作树 clean。

## 普查里其余候选的处置

52 处候选不是一次修完的清单，本轮只动余额这一族。其余按同一判据逐条裁决，**结论写进观察窗 `FINDINGS.md` 以免被重做**：`Detect` 族（5 个 adapter）是软探测结果、`GetUserInfo` 族是 verify 阶梯信号、`getAPITokens*` / `verifyWithUserIDHeader` / `trySubscriptionFallback` 是阶梯内部档位（顶层已诚实）、`listAPIKeys:715` 与 `oneapi.GetAPITokens:288` 是"上游应答了、确实没有"的真话、`newapi.GetUserGroups:819` 有 terminalError 保护、`newapi_tokens.go:211` 是 #1246 刻意保留的"上游自己的拒绝"。

**模型发现这一族（new-api / gemini / one-hub / claude 的 `GetModels` 都以 `[]string{}, nil` 收尾）是普查里剩下的最大一处，且对着一个开放的真实用户报障（#1232），单独一个 PR 做。**

## 本地门禁

`go vet ./...` 干净 · `go test ./platform/ ./service/... ./handler/... -count=1` 全绿。

不发版 —— 按 Law 3 累积进 v0.19.1。
