### PR TITLE
fix(platform): four model-discovery ladders reported every failure as "this account has no models"

### DIFF
--- a/platform/anyrouter_test.go
+++ b/platform/anyrouter_test.go
@@ -68,22 +68,26 @@ func TestAnyRouterAdapter_InheritsNewApiMethods(t *testing.T) {
 		t.Error("Checkin on unreachable URL should fail")
 	}
 
-	// GetBalance
+	// GetBalance: AnyRouter inherits New API's ladder, which reports the failure.
+	// The old shape accepted either answer, which is how a swallowed failure keeps
+	// a test green.
 	bi, err := a.GetBalance(ctx, unreachableBaseURL(t), "token", nil, nil)
 	if err == nil {
-		// GetBalance returns error on total failure (different from other adapters)
-		if bi != nil && bi.Balance > 0 {
-			t.Error("Balance should be 0 on unreachable URL")
-		}
+		t.Errorf("GetBalance must report an unreachable upstream, got %+v", bi)
+	}
+	if bi != nil {
+		t.Errorf("a failed balance fetch must not hand back a storable zero value, got %+v", bi)
 	}
 
-	// GetModels
+	// GetModels: same inheritance, and an empty list here is not a neutral answer —
+	// the refresh path turns it into `empty_models`, one phrase covering "the site
+	// turned /v1/models off", "the credential is dead" and "no models".
 	models, err := a.GetModels(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Errorf("GetModels error: %v", err)
+	if err == nil {
+		t.Error("GetModels must report an unreachable upstream, not an empty model list")
 	}
 	if len(models) != 0 {
-		t.Error("GetModels on unreachable should return empty")
+		t.Error("GetModels on unreachable should return no models")
 	}
 
 	// GetUserGroups - may return error or default on unreachable URL

--- a/platform/base.go
+++ b/platform/base.go
@@ -495,6 +495,56 @@ func extractLoginToken(resp, data map[string]interface{}) string {
 
 // --- Message helpers ---
 
+// modelFetchLadder owns one behaviour shared by every model-discovery ladder in
+// this package: telling "the upstream answered and this account has no models"
+// apart from "no rung of the ladder reached the upstream". Callers used to end
+// their ladders with `[]string{}, nil` for both, and service/account_model_refresh
+// only classifies a failure when err != nil, so every cause collapsed into the
+// single code `empty_models`.
+//
+// The rungs are a preference order (the credential the operator configured first,
+// dashboard/session fallbacks after), so the FIRST reason is kept: it is the one
+// that explains the symptom. listAPIKeys keeps the last error instead, because its
+// two endpoints are equivalent version-skew alternatives rather than a preference
+// order — that difference is deliberate, do not "unify" the two.
+//
+// A nil ladder is valid and records nothing; VerifyToken passes nil because a
+// verify rung failing is a signal to try the next credential shape, not a failure
+// to report.
+type modelFetchLadder struct {
+	answered bool
+	reason   string
+}
+
+// answer records that a rung read a real response, so an empty model list from it
+// is a true statement about the account.
+func (l *modelFetchLadder) answer() {
+	if l != nil {
+		l.answered = true
+	}
+}
+
+// fail records why a rung produced nothing. Only the first reason is kept.
+func (l *modelFetchLadder) fail(reason string) {
+	if l == nil || l.reason != "" || strings.TrimSpace(reason) == "" {
+		return
+	}
+	l.reason = strings.TrimSpace(reason)
+}
+
+// result is the end of the ladder: an answered empty list, or the reason no rung
+// could answer.
+func (l *modelFetchLadder) result() ([]string, error) {
+	if l != nil && l.answered {
+		return []string{}, nil
+	}
+	reason := "no model endpoint answered"
+	if l != nil && l.reason != "" {
+		reason = l.reason
+	}
+	return nil, fmt.Errorf("fetch models: %s", reason)
+}
+
 func extractResponseMessage(payload map[string]interface{}) string {
 	if msg, ok := getString(payload, "message"); ok && strings.TrimSpace(msg) != "" {
 		return strings.TrimSpace(msg)

--- a/platform/claude.go
+++ b/platform/claude.go
@@ -41,14 +41,23 @@ func (c *ClaudeAdapter) GetModels(ctx context.Context, baseURL string, token str
 		"x-api-key":         token,
 		"anthropic-version": ClaudeDefaultAnthropicVersion,
 	}
+	lad := &modelFetchLadder{}
+
 	models, err := c.fetchModelsFromStandardEndpoint(ctx, baseURL, claudeHeaders, proxy)
-	if err == nil && len(models) > 0 {
-		return models, nil
+	if err != nil {
+		lad.fail(err.Error())
+	} else {
+		lad.answer()
+		if len(models) > 0 {
+			return models, nil
+		}
 	}
 
-	// Fallback: strip /anthropic suffix and try OpenAI-compat
+	// Fallback: strip /anthropic suffix and try OpenAI-compat. Without one, the
+	// anthropic-shaped read above is the whole ladder, so its failure has to be
+	// reported rather than flattened into an empty model list.
 	if openAICompatBaseURL == "" {
-		return []string{}, nil
+		return lad.result()
 	}
 
 	return c.fetchModelsFromStandardEndpoint(ctx, openAICompatBaseURL, authBearerHeaders(token), proxy)

--- a/platform/gemini.go
+++ b/platform/gemini.go
@@ -21,21 +21,34 @@ func (g *GeminiAdapter) Detect(ctx context.Context, urlStr string) (bool, error)
 }
 
 // GetModels uses 3-path discovery: OpenAI-compat (if on /openai/ path) -> native Gemini -> OpenAI-compat fallback.
+//
+// All three paths used to end in `[]string{}, nil`, so an unreachable site, a
+// rejected key and a site that exposes none of the three shapes were the same
+// answer, and the caller can only classify a failure it is told about.
 func (g *GeminiAdapter) GetModels(ctx context.Context, baseURL string, apiToken string, platformUserId *int, proxy *ProxyConfig) ([]string, error) {
 	normalizedBase := normalizePlatformBaseURL(baseURL)
+	lad := &modelFetchLadder{}
 
 	// Path 1: OpenAI-compat if URL contains /openai/
 	if isOpenAICompatGeminiBase(normalizedBase) {
 		models, err := g.fetchModelsFromStandardEndpoint(ctx, normalizedBase, authBearerHeaders(apiToken), proxy)
-		if err == nil && len(models) > 0 {
-			return normalizeModelList(models), nil
+		if err != nil {
+			lad.fail(err.Error())
+		} else {
+			lad.answer()
+			if len(models) > 0 {
+				return normalizeModelList(models), nil
+			}
 		}
 	}
 
 	// Path 2: Native Gemini endpoint
 	nativeURL := resolveGeminiNativeModelsURL(normalizedBase, apiToken)
 	resp, err := fetchJSON(ctx, nativeURL, "GET", nil, nil, proxy)
-	if err == nil {
+	if err != nil {
+		lad.fail(err.Error())
+	} else {
+		lad.answer()
 		if modelsList, ok := resp["models"].([]interface{}); ok {
 			models := make([]string, 0, len(modelsList))
 			for _, m := range modelsList {
@@ -55,12 +68,17 @@ func (g *GeminiAdapter) GetModels(ctx context.Context, baseURL string, apiToken 
 	if !isOpenAICompatGeminiBase(normalizedBase) {
 		openAIURL := normalizedBase + "/v1beta/openai"
 		models, err := g.fetchModelsFromStandardEndpoint(ctx, openAIURL, authBearerHeaders(apiToken), proxy)
-		if err == nil && len(models) > 0 {
-			return normalizeModelList(models), nil
+		if err != nil {
+			lad.fail(err.Error())
+		} else {
+			lad.answer()
+			if len(models) > 0 {
+				return normalizeModelList(models), nil
+			}
 		}
 	}
 
-	return []string{}, nil
+	return lad.result()
 }
 
 func isOpenAICompatGeminiBase(baseURL string) bool {

--- a/platform/model_discovery_test.go
+++ b/platform/model_discovery_test.go
@@ -1,0 +1,97 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestModelDiscovery_FailureIsNotAnEmptyModelList pins the contract every
+// model-discovery ladder in this package has to keep: "the upstream answered and
+// this account has no models" and "no rung reached the upstream" are two different
+// answers. service/account_model_refresh classifies a failure only when err != nil,
+// so a ladder that ends in `[]string{}, nil` turns an unreachable site, a rejected
+// credential and a site that turned /v1/models off all into the single code
+// `empty_models` — which is what #1232 was reported against.
+//
+// The adapters are taken from the registry rather than built by hand, so this covers
+// what a deployment actually runs. sub2api and one-api already kept this contract and
+// are the in-repo pattern the others were brought to.
+func TestModelDiscovery_FailureIsNotAnEmptyModelList(t *testing.T) {
+	cases := []struct {
+		platform string
+		// answeredEmpty is the payload this platform's own contract uses for "I
+		// answered, there are no models". one-hub's /api/available_model fallback
+		// reads the keys of `data` as model names, so it needs an object, not a list.
+		answeredEmpty string
+		answeredOne   string
+		wantModel     string
+	}{
+		{"new-api", `{"success":true,"data":[]}`, `{"success":true,"data":[{"id":"gpt-test"}]}`, "gpt-test"},
+		{"one-hub", `{"success":true,"data":{}}`, `{"success":true,"data":[{"id":"gpt-test"}]}`, "gpt-test"},
+		{"gemini", `{"models":[],"data":[]}`, `{"models":[{"name":"gemini-test"}]}`, "gemini-test"},
+		{"claude", `{"data":[]}`, `{"data":[{"id":"claude-test"}]}`, "claude-test"},
+		{"sub2api", `{"data":[]}`, `{"data":[{"id":"gpt-test"}]}`, "gpt-test"},
+		{"one-api", `{"success":true,"data":[]}`, `{"success":true,"data":[{"id":"gpt-test"}]}`, "gpt-test"},
+	}
+
+	for _, tc := range cases {
+		adapter := GetAdapter(tc.platform)
+		if adapter == nil {
+			t.Fatalf("registry has no adapter for %q", tc.platform)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+		t.Run(tc.platform+"/unreachable is a failure", func(t *testing.T) {
+			models, err := adapter.GetModels(ctx, unreachableBaseURL(t), "sk-test-token", nil, nil)
+			if err == nil {
+				t.Errorf("GetModels reported an empty model list for an upstream nobody reached")
+			}
+			if len(models) != 0 {
+				t.Errorf("models = %v, want none", models)
+			}
+		})
+
+		t.Run(tc.platform+"/answered with no models is not a failure", func(t *testing.T) {
+			srv := answeringModelServer(tc.answeredEmpty)
+			defer srv.Close()
+			models, err := adapter.GetModels(ctx, srv.URL, "sk-test-token", nil, nil)
+			if err != nil {
+				t.Errorf("an upstream that answered with no models is a true empty answer: %v", err)
+			}
+			if len(models) != 0 {
+				t.Errorf("models = %v, want none", models)
+			}
+		})
+
+		t.Run(tc.platform+"/answered with a model", func(t *testing.T) {
+			srv := answeringModelServer(tc.answeredOne)
+			defer srv.Close()
+			models, err := adapter.GetModels(ctx, srv.URL, "sk-test-token", nil, nil)
+			if err != nil {
+				t.Fatalf("GetModels: %v", err)
+			}
+			found := false
+			for _, m := range models {
+				if m == tc.wantModel {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("models = %v, want %q in it", models, tc.wantModel)
+			}
+		})
+		cancel()
+	}
+}
+
+// answeringModelServer serves the same body on every path, which is enough for a
+// model-discovery ladder: each rung reads its own shape out of it.
+func answeringModelServer(body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -250,8 +250,9 @@ func parseUserInfo(data map[string]interface{}) *UserInfo {
 // --- VerifyToken ---
 
 func (n *NewApiAdapter) VerifyToken(ctx context.Context, baseURL, token string, platformUserId *int, proxy *ProxyConfig) (*TokenVerifyResult, error) {
-	// Try API key path first (/v1/models)
-	openAIModels := n.getOpenAIModels(ctx, baseURL, token, proxy)
+	// Try API key path first (/v1/models). nil ladder: here a rung that produces
+	// nothing is a signal to try the next credential shape, not a failure to report.
+	openAIModels := n.getOpenAIModels(ctx, baseURL, token, proxy, nil)
 	if len(openAIModels) > 0 {
 		return &TokenVerifyResult{TokenType: "apikey", Models: openAIModels}, nil
 	}
@@ -645,7 +646,14 @@ func (n *NewApiAdapter) GetBalance(ctx context.Context, baseURL, accessToken str
 // --- GetModels ---
 
 func (n *NewApiAdapter) GetModels(ctx context.Context, baseURL, token string, platformUserId *int, proxy *ProxyConfig) ([]string, error) {
-	openAIModels := n.getOpenAIModels(ctx, baseURL, token, proxy)
+	// Four rungs, and every one of them used to swallow its failure into the next,
+	// ending in `[]string{}, nil`. That made "the site turned /v1/models off",
+	// "the credential is dead", "this credential has no dashboard" and "this
+	// account really has no models" the same answer, and the caller can only
+	// classify the last one (#1232 is a report about exactly that ambiguity).
+	lad := &modelFetchLadder{}
+
+	openAIModels := n.getOpenAIModels(ctx, baseURL, token, proxy, lad)
 	if len(openAIModels) > 0 {
 		return openAIModels, nil
 	}
@@ -659,7 +667,10 @@ func (n *NewApiAdapter) GetModels(ctx context.Context, baseURL, token string, pl
 		idCopy := *userID
 		headers := n.authHeaders(token, &idCopy)
 		resp, err := fetchJSON(ctx, baseURL+"/api/user/models", "GET", nil, headers, proxy)
-		if err == nil {
+		if err != nil {
+			lad.fail(err.Error())
+		} else {
+			lad.answer()
 			if data, ok := resp["data"].([]interface{}); ok {
 				models := make([]string, 0, len(data))
 				for _, item := range data {
@@ -686,7 +697,7 @@ func (n *NewApiAdapter) GetModels(ctx context.Context, baseURL, token string, pl
 	}
 
 	// Cookie model fallback
-	cookieModels := n.getSessionModelsByCookie(ctx, baseURL, token, userID, proxy)
+	cookieModels := n.getSessionModelsByCookie(ctx, baseURL, token, userID, proxy, lad)
 	if len(cookieModels) > 0 {
 		return cookieModels, nil
 	}
@@ -694,26 +705,28 @@ func (n *NewApiAdapter) GetModels(ctx context.Context, baseURL, token string, pl
 	// Alternate userID cookie fallback
 	altID := n.probeAlternateUserIDByCookie(ctx, baseURL, token, userID, proxy)
 	if altID != nil {
-		fallbackModels := n.getSessionModelsByCookie(ctx, baseURL, token, altID, proxy)
+		fallbackModels := n.getSessionModelsByCookie(ctx, baseURL, token, altID, proxy, lad)
 		if len(fallbackModels) > 0 {
 			return fallbackModels, nil
 		}
 	}
 
-	return []string{}, nil
+	return lad.result()
 }
 
-func (n *NewApiAdapter) getOpenAIModels(ctx context.Context, baseURL, token string, proxy *ProxyConfig) []string {
+func (n *NewApiAdapter) getOpenAIModels(ctx context.Context, baseURL, token string, proxy *ProxyConfig, lad *modelFetchLadder) []string {
 	// Try /v1/models
 	resp, err := fetchJSON(ctx, baseURL+"/v1/models", "GET", nil, authBearerHeaders(token), proxy)
 	if err != nil {
+		lad.fail(err.Error())
 		return nil
 	}
+	lad.answer()
 
 	return extractModelIDsFromData(resp)
 }
 
-func (n *NewApiAdapter) getSessionModelsByCookie(ctx context.Context, baseURL, token string, userID *int, proxy *ProxyConfig) []string {
+func (n *NewApiAdapter) getSessionModelsByCookie(ctx context.Context, baseURL, token string, userID *int, proxy *ProxyConfig, lad *modelFetchLadder) []string {
 	for _, cookie := range buildCookieCandidates(token) {
 		headers := map[string]string{"Cookie": cookie}
 		for k, v := range n.userIDHeaders(userID) {
@@ -722,8 +735,10 @@ func (n *NewApiAdapter) getSessionModelsByCookie(ctx context.Context, baseURL, t
 
 		resp, err := fetchJSON(ctx, baseURL+"/api/user/models", "GET", nil, headers, proxy)
 		if err != nil {
+			lad.fail(err.Error())
 			continue
 		}
+		lad.answer()
 
 		if data, ok := resp["data"].([]interface{}); ok && len(data) > 0 {
 			models := make([]string, 0, len(data))

--- a/platform/onehub.go
+++ b/platform/onehub.go
@@ -17,18 +17,31 @@ func (o *OneHubAdapter) Detect(ctx context.Context, url string) (bool, error) {
 }
 
 // GetModels: try /v1/models (OneApi), fall back to /api/available_model.
+//
+// The embedded one-api ladder already reports its failures; this wrapper used to
+// drop that error and then swallow its own fallback's failure too, so one-hub
+// answered "no models" for a site nobody reached.
 func (o *OneHubAdapter) GetModels(ctx context.Context, baseURL string, apiToken string, platformUserId *int, proxy *ProxyConfig) ([]string, error) {
+	lad := &modelFetchLadder{}
+
 	models, err := o.OneApiAdapter.GetModels(ctx, baseURL, apiToken, platformUserId, proxy)
-	if err == nil && len(models) > 0 {
-		return models, nil
+	if err != nil {
+		lad.fail(err.Error())
+	} else {
+		lad.answer()
+		if len(models) > 0 {
+			return models, nil
+		}
 	}
 
 	// Fallback: /api/available_model
 	headers := authBearerHeaders(apiToken)
 	resp, fetchErr := fetchJSON(ctx, baseURL+"/api/available_model", "GET", nil, headers, proxy)
 	if fetchErr != nil {
-		return []string{}, nil
+		lad.fail(fetchErr.Error())
+		return lad.result()
 	}
+	lad.answer()
 
 	payload := resp
 	if data, ok := getMap(resp, "data"); ok {
@@ -47,7 +60,7 @@ func (o *OneHubAdapter) GetModels(ctx context.Context, baseURL string, apiToken 
 		}
 	}
 
-	return []string{}, nil
+	return lad.result()
 }
 
 // GetUserGroups: /api/user_group_map with data-object keys, fallback to OneApi's implementation.

--- a/platform/onehub_test.go
+++ b/platform/onehub_test.go
@@ -2,6 +2,8 @@ package platform
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -35,21 +37,44 @@ func TestOneHubAdapter_Detect(t *testing.T) {
 	}
 }
 
+// Both directions: the /api/available_model fallback still has to work, and
+// "neither ladder rung reached the upstream" is a failure rather than an empty
+// model list. The second half is what this test used to assert away.
 func TestOneHubAdapter_GetModels_Fallback(t *testing.T) {
 	o := &OneHubAdapter{
 		OneApiAdapter: &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-hub")},
 	}
 	ctx := context.Background()
 
-	// On unreachable URL, /v1/models fails, /api/available_model fails
-	// Should return empty slice without error
-	models, err := o.GetModels(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(models) != 0 {
-		t.Error("GetModels should return empty for unreachable URL")
-	}
+	t.Run("available_model fallback still yields models", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/api/available_model" {
+				_, _ = w.Write([]byte(`{"success":true,"data":{"gpt-fallback":{}}}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer srv.Close()
+
+		models, err := o.GetModels(ctx, srv.URL, "token", nil, nil)
+		if err != nil {
+			t.Fatalf("fallback path: %v", err)
+		}
+		if len(models) != 1 || models[0] != "gpt-fallback" {
+			t.Fatalf("models = %v, want [gpt-fallback]", models)
+		}
+	})
+
+	t.Run("both rungs unreachable is a failure", func(t *testing.T) {
+		models, err := o.GetModels(ctx, unreachableBaseURL(t), "token", nil, nil)
+		if err == nil {
+			t.Error("GetModels must report an unreachable upstream, not an empty model list")
+		}
+		if len(models) != 0 {
+			t.Error("GetModels on unreachable should return no models")
+		}
+	})
 }
 
 func TestOneHubAdapter_GetUserGroups_Fallback(t *testing.T) {

--- a/service/account_model_refresh_test.go
+++ b/service/account_model_refresh_test.go
@@ -129,6 +129,61 @@ func withModelRefreshCounters(t *testing.T) (rebuilds, invalidates *int) {
 	return &rebuildCount, &invalidateCount
 }
 
+// seedSiteOnPlatform inserts an active site on an arbitrary registered platform.
+func seedSiteOnPlatform(t *testing.T, db *sqlx.DB, name, url, platformName string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, use_system_proxy, sort_order, global_weight, post_refresh_probe_enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, 'active', FALSE, 0, 0, FALSE, ?, ?)`,
+		name, url, platformName, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// TestRefreshAccountModels_UpstreamFailureIsNotReportedAsEmptyModels owns the
+// operator-visible consequence of the discovery ladders, which the adapter-level
+// contract cannot show: this function classifies a failure only when the adapter
+// returns one, so a ladder ending in `[]string{}, nil` collapsed "the site is
+// unreachable", "the credential was rejected", "the upstream turned /v1/models off"
+// and "this account really has no models" into the single code `empty_models` /
+// "no models available". The account then has no models, the route rebuild finds no
+// channel, and the operator is told the account has nothing to serve — which is the
+// shape #1179 was reported as and #1232 is still open about.
+func TestRefreshAccountModels_UpstreamFailureIsNotReportedAsEmptyModels(t *testing.T) {
+	for _, platformName := range []string{"new-api", "one-hub", "gemini", "claude"} {
+		t.Run(platformName, func(t *testing.T) {
+			db := openModelRefreshTestDB(t)
+			siteID := seedSiteOnPlatform(t, db, platformName+" unreachable", "http://127.0.0.1:1", platformName)
+			accountID, _ := seedAccountOnSite(t, db, siteID, "models-owner", "sk-live-token", "active")
+
+			res := RefreshAccountModels(context.Background(), db, accountID, true, true)
+			if res.Success {
+				t.Fatalf("refresh reported success against an unreachable upstream: %+v", res)
+			}
+			if res.ErrorCode == "empty_models" {
+				t.Fatalf("a fetch that never reached the upstream was reported as %q / %q, the code that means \"this account has no models\"",
+					res.ErrorCode, res.ErrorMessage)
+			}
+			if res.ErrorCode == "" || res.ErrorMessage == "" {
+				t.Fatalf("no classified reason at all: %+v", res)
+			}
+
+			var rows int
+			if err := db.QueryRow("SELECT COUNT(*) FROM model_availability WHERE account_id = ?", accountID).Scan(&rows); err != nil {
+				t.Fatalf("count model_availability: %v", err)
+			}
+			if rows != 0 {
+				t.Fatalf("a failed refresh wrote %d model_availability rows", rows)
+			}
+		})
+	}
+}
+
 func TestPersistTokenModelAvailability_UpsertsAndMarksUnavailable(t *testing.T) {
 	db := openModelRefreshTestDB(t)
 	_, tokenID := seedAccountAndToken(t, db, "sk-backfill")


### PR DESCRIPTION
**Observed failure: #1232（开放）。** 报障者的上游关掉了 `/v1/models`，Metapi 给的答案是 `empty_models` / "no models available" —— 一句话盖住四种需要四种不同处置的事实：站点关了这个端点、账号合法地没有模型、凭据背后没有后台面、凭据死了。准入依据是这条报障 + Law 6；穷尽普查（观察窗 `ast-census`）说明这不是某个 adapter 的怪癖，而是**四条阶梯同一个收尾**。

## 缺陷

| adapter | 阶梯 | 收尾 |
|---|---|---|
| `NewApiAdapter.GetModels` | `/v1/models` → `/api/user/models`（解析 userID）→ session cookie → 备用 userID + cookie | 每档 `if err == nil` 吞掉，收尾 `[]string{}, nil` |
| `GeminiAdapter.GetModels` | openai-compat → 原生 Gemini → openai-compat 兜底 | 三条路全吞，同上 |
| `OneHubAdapter.GetModels` | 内嵌 one-api 的阶梯 → `/api/available_model` | **丢掉 one-api 已经报出来的 error**，再吞自己的兜底 |
| `ClaudeAdapter.GetModels` | anthropic 形状 → openai-compat | 没有兜底 URL 时把第一档的错误压成空列表 |

后果不在 adapter 里，在调用方：`RefreshAccountModels` **只在 `err != nil` 时分类**。拿到 `err == nil` + 空列表就走 `empty_models` 分支 ⇒ 账号模型为空 → 路由重建找不到通道 → 运营拿到 `503 No available channels`，而刷新结果告诉他"这个账号没有可服务的模型"。**这正是 #1179 被报出来的那个症状，从另一个方向到达。**

同包的 **sub2api 与 one-api 早就是诚实的**（sub2api 的注释还写着意图："Surface a terminal fetch error so callers can classify it"），所以这次是把另外四个带回本包已有的样板，不是发明新形状。

## 修法

共享的记账收成 base.go 里一个小类型（放在其它阶梯 helper 旁边），因为**四份副本正是这四条阶梯各自漂移的原因**：

- `answer()` —— 某一档真读到了响应，于是它给出的空列表是关于账号的真话；
- `fail(reason)` —— 只保留**第一个**原因：这些档是偏好序（运营配的那条路在前），第一档的失败才是解释症状的那个。`listAPIKeys` 保留的是**最后一个**错误，因为它那两个端点是等价的版本兼容替代而非偏好序；这个差别写进注释，免得被人"统一"掉；
- `result()` —— 应答过的空列表，或者"没有一档能应答"的原因。

`nil` 阶梯什么都不记，`VerifyToken` 传的就是 nil：那里某一档没结果是"换下一种凭据形状再试"的信号，不是要上报的失败。

## 测试

- **`TestModelDiscovery_FailureIsNotAnEmptyModelList`**：从**注册表**取 adapter（覆盖部署真正跑的东西），6 个平台 × 3 个方向 = 18 个子测试。四个被修的平台 + sub2api / one-api 作为样板的回归护栏：不可达 → error；应答了但没模型 → 空列表且**无** error；应答了一个模型 → 拿得回来。
- **`TestRefreshAccountModels_UpstreamFailureIsNotReportedAsEmptyModels`**：拥有运营可见的后果，四个平台各要求：不是 success、**不是 `empty_models`**、有分类码与消息、且没有写入任何 `model_availability` 行。
- 两个把吞没钉住的既有测试改写为钉两个方向：`TestOneHubAdapter_GetModels_Fallback`（原断言 "should return empty for unreachable URL"；现在同时证明 `/api/available_model` 兜底**仍然**能出模型）与 `TestAnyRouterAdapter_InheritsNewApiMethods` 的 GetModels 段（anyrouter 内嵌 new-api，继承新行为）。它上面那段 `GetBalance` 原本"两种答案都接受"，同一次编辑里收紧了——**松断言贴在紧断言旁边，正是下一个吞没能活下来的方式**。

## 变异探针（三臂）

只换五个生产文件，测试保持不变；每臂用 `git show <rev>:<path> > <path>` 重新物化。

| | ARM A 修前（master 五个文件） | ARM B 修后（HEAD） | ARM C HEAD 之上只退 `newapi.go` |
|---|---|---|---|
| adapter：new-api / one-hub / gemini / claude 的 unreachable | **FAIL ×4** | PASS ×4 | **FAIL（仅 new-api）** |
| adapter：6 平台的"应答了没模型" + "应答了一个模型" | PASS ×12 | PASS ×12 | PASS ×12 |
| adapter：sub2api / one-api 的 unreachable（样板护栏） | PASS ×2 | PASS ×2 | PASS ×2 |
| `TestAnyRouterAdapter_InheritsNewApiMethods`（内嵌 new-api） | **FAIL** | PASS | **FAIL** |
| `TestOneHubAdapter_GetModels_Fallback`（不依赖 newapi） | **FAIL** | PASS | PASS |
| service 后果：new-api / one-hub / gemini / claude | **FAIL ×4** | PASS ×4 | **FAIL（仅 new-api）** |

ARM C 是判别力臂：只弄坏 new-api 时只有 new-api 与**继承它的 anyrouter** 红，而 one-hub / gemini / claude 全绿 ⇒ 这不是"随便改点什么都会红"的糊状门。

**探针 harness 自己错过一次，写下来**：第一版 ARM C 写成"在 ARM A 之后只把 newapi.go 退回 master"，而 ARM A 已经把五个文件全退成 master 的了 ⇒ ARM C 与 ARM A 逐字相同，判别力臂测了个空气（结果看起来还"符合预期"）。修正为**每臂都从 HEAD 重新物化再退目标文件**，并重跑；两份日志分存（`mutation-probe.log` = A/B，`mutation-probe-armC.log` = 修正后的 C），脚本里留了注释说明为什么必须这样写。这与本项目已记录过两次的教训同类：**harness 的形状错了，结果会看起来是对的。**

## 本地门禁

`go vet ./...` 干净 · `go test ./platform/ ./service/... ./handler/... ./scheduler/... ./routing/... -count=1` 全绿。

## 普查里这一族之外的处置

52 处候选的逐条裁决在观察窗 `law6-census/ast-census/FINDINGS.md`（含工具自己错过两次的记录与一条已知局限）。本 PR 只动模型发现族；`sub2api.GetUserGroups` 编造 `["default"]` 记为候选未排期（后果轻一档：它会**赢过**调用方本来要做的真回落——本地 DISTINCT `token_group`）。

不发版 —— 按 Law 3 累积进 v0.19.1。
