### PR TITLE
docs(changelog): the writing contract was prose only, so the file regrew into what it forbids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@ Metapi-Go 的版本叙事。格式基于 [Keep a Changelog](https://keepachangel
 
 打 tag 时 CI 把 `## [vX.Y.Z]` 段逐字抽成该版本的 GitHub release body。**那是快照，不是引用**：tag 之后再改这里，已发布版本的发布页不跟着变。
 
-写作契约：
+写作契约（由 `docs/doc_hygiene_test.go` 机械守着，不靠自觉）：
 
-- 读者是**部署和调用 Metapi 的人**。一条只回答两件事：行为怎么变了、我要不要动手。
-- 一条 = 一行结论（带符号／端点／环境变量／表名）+ 至多一句因果。取证过程、测试与门禁的形状、行数增减、内部文件清单不进本文件——它们在 commit body 与 PR 里，`git log --grep '#1210'` 一步到达。
-- **要运维动手的必须显式写**：升级后重新登录、默认值变了、备份不再含某张表、端点删了、请求要多带一个头、日志新增 WARN。这是本文件唯一不可省略的部分。
+- **读者是部署和调用 Metapi 的人**。一条只回答两件事：行为怎么变了、我要不要动手。
+- **一条 ≤ 220 字符**（约终端两行）。超了只有两条出路：拆条，或者**指向该事实的 owner 文档**——环境变量清单、错误码表、端点清单都各有 SSOT 与门禁，本文件指路，不抄第二份。
+- **必须写进来**：端点路径、环境变量名与默认值变化、表名与列名、HTTP 状态码变化、新增日志级别、升级后要做的动作（重新登录、多带一个头、备份不再含某张表）。这是本文件唯一不可省略的部分。
+- **不许写进来**：为什么以前是错的（取证链、`⇒`）、内部 Go 符号名与文件名、测试与门禁的形状、行数与计数。它们在 commit body 与 PR 里，`git log --grep '#1210'` 一步到达。
+- **同族合并**：同一根因或同一批次的多条并成一条「××批（#a、#b、#c）」；`开发者可见` 每版至多一条。
 - 编号写 `#问题 → #PR`；只有一个编号时它就是 PR。
 - 分节固定 `安全` `修复` `变更` `移除` `开发者可见` `文档` `已知遗留`，空节不写；`已知遗留` 只收**运维可见的残留**（配了不生效、旧数据留一行、会无界增长），有 issue 的开放项看 GitHub issues。v0.16.23 及更早沿用当年的 `Added` / `Changed` / `Fixed`。
-- **v0.16.17 及更早逐字保留**；v0.16.18–v0.19.0 于 2026-09-05 按本契约做过第二次压缩（事实、编号与运维动作未变），这几版的发布页仍是压缩前长文。
+- **v0.16.12 及更早逐字保留**（本身已经够短）。v0.16.13–v0.19.0 于 2026-09-05 按本契约做过第三次压缩：编号、运维动作与事实未减，取证细节与标识符副本退出；这几版的发布页仍是压缩前长文。
 
 ## [v0.19.0] — 2026-09-04
 
@@ -19,11 +21,10 @@ Metapi-Go 的版本叙事。格式基于 [Keep a Changelog](https://keepachangel
 
 ### 修复
 
-- **balance 刷新失败给出分类原因（#1210 → #1211）**：单个与批量两个出口都保留稳定前缀并追加分类后缀（凭据过期／上游拒绝／上游不可达／上游没返回余额），如 `balance refresh failed: upstream rejected the credential (HTTP 401)`。只渲染既有错误枚举，上游 URL、token 与原文不进响应（原文进 WARN）。同批：`service/balance` 的 DB 读失败不再被当成「账号不存在」回 404。
-- **PostgreSQL 备份导入后重置 id 序列（#1217 → #1218）**：导入带显式 id 而 serial 序列停在原位，恢复后的第一次写入撞 `duplicate key value violates unique constraint "sites_pkey"`。migrator 与导入共用 `store.ResyncPGIDSequences`（migrator 警告续跑，导入判致命）。SQLite 不受影响。
-- **`model_probe_results` 有了保留期（#1221 → #1222）**：此前没有任何 DELETE 路径。现由既有 `RetentionScheduler` 按 7 天窗口每小时清理，豁免每个 `(account_id, model_name)` 的最新一行（路由重建读的就是它）。无新配置项。
+- **balance 刷新失败带分类原因（#1210 → #1211）**：稳定前缀 + 分类后缀，如 `balance refresh failed: upstream rejected the credential (HTTP 401)`；上游 URL、token 与原文不进响应（原文进 WARN）。同批：余额读库失败不再回 404。
+- **PostgreSQL 备份导入后重置 id 序列（#1217 → #1218）**：此前恢复后的第一次写入撞 `duplicate key value violates unique constraint "sites_pkey"`。SQLite 不受影响。
+- **`model_probe_results` 有了保留期（#1221 → #1222）**：此前没有任何 DELETE 路径。现按 7 天窗口每小时清理，豁免每个 `(account_id, model_name)` 的最新一行（路由重建读的就是它）。无新配置项。
 - **账号详情抽屉逐条报出通道真正使用的凭据来源（#1219 → #1220）**：不再用一个笼统状态掩盖；下游密钥的空 model policy 明确显示为 deny-all。
-- **架构边界门扫不到文件时不再判通过（#1214）**：任一域解析到 0 个生产 Go 文件即失败；skip 列表补上 agent worktree 与 gitignored 私有目录。
 
 ### 变更
 
@@ -31,7 +32,8 @@ Metapi-Go 的版本叙事。格式基于 [Keep a Changelog](https://keepachangel
 
 ### 开发者可见
 
-- **核心链四态门进 CI `test-e2e`（#1213、#1216、#1212）**：Fresh 之外新增 Restart（同一 data dir 重启，不重新登录／不重建）、Aged（老化存量凭据后复跑）、Restore（备份导入全新 data dir 后直接中继），三态都要求真实 completion 成功。前端验收补上尾段（#1220）：UI 签发下游密钥 → 独立 HTTP 客户端（无页面、无 admin token）真调 `/v1/chat/completions`，并按 `EXPECT_SERVER_COMMIT` 对 `/api/about` 做身份 preflight。
+- **核心链四态门进 CI（#1213、#1216、#1212）**：Fresh 之外新增 Restart（同一 data dir 重启）、Aged（老化存量凭据）、Restore（备份导入全新 data dir），三态都要求真实 completion 成功。
+- **前端验收补上尾段（#1220）**：UI 签发密钥后由独立 HTTP 客户端（无页面、无 admin token）真调 `/v1/chat/completions`，并按 `EXPECT_SERVER_COMMIT` 对 `/api/about` 做身份 preflight。架构边界门扫不到文件时不再判通过（#1214）。
 
 ### 已知遗留
 
@@ -39,49 +41,50 @@ Metapi-Go 的版本叙事。格式基于 [Keep a Changelog](https://keepachangel
 
 ## [v0.18.0] — 2026-09-03
 
-> 减法版本：删掉从未发布或从未接线的面，同时根修 New API 主链上三个各自足以致死的缺陷。**升级后需要重新登录一次账号；令牌不需要手工绑定。**
+> 减法版本：删掉从未发布或从未接线的面，同时根修 New API 主链上三个各自足以致死的缺陷——凭据 15 分钟就过期、令牌存的是掩码显示值、模型要等凌晨 4 点才同步，三个都表现为「无可用渠道」。**升级后需要重新登录一次账号；令牌不需要手工绑定。**
 
 ### 修复
 
-- **New API 中继链从「看起来绑上」变成持久（#1179 → #1187）**：① 登录返回的约 15 分钟 dashboard JWT 曾被当长期凭据落库，过期后模型刷新塌成空列表、路由无通道、`503 No available channels`——现在登录时提升为 New API 长期 dashboard PAT，**发不出持久凭据就拒绝绑定**，并用 live JWT 撤销临时上游会话。② 令牌列表的掩码显示值曾被当真实 relay key 落库（请求 401、通道被停用）——现在经所有权校验的 `POST /api/token/batch/keys` hydrate，hydrate 不出来即报错，掩码行在 UI 上保持 `masked_pending`。③ 模型列表此前要等后台调度（默认凌晨 4 点）——现在登录后立即同步，route rebuild 可以服务触发它的那次请求。
-- **`503 No available channels` 说清为什么（#1179 → #1186）**：`proxy.ExplainNoChannel` 给一行结论加主候选拒绝原因（无启用路由匹配该模型／通道令牌未绑定或停用／全部冷却或下游密钥策略排除站点），同时进 503 body。
-- **重建路由不再随发出它的 HTTP 请求一起死（#1174 → #1185）**：`POST /api/routes/rebuild` 曾整趟跑在 `r.Context()` 上，`refreshModels: true` 时客户端 30s 先挂断、日志只剩 `context canceled`；现改用 `context.WithoutCancel` + 30 分钟预算。`POST /api/settings/maintenance/clear-cache` 也不再删掉重建要用的输入（清业务行是 `factory-reset` 的职责）。
-- **账号编辑保存的 `credentialMode` 不再蒸发（#1176 → #1184）**：更新 payload 缺该字段、handler 静默丢弃 ⇒ 改成 session、拿到成功 toast、重开又是 API key。现在进 payload 并合并进 `extraConfig`，且在碰任何凭据字段之前解析（此前切 session 也会把 session 凭据抄进 `api_token`，被凭据回落当 API key 发出）。撑不起的模式回 400。
-- **AnyRouter 校验失败说明它要什么凭据（#1133 → #1195）**：`token verification failed` → 明确指引：access-token / API-key 绑定不支持、必须用 session 模式、字段接受 `session=<value>` 或完整 `Cookie:` 头。bind 与 verify 共用 `credentialVerificationFailureMessage(platform)`。
-- **「同步站点令牌」幂等（#1193 → #1196）**：上游掩码 relay key 时行解析成 `masked_pending`、永远匹配不上 ready 行，每次同步都 INSERT 一份副本；现按精确 key 值匹配、优先 ready 行、回落 masked 行，UPDATE 保留 `value_status`。
-- **删表不再让删除之前写的备份恢复不了（#1201）**：导入曾拒绝任何不认识的 payload key ⇒ 有效旧备份变 `400 unknown table proxy_debug_traces`。现按来源区分：真导出文件里的未知 key ＝本 build 已删的表，跳过并在 import 与 preview 响应里报 `ignoredTables`；策略排除表与手写 JSON 的未知 key 仍 400。
+- **New API 中继链从「看起来绑上」变成持久（#1179 → #1187）**：① 约 15 分钟的登录 JWT 提升为长期 PAT，**发不出持久凭据就拒绝绑定**，并撤销临时上游会话；② 掩码显示值不再当 relay key 落库，改经 `POST /api/token/batch/keys` hydrate，hydrate 不出来即报错（UI 保持 `masked_pending`）；③ 登录后立即同步模型，不再等后台调度。
+- **`503 No available channels` 说清为什么（#1179 → #1186）**：一行结论加主候选拒绝原因（无启用路由匹配该模型／通道令牌未绑定或停用／全部冷却或下游密钥策略排除站点），同时进 503 body。
+- **重建路由不再随发出它的 HTTP 请求一起死（#1174 → #1185）**：`POST /api/routes/rebuild` 此前跑在请求 context 上，客户端 30s 挂断后日志只剩 `context canceled`；现改 30 分钟独立预算。`POST /api/settings/maintenance/clear-cache` 也不再删掉重建要用的输入（清业务行是 `factory-reset` 的职责）。
+- **账号编辑保存的 `credentialMode` 不再蒸发（#1176 → #1184）**：更新 payload 缺该字段、handler 静默丢弃，改成 session、拿到成功 toast、重开又是 API key；现进 payload 并在碰任何凭据字段之前解析（此前切 session 也会把 session 凭据抄进 `api_token`），撑不起的模式回 400。
+- **AnyRouter 校验失败说明它要什么凭据（#1133 → #1195）**：`token verification failed` 改为明确指引——必须用 session 模式，字段接受 `session=<value>` 或完整 `Cookie:` 头。
+- **删表不再让删除之前写的备份恢复不了（#1201）**：有效旧备份此前变 `400 unknown table proxy_debug_traces`。现按来源区分：真导出文件里的未知 key ＝本 build 已删的表，跳过并在 import 与 preview 响应里报 `ignoredTables`；策略排除表与手写 JSON 的未知 key 仍 400。
+- **「同步站点令牌」幂等（#1193 → #1196）**：上游掩码 relay key 时行永远匹配不上 ready 行，每次同步都 INSERT 一份副本；现按精确 key 值匹配，UPDATE 保留 `value_status`。
 
 ### 移除
 
 - **未发布的 Electron 桌面外壳（#1197）**：连同公开、未认证、只为托盘而设的 `GET /api/desktop/health`。
-- **永久为空或无人实现的控制面（#1199、#1201）**：proxy debug-trace 子系统（两张表、两个读路由、九个 `PROXY_DEBUG_*` 开关及其设置 UI）· `proxy_files` 表 + `PROXY_FILE_RETENTION_*` + 其调度器 · `admin_snapshots` 表 + 其调度器（`RunProjectionPass` 仍由 usage-aggregation 调度器跑）· update-center 五个操作臂（`POST /api/update-center/check`、`PUT /config`、`POST /deploy`、`POST /rollback`、`GET /tasks/{id}/stream`）+ `METAPI_ENABLE_UPDATE_CENTER`（只读状态卡保留）· model-tester 流式/任务臂（`/api/test/proxy`、`/api/test/chat/stream` 及各自 jobs 端点；同步探针 `POST /api/test/chat` 保留）。
-- **无实现者与无调用者的代码（#1187、#1190、#1198、#1201、#1204）**：`RouteRefreshWorkflow` 家族 · `RESPONSES_COMPACT_FALLBACK_TO_RESPONSES_ENABLED` · `routing` 的死 pricing override 链（`NormalizePricingRatio`、`EstimateProxyCostFromModel`、`BuildPricingOverrideModel`）· 六个零引用 helper · 四个不可能失败的测试。
-- **16 份维护者过程史移出公开仓（#1191、#1194）**：`docs/internal/` 下的 STATE / log / MASTER / benchmark 与 11 份 analysis 及设计稿；角色改由 GitHub issues 与 releases、本文件、`docs/architecture.md` 承接。
+- **proxy debug-trace 子系统（#1199、#1201）**：两张表、两个读路由、九个 `PROXY_DEBUG_*` 开关及其设置 UI；同批移除 `proxy_files`、`admin_snapshots` 两张表及其调度器与 `PROXY_FILE_RETENTION_*`。
+- **update-center 的五个操作臂（#1201）**：`POST /api/update-center/check`、`PUT /config`、`POST /deploy`、`POST /rollback`、`GET /tasks/{id}/stream` 与 `METAPI_ENABLE_UPDATE_CENTER`；只读状态卡保留。
+- **model-tester 的流式与任务臂（#1201）**：`/api/test/proxy`、`/api/test/chat/stream` 及各自 jobs 端点；同步探针 `POST /api/test/chat` 保留。
+- **无实现者与无调用者的代码（#1187、#1190、#1198、#1201、#1204）**：一个只被测试 mock 养活的路由刷新接口家族、`RESPONSES_COMPACT_FALLBACK_TO_RESPONSES_ENABLED`、死 pricing override 链、六个零引用 helper、四个不可能失败的测试。
+- **16 份维护者过程史移出公开仓（#1191、#1194）**：角色改由 GitHub issues 与 releases、本文件、`docs/architecture.md` 承接。
 
 ### 开发者可见
 
-- **`handler/admin/accounts.go` 按关注点拆成 6 个同包文件（#1192）**；同形测试折成表格（#1188、#1189、#1200、#1202、#1203、#1206），用例集合机械比对、差集为空、子测试名保留。
-- **CI 的 `bun install` 对瞬时故障有界重试（#1181）**：损坏或截断的 tarball 报 `Integrity check failed`，重跑就装得上，却能挂掉必选检查。同时修 Dockerfile 缓存挂载路径（`~/.bun/install-cache` → `~/.bun/install/cache`，此前那句声明从未缓存过任何东西）。
-- **仓库卫生（#1194）**：`.gitignore` 补 `.env.*`（保留 `!.env.example`）、`*.log`、`/dist-bin/`；CI 缓存 key 从哈希一个不存在的 lockfile 改为哈希真实存在的那个。
+- **账号 handler 按关注点拆成 6 个同包文件（#1192）**；同形测试折成表格（#1188、#1189、#1200、#1202、#1203、#1206），用例集合机械比对、差集为空、子测试名保留。
+- **CI 与仓库卫生（#1181、#1194）**：前端依赖安装对瞬时故障有界重试（损坏 tarball 报 `Integrity check failed`、重跑就装得上，却能挂掉必选检查）；`.gitignore` 补 `.env.*`（保留 `!.env.example`）、`*.log`、`/dist-bin/`。
 
 ### 已知遗留
 
 - `PayloadRules` 无运行时消费者、`OpenAiServiceTierRules` 无读者，而 `docs/configuration.md` 仍把两者写成可用：**配了不生效**。
 - 本版之前绑定的账号可能留一条 `masked_pending` 旧令牌行：一次性、不可路由，运营可删。
+
 ## [v0.17.1] — 2026-09-03
 
 ### 修复
 
-- **备份导出不再静默丢 5 张用户可见状态表（#1172）**：`service/backup.AllTables` 是仓库里第三份手抄清单，漂移到 37 张里的 28 张 ⇒ `GET /api/settings/backup/export?type=all` 每次静默丢弃 `product_announcements`（产品横幅消失）、`announcement_dismissals`（已读公告重新弹出）、`model_name_redirects`（`source=manual` 行永不重生成）、`balance_history`（余额趋势从恢复日起空白）、`model_verify_history`（批量校验历史消失），而导入端回 200 报成功。
-- **备份文件自己陈述自己的缺口（#1172）**：导出 payload 的 `metadata` 新增 `excluded_tables`（表名 → 理由）；既有形状（`exported_at` / `version` / `type` / `tables`）与两条导入路径不变，WebDAV 往返与 TS v2.1 兼容层不受影响。**导入点名要一张被排除的表现在回 400**（此前静默忽略）；旧备份缺表＝跳过而不是错误。
-- **4 张表显式排除，理由进 metadata 与文档（#1172）**：`admin_sessions`（导入 token hash 会让源站签发的 cookie 在本站生效；**恢复后要求重新登录**）· `admin_audit_logs`（源站写操作的 append-only 轨迹）· `model_probe_results`（探针每 tick 重建，路由只取每 `(account, model)` 的最新一行）· `catalog_sources`（每行 `url` 由目录同步服务端抓取，而导入 URL 闸当时只覆盖 `sites` 与 `site_api_endpoints`）。
-- **更正上一版文档给的一条不存在的退路（#1172）**：`docs/api/settings.md` 曾写「需要就先导出备份」以保留审计与探测历史，而备份从来不含这两张表；现明确说明要用数据库工具自己 dump。
-- **库里一条读不出来的设置行不再清空已配置的值（#1173）**：`payload_rules` / `openai_service_tier_rules` / `checkin_schedule_mode` / `notify_task_toggles` 的水合分支把解析失败（解析器用 `nil` 编码）当值赋上去 ⇒ 一条坏行在下次重启时清空已配好的规则集且日志无字。现在坏行丢弃并告警；JSON `null` 与 `[]` 仍是可读的清空意图，照常生效。**启动日志因此可能新增 WARN 行。**
-- **每次启动都打的那条假 WARN 没有了（#1178）**：`setupSPAFallback` 还挂着 Vite 时代的 `/assets/*`，而内嵌 dist 自迁移起就没有该目录 ⇒ 挂载永不可达而守卫报警。同批立门禁：`index.html` 里每条 root-relative `src` / `href` 必须回 200 **且不得以 `text/html` 回来**（SPA fallback 对未挂载路径也答 `200 text/html`，正是把白屏藏在正常状态码后面的方式）。
+- **备份导出不再静默丢 5 张用户可见状态表（#1172）**：`/api/settings/backup/export?type=all` 曾静默丢弃 `product_announcements`、`announcement_dismissals`、`balance_history`、`model_name_redirects`、`model_verify_history`，导入端还回 200。
+- **备份文件自己陈述自己的缺口（#1172）**：导出 `metadata` 新增 `excluded_tables`（表名 → 理由）；既有 payload 形状与两条导入路径不变，WebDAV 往返与 TS v2.1 兼容层不受影响。**导入点名要一张被排除的表现在回 400**（此前静默忽略）；旧备份缺表＝跳过。显式排除 4 张，其中 `admin_sessions` 意味着**恢复后要求重新登录**。
+- **库里一条读不出来的设置行不再清空已配置的值（#1173）**：`payload_rules` / `openai_service_tier_rules` / `checkin_schedule_mode` / `notify_task_toggles` 的坏行此前在下次重启时清空已配好的规则集且日志无字。**启动日志因此可能新增 WARN 行。**
+- **每次启动都打的那条假 WARN 没有了（#1178）**：SPA fallback 还挂着一个内嵌 dist 里根本不存在的目录挂载点，守卫因此长期报警。
+- **更正上一版文档给的一条不存在的退路（#1172）**：`docs/api/settings.md` 曾写「需要就先导出备份」以保留审计与探测历史，而备份从来不含这两张表。
 
 ### 开发者可见
 
-- **CI 必选分片此前跑 0 个测试仍全绿（#1175）**：`test-sqlite-shard` 的分片算术写错，错误又恰好落在 `set -e` 管不到的条件里 ⇒ 约三十个 tag 的 SQLite 测试与 `-race` 实际未执行；现在断言本片应得的包数——选少了和选不到一样红（不变量见 `docs/testing.md`）。e2e 备份用例的「导出应有多少张表」改从注册表取值（那曾是第四份手抄清单）。
+- **CI 必选分片 `test-sqlite-shard` 此前跑 0 个测试仍全绿（#1175）**：分片算术写错而错误落在 `set -e` 管不到的条件里，约三十个 tag 的 SQLite 测试与 `-race` 实际未执行；现在断言本片应得的包数——选少了和选不到一样红。
 
 ### 已知遗留
 
@@ -92,32 +95,33 @@ Metapi-Go 的版本叙事。格式基于 [Keep a Changelog](https://keepachangel
 
 ### 安全
 
-- **转发链客户端 IP 改为从右往左解析（#1161）**：配置 `TRUSTED_PROXY_CIDRS` 时不再取 `X-Forwarded-For` 最左值（那一段由调用方自己塞），而是把所有转发头按序拼成链、补上直接 peer，再从最右往左跳过可信 CIDR，返回第一个不可信地址。修掉三个后果：admin IP 白名单可被一个伪造头绕过、每 IP 限流可无限换桶、审计日志记的是攻击者自选 IP。
-- **账号写路径不再回显明文凭据（#1163）**：`PUT /api/accounts/{id}` 与 `POST /api/accounts/{id}/rebind-session` 此前原样返回 `accessToken`、`apiToken` 与 `extraConfig.autoRelogin.passwordCipher` ⇒ 一次 `{"sortOrder": 7}` 空操作更新就能读出整库凭据；两个写响应现在与列表共用 `service.RedactAccountSecrets`。**凭据发放面刻意保留回显**（`POST /api/accounts/login`、`POST /api/accounts/verify-token`）；取回**已存**密钥仍是显式动作（`GET /api/account-tokens/{id}/value`、下游密钥导出）。规则写进 `docs/api/accounts.md`。
+- **转发链客户端 IP 改为从右往左解析（#1161）**：配置 `TRUSTED_PROXY_CIDRS` 时不再取 `X-Forwarded-For` 最左值（那一段由调用方自己塞）。修掉三个后果：admin IP 白名单可被一个伪造头绕过、每 IP 限流可无限换桶、审计日志记的是攻击者自选 IP。
+- **账号写路径不再回显明文凭据（#1163）**：`PUT /api/accounts/{id}` 与 `POST /api/accounts/{id}/rebind-session` 此前原样返回 `accessToken`、`apiToken` 与自动重登密码密文，一次空操作更新就能读出整库凭据。
+- **刻意保留的回显面（#1163）**：凭据**发放**（`POST /api/accounts/login`、`POST /api/accounts/verify-token`）仍回显；取回**已存**密钥仍是显式动作（`GET /api/account-tokens/{id}/value`）。规则写进 `docs/api/accounts.md`。
 
 ### 修复
 
-- **流式请求的中断、截断与空内容不再记成功（#1159）**：此前只区分「idle 超时」与「其它一律正常结束」，内容级判定只写日志不记账 ⇒ 上游中途断连、被 `PROXY_MAX_STREAM_RESPONSE_BYTES` 截断、或返回命中 `PROXY_ERROR_KEYWORDS` 的错误体时，渠道健康度、`proxy_logs` 与终端指标全按成功记账。现在流结束原因分五类（正常／idle 超时／上游故障／被截断／客户端断开），状态、原因与 outcome 由同一个所有者决定。
-- **恢复出厂设置真的恢复到出厂（#1165）**：`POST /api/settings/maintenance/factory-reset` 此前遍历一份比 schema 少 9 张表的手抄清单，其中包含 `admin_sessions` ⇒ **重置前签发的每个 admin cookie 仍对一个空库有写权限**。现表清单从 schema 注册表派生，唯一排除项是 additive 迁移日志 `schema_migrations`。**重置成功后必须重新登录。**
-- **`cmd/migrate` 不再静默丢表（#1165）**：方言迁移（SQLite ↔ PostgreSQL）按另一份手抄清单只拷了 37 张表里的 20 张——命令正常退出、checksum 全匹配，17 张表的数据没被搬运。现在拷贝集、清空序、逐表列规格与建表序全部从同一个注册表派生；源库存在而 Go schema 未声明的列在拷贝前逐表打 Warning。
-- **`checkin_interval_hours` 的越界值不再被静默丢弃（#1166）**：库内该键此前「范围检查不通过就不赋值、不告警、还算已处理」，而 `CHECKIN_INTERVAL_HOURS` 走双侧钳制 ⇒ 库里存 30、进程用环境变量的值、`GET /api/settings/runtime` 回显第三个值。
-- **`GET /api/channels` 的快照缓存此前几乎从不命中（#1167）**：缓存只有一个槽位而键空间是多键的（无界视图 + 每个分页/状态筛选各一键），`page=1` 与 `page=2` 互相逐出，那条 fleet-wide 5-way JOIN 照跑。现改有界多键缓存（至多 16 键、FIFO 淘汰）；TTL、`?refresh=true`、`x-channels-snapshot-cache`、并发去重与失效语义未变。
+- **恢复出厂设置真的恢复到出厂（#1165）**：`POST /api/settings/maintenance/factory-reset` 此前遍历一份比 schema 少 9 张表的手抄清单，其中包含 `admin_sessions`，**重置前签发的每个 admin cookie 仍对一个空库有写权限**。现从注册表派生，唯一排除项是 `schema_migrations`。**重置成功后必须重新登录。**
+- **`cmd/migrate` 不再静默丢表（#1165）**：方言迁移（SQLite ↔ PostgreSQL）此前只拷了 37 张表里的 20 张——命令正常退出、checksum 全匹配；现拷贝集与建表序从 schema 注册表派生。
+- **流式请求的中断、截断与空内容不再记成功（#1159）**：上游中途断连、被 `PROXY_MAX_STREAM_RESPONSE_BYTES` 截断、或返回命中 `PROXY_ERROR_KEYWORDS` 的错误体时，渠道健康度、`proxy_logs` 与终端指标此前全按成功记账。
+- **`checkin_interval_hours` 的越界库值不再被静默丢弃（#1166）**：此前库存 30、进程用 `CHECKIN_INTERVAL_HOURS` 的值、`GET /api/settings/runtime` 回显第三个值。
+- **`GET /api/channels` 的快照缓存此前几乎从不命中（#1167）**：单槽位对多键空间，`page=1` 与 `page=2` 互相逐出；现有界多键，TTL、`?refresh=true` 与 `x-channels-snapshot-cache` 语义未变。
 
 ### 变更
 
-- **站点 `custom_headers` 里的 `Accept-Encoding` 不再可配（#1168）**：它关掉 net/http 的透明解压，答案以压缩字节进入解析 ⇒ 用量提取找不到 token（真实调用计零费）、`PROXY_ERROR_KEYWORDS` 扫压缩噪声（该失败的没失败）、流式分析器读不到 `data:` 事件（开 `PROXY_EMPTY_CONTENT_FAIL` 时健康 200 流被记成 502「空内容」）。现该头在装配侧被过滤，`gzip` / `deflate` 先解码再判定与计费，重构后的响应不再带 `Content-Encoding`。
-- **解不了的编码诚实上报，不猜（#1168）**：`br`、`zstd`、多层编码栈或解码失败时，响应体连同它自己的 `Content-Encoding` 原样转发（客户端仍能解），不解析、用量记为显式 `unknown`，关键字与空内容规则不在没人读过的字节上开火；每次这样处理打一条稳定文案的 WARN。文档同步 `docs/configuration.md` 与 `docs/api/proxy.md`。
-- **夹在两次上游调用之间的等待现在可以被取消（#1169）**：签到 transient 重试退避、同站点节奏等待与三个 OAuth onboard 轮询此前不看 context ⇒ 关机或每账号预算耗尽后 worker 仍睡完，并把睡完之后的那次上游调用照发。等待时长语义未动，只加可取消性；`POST /api/checkin/trigger` 是刻意例外（跑在请求 context 上）。
-- **Redis 共享计数器的补偿回滚不再每次上行脚本体（#1170）**：回滚挂在限流拒绝与失败补偿两条热路径上。现在先 `EVALSHA`，仅在服务器答 `NOSCRIPT`（重启、`SCRIPT FLUSH`、切副本）时回退一次 `EVAL`；原子语义（减量 + 非正数即删键自愈）不变，ACL 禁 scripting 的 Redis（`NOPERM`）降级为 `INCRBY`。
-- **文档成为可对账的参考（#1160）**：环境变量清单 ↔ 代码读取点、路由清单 ↔ router 注册逐条对账，由门禁守着（漂移即 CI 红）；`.env.example`、`docs/configuration.md`、`docs/api/**` 与实现不一致处按实现纠正。
+- **站点 `custom_headers` 里的 `Accept-Encoding` 不再可配（#1168）**：它关掉透明解压、答案以压缩字节进入解析——用量提取找不到 token（真实调用计零费）、`PROXY_ERROR_KEYWORDS` 扫压缩噪声、流式分析器读不到 `data:` 事件。现该头在装配侧被过滤，`gzip` / `deflate` 先解码再判定与计费。
+- **解不了的编码诚实上报，不猜（#1168）**：`br`、`zstd`、多层编码栈或解码失败时原样转发（客户端仍能解），不解析、用量记为显式 `unknown`，`PROXY_ERROR_KEYWORDS` 与 `PROXY_EMPTY_CONTENT_FAIL` 不在没人读过的字节上开火；每次这样处理打一条稳定文案的 WARN。
+- **夹在两次上游调用之间的等待现在可以被取消（#1169）**：签到重试退避、同站点节奏等待与三个 OAuth onboard 轮询此前不看 context，关机后 worker 仍睡完并照发下一次上游调用。`POST /api/checkin/trigger` 是刻意例外。
+- **Redis 共享计数器的补偿回滚不再每次上行脚本体（#1170）**：现先 `EVALSHA`、仅在服务器答 `NOSCRIPT` 时回退一次 `EVAL`；ACL 禁 scripting 的 Redis 降级为 `INCRBY`。
 
 ### 移除
 
-- **`HOME_PAGE_CONTENT`（#1166）**：`.env.example` 与 `docs/configuration.md` 不再列这个键——它在 Go 实现里从来没有读取点，数据库侧的孪生键与前端字段早已下线。设置了该变量的部署不会报错，但它本来就什么都没做（`SYSTEM_NAME` / `LOGO` / `FOOTER` / `ABOUT` 不受影响）。
+- **`HOME_PAGE_CONTENT`（#1166）**：不再有文档条目——它在 Go 实现里从来没有读取点。设置了该变量的部署不会报错，但它本来就什么都没做（`SYSTEM_NAME` / `LOGO` / `FOOTER` / `ABOUT` 不受影响）。
 
 ### 开发者可见
 
-- **PostgreSQL 门禁套件在复用同一个库时可重复运行（#1164）· `scripts/e2e/smoke.sh` 的站点解析与后端去重键一致（#1162）**：新增 `internal/pgtest.Reset`，全套 PG 门禁必须以 `-count=1 -tags=integration -p 1` 运行（共享库），已写进文档与 CI；`smoke.sh` 遇 `POST /api/sites` 409 时改按后端实际去重的 `(platform, url)` 找回已有站点，而不是按脚本自己的 `SITE_NAME`（此前站点名不同就让后续 login / account / models / balance / checkin 全线跳过并报失败）。
+- **文档成为可对账的参考（#1160）**：环境变量清单 ↔ 代码读取点、路由清单 ↔ router 注册逐条对账，漂移即 CI 红。
+- **PostgreSQL 门禁可在复用同一个库时重复运行（#1164）**：须 `-count=1 -tags=integration -p 1`。同批 `scripts/e2e/smoke.sh` 遇 `POST /api/sites` 409 时按后端真实去重键 `(platform, url)` 找回站点（#1162）。
 
 ## [v0.16.23] — 2026-09-03
 
@@ -126,16 +130,15 @@ Metapi-Go 的版本叙事。格式基于 [Keep a Changelog](https://keepachangel
 - **`USAGE_PROJECTION_INTERVAL_MS`（#1151）**：用量聚合的投影节奏（`proxy_logs` → 站点/模型汇总）可调，钳制 1000–3600000 ms，默认仍 5s。
 - **启动日志报出日志清理体制归属（#1156）**：一条 `settings: log retention regime` 给出 `regime`（`log_cleanup` / `legacy_fallback`）、`configured`、`source`（`db_settings` / `env_toggle` / `none`）、两个 toggle 与保留天数。
 
-### Changed
-
-- **`KeyAdmissionLimiter.Allow()` 贯穿请求上下文（#1152）· `store.GetDB()` 改原子指针（#1151）**：客户端已断开的请求不再耗完计数器超时、也不再占着该密钥的串行互斥锁把同密钥的其它请求排在后面；请求路径不再争一把全局库互斥锁（打开/迁移/切换仍串行）。
-
 ### Fixed
 
-- **老 PostgreSQL 库启动即失败（#1153）**：三个 BOOLEAN 列写了数字默认值（`sites.use_system_proxy`、`sites.post_refresh_probe_enabled`、`model_availability.is_manual`）⇒ 增量迁移 `ALTER TABLE … ADD COLUMN … BOOLEAN DEFAULT 0` 报 42804（`column … is of type boolean but default expression is of type integer`）。**全新库永远复现不了**，只有升上来的库会走到那一步。
-- **管理界面保存的运行时设置重启后静默失效（#1156）**：写侧入库、读侧没有水合分支——33 个键里 27 个重启后不生效，本版补齐；6 个进带理由的白名单（`db_type` / `db_url` / `db_ssl` 在水合前就被 bootstrap 消费，三个 `*_schedule_v2` 由迁移服务与排班端点自己读）。最贵的一条是 `admin_ip_allowlist`：**重启后控制面板的 IP 限制静默消失**。同族：三个凭据键（`auth_token` / `proxy_token` / `account_credential_secret`）写侧 JSON 编码、读侧只 `TrimSpace` ⇒ 轮换过的令牌重启后带引号进快照、常量时间比较必然失配；日志清理设置水合侧读 `log_cleanup.enabled` 而写侧只写 `log_cleanup_enabled` ⇒ 整块死码（统一到写侧拼写，点号留只读别名）；日志清理体制（新 cleanup 调度器还是 legacy `PROXY_LOG_RETENTION_DAYS` pruner 拥有日志表）曾被 settings 表里任意一行静默开启，顶掉显式配置的 `LOG_CLEANUP_CRON` / `LOG_CLEANUP_RETENTION_DAYS`；`system_name` / `logo` / `footer` / `about` / `server_address` 丢弃空值 ⇒ 清空的品牌信息重启后复活（凭据键的空值守卫保留）；`admin_ip_allowlist` 与 `proxy_error_keywords` 写库失败此前返回 200，**现返回 500**。
-- **共享准入的补偿回滚丢弃并发预占（#1154）**：Redis 回滚从两个往返（先减、非正再 `DEL`）改为单脚本原子完成——窗口期内别人预占的计数不再被一起删掉。
-- **界面批（#1155）**：导入站点后账号列表不刷新、行内开关不即时翻转（mutation 失效快照而表格读分页缓存 ⇒ 同一动作在 `/sites` 与 `/accounts` 两套答案，现改为失效查询工厂根 + 按分页前缀批量 patch）；三个 i18n 键在两个语言包里都不存在，界面渲染出裸键（`modelTester.error.sessionExpired`、`accounts.models.refreshFailed` / `manualFailed`）。
+- **老 PostgreSQL 库启动即失败（#1153）**：三个 BOOLEAN 列写了数字默认值（`sites.use_system_proxy`、`sites.post_refresh_probe_enabled`、`model_availability.is_manual`），增量迁移报 42804。**全新库永远复现不了**，只有升上来的库会走到那一步。
+- **管理界面保存的运行时设置重启后静默失效（#1156）**：写侧入库、读侧没有水合分支——33 个键里 27 个重启后不生效，本版补齐；6 个进带理由的白名单（`db_type` / `db_url` / `db_ssl` 在水合前就被消费，三个 `*_schedule_v2` 由迁移服务与排班端点自己读）。
+- **其中最贵的一条（#1156）**：`admin_ip_allowlist` 重启后**控制面板的 IP 限制静默消失**。同批三个凭据键（`auth_token` / `proxy_token` / `account_credential_secret`）写侧 JSON 编码、读侧只去空格，轮换过的令牌重启后必然比较失配。
+- **日志清理设置此前是整块死码（#1156）**：水合侧读的键名与写侧写的不一致，`LOG_CLEANUP_CRON` / `LOG_CLEANUP_RETENTION_DAYS` 配了不生效；清理体制（新调度器还是 legacy `PROXY_LOG_RETENTION_DAYS` pruner 拥有日志表）还曾被 settings 表里任意一行静默开启，顶掉显式配置。
+- **品牌与写失败语义（#1156）**：`system_name` / `logo` / `footer` / `about` / `server_address` 此前丢弃空值，清空的品牌信息重启后复活；`admin_ip_allowlist` 与 `proxy_error_keywords` 写库失败此前返回 200，**现返回 500**。
+- **并发批（#1154、#1152、#1151）**：Redis 补偿回滚改单脚本原子完成，窗口期内别人预占的计数不再被一起删掉；已断开的请求不再耗完准入计数器超时、也不再占着该密钥的串行锁；请求路径不再争一把全局库互斥锁。
+- **界面批（#1155）**：导入站点后账号列表不刷新、行内开关不即时翻转（同一动作在 `/sites` 与 `/accounts` 有两套答案）；三个 i18n 键在两个语言包里都不存在，界面渲染出裸键。
 
 ## [v0.16.22] — 2026-09-02
 
@@ -146,145 +149,141 @@ Metapi-Go 的版本叙事。格式基于 [Keep a Changelog](https://keepachangel
 
 ### Changed
 
-- **`/v1` 与上游之间的头策略（#1145）**：上行透传客户端协议开关 `anthropic-version`、`anthropic-beta`、`openai-beta`、`user-agent`、`x-stainless-*`（此前只带 `Content-Type` + 站点 `custom_headers` + 账号 token，Claude Code 的 prompt caching 与 fine-grained tool streaming 到不了上游）；下行改内容语义白名单，厂商指纹头（实测可见 `X-New-Api-Version`）与上游 `Set-Cookie` 不再泄漏，上游同名头也不再覆盖 metapi 自己的 `X-Request-Id`。
-- **`/v1` 写超时不再掐断慢响应（#1145）**：`Server.WriteTimeout`（60s）在请求头读完时即武装、因此也覆盖等待上游的时间，而缓冲派发上限是 `max(90s, 首字节窗口 ×2)` ⇒ 61~90s 之间返回的非流式响应在回写时被掐断（「拿到结果却连接被重置」）。现由专用中间件持有代理写期限。
-- **Redis 共享限流不再全局串行（#1147）**：配置 `REDIS_URL` 后此前是「全局一把锁 + 每命令一次 TCP 握手」；现改为 64 条 cache-line 对齐分片 + 连接复用 + 贯穿 ctx。**语义零漂移**：出错仍 fail-open 回落本地窗口，`over_rpm` / `over_tpm`、`Retry-After`、`UsedRPM` / `UsedTPM`、键命名空间与全部 env 名不变。
+- **`/v1` 与上游之间的头策略（#1145）**：上行透传 `anthropic-version`、`anthropic-beta`、`openai-beta`、`user-agent`、`x-stainless-*`（此前 Claude Code 的缓存到不了上游）；下行改内容语义白名单，厂商指纹头与上游 `Set-Cookie` 不再泄漏，也不再覆盖 metapi 自己的 `X-Request-Id`。
+- **`/v1` 写超时不再掐断慢响应（#1145）**：61~90s 之间返回的非流式响应此前在回写时被 60s 服务器写超时掐断（「拿到结果却连接被重置」）；现由专用中间件持有代理写期限。
+- **Redis 共享限流不再全局串行（#1147）**：配置 `REDIS_URL` 后此前是「全局一把锁 + 每命令一次 TCP 握手」。**语义零漂移**：出错仍 fail-open 回落本地窗口，错误码、`Retry-After` 与全部 env 名不变。
 - **`PROXY_VIDEO_TASK_RETENTION_DAYS` 默认 0 → 7（#1146）**：`0` 等于保留期调度器整条禁用、`proxy_video_tasks` 无界增长；`<=0` 仍是运维显式关闭，只是不再是默认。
 
 ### Fixed
 
-- **下游密钥的过期时间此前完全不生效（#1148）**：表单出站裸 `datetime-local` 串（形如 `2030-01-02T03:04`，无秒无时区），两处解析器都不认，而不可解析的过期时间会**跳过整个过期检查**——一把 2020 年就该过期的密钥仍能以 200 调 `/v1/models`（RFC3339 形式正确返回 403）。
-- **数据面 SSRF dial 级纵深（#1145）**：转发 transport 曾是裸 `net.Dialer`，校验通过后重新解析（DNS rebinding）仍可落到不同地址；现执行器、SSE 流 transport、两个兜底派发客户端与渠道健康探针统一挂 DNS 钉扎守卫。
-- **视频任务进程内缓存无界增长（#1146）**：`publicId → 上游视频 id`（含 sticky 渠道/账号 pin）的重写缓存曾是包级 map 且无驱逐；现按同一保留期旋钮做 TTL，驱逐在插入路径摊销触发，无后台 goroutine。
+- **下游密钥的过期时间此前完全不生效（#1148）**：表单出站是裸 `datetime-local` 串（形如 `2030-01-02T03:04`），两处解析器都不认，而不可解析的过期时间会**跳过整个过期检查**——一把 2020 年就该过期的密钥仍能以 200 调 `/v1/models`。
+- **内部正确性批（#1145、#1146）**：数据面补 dial 级 SSRF 纵深（DNS rebinding：校验通过后重新解析仍可落到不同地址）；视频任务的进程内重写缓存此前是无驱逐的包级 map，现按保留期做 TTL。
 
 ### Docs
 
-- `docs/api/proxy.md` 新增「Header policy (/v1 surface)」与「Timeouts (/v1 surface)」；`docs/api/conventions.md` 新增「Site upstream SSRF hardening (proxy data plane)」。
+- `docs/api/proxy.md` 新增「Header policy」与「Timeouts」两节；`docs/api/conventions.md` 新增站点上游 SSRF 加固一节。
 
 ## [v0.16.21] — 2026-09-02
 
 ### Added
 
-- **接管库时间戳归一化（#1142）**：启动迁移把 TS 时代写在 TEXT `*_at` / `*_until` 列里的 `'YYYY-MM-DD HH:MM:SS'` 重写为 RFC3339 UTC——两种格式混排时字典序比较失真（空格 0x20 排在 `T` 0x54 前）：`ORDER BY created_at` 错排、范围过滤边界失真、checkin 清扫把全部行当成同一时刻。
-- **`/v1` 错误契约文档（#1140）**：`docs/api/proxy.md` 新增「Error shape (/v1 surface)」（OpenAI 信封 + 完整 status/type/code 对照表）；admin 面（`/api/*`）平铺契约不变。
+- **接管库时间戳归一化（#1142）**：启动迁移把 TS 时代写在 TEXT `*_at` / `*_until` 列里的 `'YYYY-MM-DD HH:MM:SS'` 重写为 RFC3339 UTC——混排时字典序比较失真，`ORDER BY created_at` 错排、范围过滤边界失真、checkin 清扫把全部行当成同一时刻。
 
 ### Changed
 
-- **`/v1` 鉴权与限流错误对齐 OpenAI 信封（#1140）**：中间件裸 `{"error":"..."}` 统一为 `{"error":{message,type,code,request_id}}`；invalid key `403` → `401 authentication_error/invalid_api_key`（SDK 把 403 视为不可重试的权限错误、跳过换 key 路径），配额耗尽 `403` → `429 insufficient_quota`。
-- **`PROXY_MAX_STREAM_RESPONSE_BYTES` 默认 1MB → 64MB（#1141）**：推理模型长输出常态超 1MB，此前被中途截断且自定义错误事件多被 SDK 静默吞掉（表现为「回答戛然而止」）；上限保留为失控护栏。同批 SSE 响应补 `X-Accel-Buffering: no`，nginx 系反代不再缓冲首 token。
-- **死码清扫（#1137、#1138）**：Go 侧 14 项零引用生产码删除（oauth import 族、quota `Record*` 族、routing `PricingReference` 与四端口接口、`ClearChannelFailureState` 级联等；`/api/oauth/import` 保持文档化 UI-parity 桩）；web 侧 `web/scripts/oneoff/` 整目录删除，5 处手写 clipboard 收敛为共享 `copyText()`。
+- **`/v1` 鉴权与限流错误对齐 OpenAI 信封（#1140）**：裸 `{"error":"..."}` 统一为 `{"error":{message,type,code,request_id}}`；invalid key `403` → `401 authentication_error/invalid_api_key`，配额耗尽 `403` → `429 insufficient_quota`。
+- **`/v1` 错误契约文档（#1140）**：`docs/api/proxy.md` 新增「Error shape (/v1 surface)」（OpenAI 信封 + 完整 status/type/code 对照表）；admin 面（`/api/*`）平铺契约不变。
+- **`PROXY_MAX_STREAM_RESPONSE_BYTES` 默认 1MB → 64MB（#1141）**：推理模型长输出常态超 1MB，此前被中途截断且错误事件多被 SDK 静默吞掉（表现为「回答戛然而止」）。同批 SSE 响应补 `X-Accel-Buffering: no`，nginx 系反代不再缓冲首 token。
+- **死码清扫（#1137、#1138）**：Go 侧 14 项零引用生产码删除（`/api/oauth/import` 保持文档化 UI-parity 桩）；web 侧一次性脚本目录整体删除，5 处手写 clipboard 收敛为共享实现。
 
 ### Fixed
 
-- **SSRF 目标校验缺口（安全，#1139）**：站点批量导入（`POST /api/sites/import`）、原生备份导入、TS v2.1 备份导入三条路径绕过 `IsForbiddenSiteTargetURL` ⇒ 构造备份即可植入 `url=http://169.254.169.254/…` 的站点，配合下游密钥一次 `/v1` 请求回流云 metadata / IAM 内容。现三路径统一走同一个净化器。
-- **PostgreSQL 与路由注册批（#1141）**：`GET /v1/pricing` 曾在 `/v1` 组内注册绝对路径 ⇒ 文档承诺的路径一直 404、真实可达的是 `/v1/v1/pricing`；`catalogsync.CreateSource` 在 PG 必失败（pgx stdlib 不实现 `LastInsertId`），补 `RETURNING id` 方言分支；审计日志 `path LIKE ?` 双侧 `LOWER()` 对齐（SQLite 不敏感、PG 敏感）。
+- **SSRF 目标校验缺口（安全，#1139）**：站点批量导入（`POST /api/sites/import`）、原生备份导入、TS v2.1 备份导入三条路径绕过内网地址闸，构造备份即可植入指向云 metadata 的站点，配合下游密钥一次 `/v1` 请求回流 IAM 内容。现三路径统一走同一个净化器。
+- **PostgreSQL 与路由注册批（#1141）**：`GET /v1/pricing` 此前一直 404（真实可达的是 `/v1/v1/pricing`）；`catalog_sources` 写入在 PG 必失败；审计日志路径搜索在 PG 大小写敏感。
 
 ## [v0.16.20] — 2026-09-01
 
 ### Added
 
-- **运行事件结构化（checkin 事件族先行）**：`service/events` 类型化注册表（注册防重复、参数严格校验）；`WriteEvent` 在历史英文 title/message 之外新增 `title_key` + `params` JSON（notify / CSV / 历史行等非 UI 消费者字节级不变）。
-- **界面与无障碍批（#1097、#1026、#1072、#1073、#1080、#1087）**：叶子实体单行删除改 6 秒「撤销」窗口（真实删除延后到窗口关闭）；下游密钥凭证树形选择器（站点 → 账号 → 密钥三级勾选 `allowedCredentialRefs` / `excludedCredentialRefs`）；Ctrl/⌘+K 可直接执行动作；恢复出厂设置改 type-to-confirm（输入 `RESET` + 倒计时）；六个主图全部有 sr-only 数据表；i18n 双语键的 `{{变量}}` 集合必须一致。
+- **运行事件结构化（checkin 事件族先行）**：事件写路径在历史英文 title/message 之外新增 `title_key` + `params` JSON，notify / CSV / 历史行等非 UI 消费者字节级不变。
+- **界面与无障碍批（#1097、#1026、#1072、#1073、#1080、#1087）**：单行删除改 6 秒「撤销」窗口（真实删除延后到窗口关闭）；下游密钥凭证树形选择器（站点 → 账号 → 密钥三级勾选）；Ctrl/⌘+K 可直接执行动作；恢复出厂设置改 type-to-confirm（输入 `RESET` + 倒计时）；六个主图全部有 sr-only 数据表。
 
 ### Changed
 
-- **管理端大表服务端分页与筛选（#1075、#1077、#1122，issue #1108）**：账号、模型市场、渠道列表改服务端分页，`GET /api/channels` 新增 `status` 过滤与 `GET /api/channels/error-summary`；`GET /api/accounts` 新增 `q` / `status` / `site`（此前分页在服务端、筛选却在客户端，站点不在当前页时永远筛不出来），`total` 是筛选后计数、非法值 400。
-- **统一 400 错误体携带机器可读 `errorCode`（#1065）· 畸形凭证引用改显式 400（#1026）**：认证与会话 8 码、资源不存在 5 码、能力未实现/禁用 3 码、设置校验 1 码、加载失败族 1 码（覆盖 72 个调用点，见 `docs/api/conventions.md`）；`allowed/excludedCredentialRefs` 里的非对象、未知或缺失 `kind`、非正 `siteId` / `accountId`、`account_token` 缺 `tokenId` 不再被静默丢弃（对允许列表而言等于静默放宽策略）。
-- **`docs/api.md` 按域拆分为 `docs/api/*.md`（17 个文件）**：`docs/api.md` 保留为索引并以 stub 承接原标题，旧 `api.md#<anchor>` 深链继续解析。
-- **前端结构与界面形态批（#1099、#1084、#1095、#1082、#1123、#1124）**：事件标题 i18n 两份映射归一；三份 `createSectionRegistry` 克隆合一、8 个列表页手写的加载失败横幅 + 重试收进表格底座、站点表单改右侧抽屉、筛选与页码写入 URL、文案与行高校对。行为均不变。
+- **管理端大表服务端分页与筛选（#1075、#1077、#1122，issue #1108）**：账号、模型市场、渠道列表改服务端分页；`GET /api/channels` 新增 `status` 过滤与 `GET /api/channels/error-summary`；`GET /api/accounts` 新增 `q` / `status` / `site`（此前站点不在当前页就永远筛不出来），`total` 是筛选后计数。
+- **统一 400 错误体携带机器可读 `errorCode`（#1065）**：18 码覆盖 72 个调用点，清单见 `docs/api/conventions.md`。
+- **畸形凭证引用改显式 400（#1026）**：`allowed/excludedCredentialRefs` 里的非对象、未知或缺失 `kind`、非正 `siteId` / `accountId`、`account_token` 缺 `tokenId` 不再被静默丢弃（对允许列表而言等于静默放宽策略）。
+- **`docs/api.md` 按域拆分为 `docs/api/*.md`（17 个文件）**：原文件保留为索引并以 stub 承接原标题，旧深链继续解析。
 
 ### Fixed
 
-- **下游密钥凭证维度端到端修复（#1026）**：`auth.ExcludedCredentialRef` 的 JSON 标签是 snake_case，而管理端持久化形状是 camelCase ⇒ 代理路径解析不出运营刚配好的排除项。
-- **运行时设置的并发撕裂读（#1079）**：`RuntimeSettings` 迁移为不可变快照交换——此前约 25 个运行时写字段与热路径无锁读并存，并发下可能读到半更新状态（如代理 token 校验瞬时 401 抖动）。
-- **前端错误与本地化批（#1091、#1080、#1086、#1088、#1101、#1102、#1104）**：铃铛弹层不再裸渲染后端为兼容保留的英文 `label`；错误 toast 去重与状态感知本地化（502–504 不再泄漏 axios 英文原文）；列表加载失败改整块替换 + 内置重试；浅色主题对比度达 WCAG AA；landmark / `alt` / 空表头 / 重复日期 / 移动端头部 / 不可用态 delta 等修正；channels 页「响应延迟」列回到首屏。
+- **下游密钥凭证维度端到端修复（#1026）**：排除项的 JSON 标签是 snake_case 而管理端持久化形状是 camelCase，代理路径解析不出运营刚配好的排除项。
+- **运行时设置的并发撕裂读（#1079）**：约 25 个运行时写字段与热路径无锁读并存，并发下可能读到半更新状态（如代理 token 校验瞬时 401 抖动）；现改为不可变快照交换。
+- **前端错误与本地化批（#1082、#1084、#1086、#1088、#1091、#1095、#1099、#1101、#1102、#1104、#1123、#1124）**：错误 toast 去重与状态感知本地化（502–504 不再泄漏 axios 英文原文）；列表加载失败改整块替换 + 内置重试；浅色主题对比度达 WCAG AA；channels 页「响应延迟」列回到首屏；站点表单改右侧抽屉、筛选与页码写入 URL。
 
 ### Security
 
-- **SPA CSP 去 `style-src 'unsafe-inline'`**：收紧为 `'self' 'nonce-<per-request>' 'sha256-<toast-css>'`，其余 directive 不变；Go SPA fallback 每响应生成 16 字节随机 nonce 并注入 `<meta name="csp-nonce">`。
+- **SPA CSP 去 `style-src 'unsafe-inline'`**：收紧为 `'self'` + 每响应随机 nonce + 一处 toast CSS 哈希，其余 directive 不变。
 - **凭证导出遮罩改真占位符（#1080）**：不再以 CSS blur 伪掩码渲染（明文此前仍留在 DOM 与无障碍树中，读屏可读出），改为 `••••••••` 占位符 + `aria-hidden`。
 
 ## [v0.16.19] — 2026-08-29
 
 ### Security
 
-- **管理员会话模型重构（#1034、#1057）**：主 token 不再以明文存于浏览器 localStorage（原 12h 窗口）——登录改为 `POST /api/auth/login` 以主 token 换取服务端会话（`admin_sessions` 表），凭证经 HttpOnly + SameSite=Strict 的 `metapi_session` cookie 携带，库里只存 SHA-256 哈希，会话滑动续期。实时运维 WS 不再接受 `?token=<主 token>`，改由 `POST /api/auth/ws-ticket` 签发 60s 单次 ticket——主 token 从此不进 URL。
-- **失败认证纳入限速 + 敏感操作主 token 重确认（#1034、#1057）**：per-IP 限速中间件移至认证之前（401/403 不再绕过桶约束），`/api/auth/*` 另加严格桶。备份导出（下载与 WebDAV）、下游密钥导出、主 token 轮换要求 `X-Admin-Confirm-Token` 头重出示主 token（即使持有活跃会话），否则 403 `reauthRequired`；凭证导出对话框默认锁定遮罩、密钥默认遮罩显示、深链打开前显式确认。**这些操作从此需要多带一个头，自动化脚本要跟着改。**
+- **主 token 不再明文存于浏览器 localStorage（#1034、#1057）**：登录改为 `POST /api/auth/login` 换取服务端会话（`admin_sessions` 表），凭证经 HttpOnly + SameSite=Strict 的 `metapi_session` cookie 携带、库里只存 SHA-256 哈希、会话滑动续期。
+- **实时运维 WS 不再接受 `?token=<主 token>`（#1034、#1057）**：改由 `POST /api/auth/ws-ticket` 签发 60s 单次 ticket，主 token 从此不进 URL。
+- **失败认证纳入限速 + 敏感操作主 token 重确认（#1034、#1057）**：per-IP 限速中间件移至认证之前（401/403 不再绕过桶约束），`/api/auth/*` 另加严格桶。备份导出（下载与 WebDAV）、下游密钥导出、主 token 轮换要求 `X-Admin-Confirm-Token` 头，否则 403 `reauthRequired`。**这些操作从此需要多带一个头，自动化脚本要跟着改。**
 
 ### Added
 
-- **会话配置项（#1034、#1057）**：`ADMIN_SESSION_TTL_MINUTES`（默认 720）、`ADMIN_SESSION_COOKIE_SECURE`（默认 auto，按请求协议自适应）、`AUTH_RATE_LIMIT_RPS` / `AUTH_RATE_LIMIT_BURST`（默认 10/20），零配置即安全；`cmd/migrate` 携带 `admin_sessions`，会话跨 SQLite ↔ PostgreSQL 切换存活。
-- **上游账号健康监测全局开关（#1027、#1056）· 账号代理支持 SOCKS5（#1009、#1059）**：运行时设置 `checkinEnabled` / `balanceRefreshEnabled`（热生效、持久化）+ 环境变量 `CHECKIN_ENABLED` / `BALANCE_REFRESH_ENABLED`，模型可用性探测改运行时热停；账号 `proxyUrl` 接受 `socks5://` 与 `socks5h://`。
+- **会话配置项（#1034、#1057）**：`ADMIN_SESSION_TTL_MINUTES`（默认 720）、`ADMIN_SESSION_COOKIE_SECURE`（默认 auto）、`AUTH_RATE_LIMIT_RPS` / `AUTH_RATE_LIMIT_BURST`（默认 10/20）；`cmd/migrate` 携带 `admin_sessions`，会话跨 SQLite ↔ PostgreSQL 切换存活。
+- **上游账号健康监测全局开关（#1027、#1056）· 账号代理支持 SOCKS5（#1009、#1059）**：运行时设置 `checkinEnabled` / `balanceRefreshEnabled`（热生效、持久化）+ 环境变量 `CHECKIN_ENABLED` / `BALANCE_REFRESH_ENABLED`；`proxyUrl` 接受 `socks5://` 与 `socks5h://`。
 
 ### Fixed
 
-- **清空账号代理字段保存即清除（#1009、#1059）**：空值显式清除（前端清空后载荷省略 + 后端 `MergeExtraConfig` typed-nil 双因）；账号更新路径补 scheme 校验。
-- **调度器与并发批（#1061、#1052）· PostgreSQL 方言陷阱清扫（#1060）**：job panic 统一 recover、in-flight 标志锁外读竞态修复、`channel_recovery` / `backup_webdav` / `model_probe` 吞没的 DB 错误显性化、路由健康快速路径无锁读改 `RLock`；BOOLEAN 列整数字面量绑定重写（42804 / 22P02 类）、管理搜索 LIKE 双侧 `LOWER()`、静态方言门禁扩至全包（零迁移）。
+- **清空账号代理字段保存即清除（#1009、#1059）**：此前前端清空后载荷省略该字段、后端合并又把旧值留下。
+- **内部正确性批（#1061、#1052、#1060）**：job panic 统一 recover、in-flight 标志锁外读竞态修复、`channel_recovery` / `backup_webdav` / `model_probe` 吞没的 DB 错误显性化；PostgreSQL 方言陷阱清扫（BOOLEAN 整数字面量绑定、管理搜索 LIKE 大小写）。
 
 ### Changed
 
-- **管理读路径索引（#1054）· 出站 HTTP 客户端基线（#1058）· 构建配置与 UX 批（#1053、#1055）**：三个高频读路径加索引（300k 行实测最贵一条 17.9ms → 0.5ms），proxy-logs `LEFT` → `INNER`、marketplace N+1 批量化；15 处出站调用点统一 `internal/httpclient`（dial 30s / TLS 10s / idle 90s / 池 100-20）并由 AST 门禁拦截裸客户端；`rsbuild.config.ts` 成为唯一构建配置（删 `vite.config.ts`）、匿名大块拆为 `vendor-i18n` / `vendor-icons` / `vendor-core`；focus-ring 统一 token（≥3:1）、流量与成本图补 sr-only 摘要表。
+- **性能与基线批（#1054、#1058、#1053、#1055）**：三个高频管理读路径加索引（300k 行实测最贵一条 17.9ms → 0.5ms）；15 处出站调用点统一超时与连接池；`rsbuild.config.ts` 成为唯一构建配置（删 `vite.config.ts`）；focus-ring 统一 token、流量与成本图补 sr-only 摘要表。
 
 ## [v0.16.18] — 2026-08-29
 
 ### Added
 
 - **`PROXY_STREAM_IDLE_TIMEOUT_SEC`（默认 300，#1046）**：每转发一个 chunk 重置计时窗，窗口内无新 chunk 即中断卡死的流并按上游超时故障记录（渠道健康、失败日志、终态一致）。只约束 chunk 间隔、不约束流总时长；`0`、负数、非法值回退默认。
-- **`proxyRetryStatusRanges` / `proxyDisableStatusRanges`（#1049）**：运行时设置（设置页可编辑，`PUT /api/settings/runtime` 同契约）——retry 决定哪些上游状态码计为可重试的渠道故障，disable 决定哪些状态码在冷却升级之外直接禁用故障渠道（`enabled=false` + 人工覆盖标记）。
-- **`PUT /api/channels/batch` 部分更新（#1047）**：只写字段出现的、载荷校验（空批 / 超 1000 / 重复 id / 无可更新字段）、逐项真值返回；模型测试台批量对比出现失败行时提供「禁用失败渠道」动作（确认对话框列明数量与人工覆盖后果）。
-- **界面批（#1048、#1026、#1039、#1036）**：渠道页失败横幅 +「只看失败」经可分享的 `?status=` 进入仅失败视图（人工停用不计入）；密钥表单新增「上游站点限制」多选（留空 = 不限制，完整往返既有 `allowedSiteIds`）；CmdK 面板命中一键深链到实体本身；zh-CN 语言下站点表崩溃修复（`createdAt` 列对无效 Intl locale 的防护回退）。
+- **`proxyRetryStatusRanges` / `proxyDisableStatusRanges`（#1049）**：运行时设置（设置页可编辑，`PUT /api/settings/runtime` 同契约）——retry 决定哪些上游状态码计为可重试的渠道故障，disable 决定哪些状态码在冷却升级之外直接禁用故障渠道。
+- **`PUT /api/channels/batch` 部分更新（#1047）**：只写字段出现的、载荷校验（空批 / 超 1000 / 重复 id / 无可更新字段）、逐项真值返回；模型测试台出现失败行时提供「禁用失败渠道」动作。
+- **界面批（#1048、#1026、#1039、#1036）**：渠道页失败横幅 +「只看失败」经可分享的 `?status=` 进入仅失败视图；密钥表单新增「上游站点限制」多选（留空 = 不限制，完整往返既有 `allowedSiteIds`）；CmdK 面板命中一键深链到实体本身；zh-CN 语言下站点表崩溃修复。
 
 ### Fixed
 
-- **路由自动重建真值（#1024）**：`POST /api/routes/rebuild` 现在消费 `refreshModels`（默认 true：先批量刷新全部活跃账号的上游模型、单账号失败不中断整批，再重建通道）；完成提示读取真实统计并区分三态——成功（真实路由/通道数）、无路由可重建（引导先创建路由）、通道无变化（引导核对账号模型）。
+- **路由自动重建真值（#1024）**：`POST /api/routes/rebuild` 现在消费 `refreshModels`（默认 true：先批量刷新全部活跃账号的上游模型、单账号失败不中断整批，再重建通道）；完成提示读取真实统计并区分三态——成功、无路由可重建、通道无变化。
 
 ### Security
 
-- **CSP 收紧（#1041）**：内联 bootstrap 脚本外部化，移除 `unsafe-inline`。
-- **前端安全快赢批（#1037）**。
-
-### Changed
-
-- **前端体检快赢批**：构建（#1040）、可访问性（#1042、#1043）、卫生（#1044）、UX（#1045）。
+- **CSP 收紧（#1041）**：内联 bootstrap 脚本外部化，移除 `unsafe-inline`。同批前端安全、构建、可访问性、卫生与 UX 小修（#1037、#1040、#1042、#1043、#1044、#1045），无对外行为契约变化。
 
 ## [v0.16.17] — 2026-08-28
 
 ### Added
 
-- **协议转换快照回归套件（#1018）**：46 份手写夹具 + 快照锁死协议转换层——Gemini generateContent 请求转换（thoughtSignature 哨兵/工具调用/多模态占位/thinkingConfig 与 tool_choice 矩阵）、Responses 连续性策略与 reasoning 清洗决策表、响应/SSE usage 提取四形状与增量流解析（含 7 字节分块边界）、completions/embeddings/images 恒等契约；新增快照测试 harness（`GOLDEN_UPDATE=1` 重写，纪律入 `docs/testing.md`），零生产代码改动。
-- **行级探测健康条（#1020）**：渠道/账号表格新增探测历史健康条——新增只读端点 `GET /api/channels/probe-history` 与 `GET /api/accounts/probe-history`（`limit` 1–50 默认 20，单条窗口查询一次取回全表历史，无 N+1）；竖条按时间着色 success/failure/inconclusive/skipped，tooltip 汇总窗口成功率与平均延迟，键盘可达 + aria 摘要；批量查询未定显示占位、无历史如实标注。
-- **结构化冷却原因（#1019）**：`route_channels` 与 `oauth_route_unit_members` 新增 `cooldown_reason_code`/`cooldown_reason`/`cooldown_reason_at` 三可空列（additive step `sc2_025`，双方言 + 迁移工具携带）；9 码只增词表（`usage_limit`/`rate_limited`/`auth_error`/`upstream_error`/`client_error`/`timeout`/`network_error`/`probe_failure`/`unknown`），错误摘要净化并截断 200 runes；流量与探测失败双路径记录、全部清除点同步清原因；渠道页冷却/熔断徽章可点击，根因弹窗含本地化触发码、错误摘要、记录时间与剩余倒计时，旧数据如实显示「原因未记录」；`GET /api/channels` 新增三个 camelCase 字段（`docs/api.md` 同步）。
+- **行级探测健康条（#1020）**：渠道/账号表格新增探测历史健康条，配只读端点 `GET /api/channels/probe-history` 与 `GET /api/accounts/probe-history`（`limit` 1–50 默认 20）；竖条按时间着色，tooltip 汇总窗口成功率与平均延迟，键盘可达。
+- **结构化冷却原因（#1019）**：`route_channels` 与 `oauth_route_unit_members` 新增 `cooldown_reason_code` / `cooldown_reason` / `cooldown_reason_at` 三可空列（additive step `sc2_025`，双方言携带）；渠道页冷却/熔断徽章可点开根因弹窗，旧数据如实显示「原因未记录」。
+- **协议转换层加了 46 份夹具的快照回归套件（#1018）**：零生产代码改动。
 
 ## [v0.16.16] — 2026-08-28
 
 ### Added
 
-- **定时上游模型同步（#1005）**：新增 `MODEL_SYNC_CRON`（默认 `0 4 * * *`，每日 04:00）定期批量刷新全部活跃账号的上游模型列表；设置页 `modelSyncCron` 支持运行时热更新（校验拒绝非法 cron）；单账号失败不中断整批，批量完成后路由重建与缓存失效恰好整体发生一次。手工单账号刷新端点行为与响应载荷不变。
-- **上游代理超时可配置（#1009）**：新增五个 `PROXY_*_TIMEOUT_SEC` 环境变量——`PROXY_CONNECT_TIMEOUT_SEC`（默认 2）、`PROXY_TLS_HANDSHAKE_TIMEOUT_SEC`（10）、`PROXY_RESPONSE_HEADER_TIMEOUT_SEC`（30）、`PROXY_IDLE_CONN_TIMEOUT_SEC`（90）、`PROXY_REQUEST_TIMEOUT_SEC`（30）——按部署调优出站站点代理/上游请求超时；`0`/负数/非法值回退默认，未配置时零行为变化。
+- **定时上游模型同步（#1005）**：新增 `MODEL_SYNC_CRON`（默认 `0 4 * * *`，每日 04:00）定期批量刷新全部活跃账号的上游模型列表；设置页 `modelSyncCron` 支持运行时热更新；单账号失败不中断整批。手工单账号刷新端点行为与响应载荷不变。
+- **上游代理超时可配置（#1009）**：新增五个 `PROXY_*_TIMEOUT_SEC`（connect 2 / TLS handshake 10 / response header 30 / idle conn 90 / request 30 秒），非法值回退默认，未配置时零行为变化；完整变量名见 `docs/configuration.md`。
 
 ### Changed
 
-- **竞品研究文档**：新增 `docs/internal/analysis/competitor-study-2026-08.md`（new-api / axonhub / sub2api 对标与可执行建议），为后续波次提供方向输入。
+- **竞品研究文档（new-api / axonhub / sub2api 对标）**：已于 v0.18.0 随其余维护者过程史移出公开仓（#1194）。
 
 ## [v0.16.15] — 2026-08-27
 
 ### Fixed
 
-- **账号表单验证真值（#1007）**：inline token verification 与账号创建现在使用表单中尚未保存的 `platformUserId` / `proxyUrl`；显式表单代理覆盖站点、Resin 与系统代理，校验 `http(s)`/`socks` URL，创建后持久化 `extraConfig.proxyUrl`，非法值 fail-closed。
-- **Accounts 分页（#1008）**：URL 控制的页码选择不再被 TanStack 自动重置；真实表格回归测试确认第 2 页稳定渲染第 11–20 行。
+- **账号表单验证真值（#1007）**：inline token verification 与账号创建现在使用表单中尚未保存的 `platformUserId` / `proxyUrl`；显式表单代理覆盖站点、Resin 与系统代理，创建后持久化 `extraConfig.proxyUrl`，非法值 fail-closed。
+- **Accounts 分页（#1008）**：URL 控制的页码选择不再被表格库自动重置；第 2 页稳定渲染第 11–20 行。
 
 ## [v0.16.14] — 2026-08-27
 
 ### Changed
 
-- **账号 token 同步 UI 真值（#1002 后续）**：账号创建/登录后的 toast 如实报告后端 `tokenSyncStatus`/`tokenCount`/`tokenSyncMessage` 四态——synced 显示真实持久化计数、empty 提示暂无上游令牌、failed 降级为部分初始化警告（账号保留、可在令牌面板重试同步）、skipped/旧响应保持原引导文案；`/token-routes` CTA 在所有状态保留。
+- **账号 token 同步 UI 真值（#1002 后续）**：账号创建/登录后的 toast 如实报告后端 `tokenSyncStatus` / `tokenCount` / `tokenSyncMessage` 四态——synced 显示真实持久化计数、empty 提示暂无上游令牌、failed 降级为部分初始化警告、skipped 与旧响应保持原引导文案。
+- **failed 不是失败即回滚（#1002 后续）**：账号保留、可在令牌面板重试同步，`/token-routes` CTA 在所有状态保留。
 
 ## [v0.16.13] — 2026-08-25
 
 ### Added
 
-- **Session 账号 token 自动同步（#1002）**：账号创建/登录后经既有同步路径自动同步上游 token；响应报告真实持久化的 `tokenCount` 与 `tokenSyncStatus`/`tokenSyncMessage`；同步失败仅发出部分初始化警告并保留已验证账号，绝不回滚；API-key 连接显式跳过；移除硬编码 `tokenCount: 1`。
-- **账号 Models 面板（#998）**：账号详情新增 Models 面板——手工上游刷新、手工添加与显式移除模型、来源/可用性状态诚实呈现；刷新把可用性持久化到既有 owner，路由重建与缓存失效每次刷新动作恰好发生一次；上游失败诚实报告且无副作用。
+- **Session 账号 token 自动同步（#1002）**：账号创建/登录后自动同步上游 token，响应报告真实持久化的 `tokenCount` 与 `tokenSyncStatus` / `tokenSyncMessage`；同步失败仅发出部分初始化警告并保留已验证账号，绝不回滚；API-key 连接显式跳过。
+- **账号 Models 面板（#998）**：账号详情新增 Models 面板——手工上游刷新、手工添加与显式移除模型、来源/可用性状态诚实呈现；路由重建与缓存失效每次刷新动作恰好发生一次；上游失败诚实报告且无副作用。
 
 ## [v0.16.12] — 2026-08-25
 

--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -361,4 +362,163 @@ func resolveLinkTarget(root, linkingFileRel, target string) string {
 	dir := filepath.Dir(filepath.FromSlash(linkingFileRel))
 	resolved := filepath.ToSlash(filepath.Clean(filepath.Join(dir, filepath.FromSlash(target))))
 	return resolved
+}
+
+// --- CHANGELOG writing contract -------------------------------------------
+//
+// CHANGELOG.md states a writing contract at its top and then, twice, did not
+// keep it: entries grew back into incident reports carrying the forensic
+// mechanism, internal Go symbol names and duplicate copies of identifier
+// lists whose owner is docs/ (#1236 asserted untrue things about itself,
+// #1245 had grown back into the forensic record its own contract forbids).
+// Both were caught by a human reading the file, not by anything mechanical.
+// A prose-only contract that regressed twice is an absent gate, so the parts
+// of it that are decidable without judgement are decided here.
+//
+// Deliberately NOT enforced: whether a given entry is worth writing at all.
+// That is the judgement half of the contract and it stays with the reviewer.
+
+// changelogBulletBudget is the per-entry ceiling the contract states, in
+// runes (the file is mostly Chinese, where bytes would triple every count).
+// Two ways out when an entry does not fit: split it, or point at the doc that
+// owns the identifier list instead of copying it a second time.
+const changelogBulletBudget = 220
+
+// changelogContractFloor is the oldest version section the contract governs.
+// v0.16.12 and earlier predate it, are already terse, and the contract
+// promises to preserve them verbatim — so the length rule must not reach them
+// (two of those entries are 231 and 259 runes and are allowed to stay).
+var changelogContractFloor = [3]int{0, 16, 13}
+
+var (
+	changelogVersionRE = regexp.MustCompile(`^## \[v(\d+)\.(\d+)\.(\d+)\]`)
+	changelogSectionRE = regexp.MustCompile(`^### (.+)$`)
+	// The forensic-mechanism arrow: "the code did X ⇒ therefore the user saw
+	// Y" is the shape every over-long entry grew from. The reader needs the
+	// second half only; the first half is the commit body's job.
+	changelogForensicArrowRE = regexp.MustCompile(`⇒`)
+	// Internal Go symbols (`service.RedactAccountSecrets`). Table and column
+	// names stay legal: they are lowercase on both sides of the dot.
+	changelogInternalSymbolRE = regexp.MustCompile("`[a-z][a-z0-9_]*\\.[A-Z][A-Za-z0-9]*")
+	changelogGoFileRE         = regexp.MustCompile(`[a-z0-9_]+\.go\b`)
+	changelogTestNameRE       = regexp.MustCompile(`\bTest[A-Z][A-Za-z0-9]+`)
+)
+
+var changelogAllowedSections = map[string]bool{
+	"安全": true, "修复": true, "变更": true, "移除": true,
+	"开发者可见": true, "文档": true, "已知遗留": true,
+	"Added": true, "Changed": true, "Fixed": true, "Security": true,
+	"Docs": true, "Performance": true, "Accessibility": true,
+	"Deprecated": true, "Removed": true,
+}
+
+func TestChangelogStaysANarrativeNotAForensicRecord(t *testing.T) {
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "CHANGELOG.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(data), "\n")
+
+	var findings []string
+	sectionsGoverned, bulletsChecked, devVisibleSections := 0, 0, 0
+	version := [3]int{}
+	governed := false
+	// The contract preamble at the top of the file names the tokens it bans
+	// (`⇒` among them), so the entry rules only apply below the first version
+	// heading. Without this the gate reports the rule as a violation of itself.
+	inVersionSections := false
+
+	for i, line := range lines {
+		lineNo := i + 1
+		if m := changelogVersionRE.FindStringSubmatch(line); m != nil {
+			inVersionSections = true
+			version = [3]int{atoiOrZero(m[1]), atoiOrZero(m[2]), atoiOrZero(m[3])}
+			governed = versionCompare(version, changelogContractFloor) >= 0
+			if governed {
+				sectionsGoverned++
+			}
+			devVisibleSections = 0
+			continue
+		}
+		if m := changelogSectionRE.FindStringSubmatch(line); m != nil {
+			if !changelogAllowedSections[m[1]] {
+				findings = append(findings, formatFinding("CHANGELOG.md", lineNo, "unknown section heading "+m[1], line))
+			}
+			if m[1] == "开发者可见" {
+				devVisibleSections++
+				if devVisibleSections > 1 {
+					findings = append(findings, formatFinding("CHANGELOG.md", lineNo, "more than one 开发者可见 section in one version", line))
+				}
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "- ") || !inVersionSections {
+			continue
+		}
+		entry := strings.TrimPrefix(line, "- ")
+		bulletsChecked++
+		// The forensic markers are banned in every section, including the
+		// verbatim-preserved tail: it already contains none of them, so
+		// applying the rule file-wide costs nothing and stops the tail from
+		// becoming a place to hide them.
+		for _, check := range []struct {
+			re   *regexp.Regexp
+			what string
+		}{
+			{changelogForensicArrowRE, "forensic mechanism arrow (belongs in the commit body)"},
+			{changelogInternalSymbolRE, "internal Go symbol (belongs in the commit body)"},
+			{changelogGoFileRE, "Go file name (belongs in the commit body)"},
+			{changelogTestNameRE, "Go test name (belongs in the commit body)"},
+		} {
+			if m := check.re.FindString(entry); m != "" {
+				findings = append(findings, formatFinding("CHANGELOG.md", lineNo, check.what+" -> "+m, line))
+			}
+		}
+		if governed && utf8RuneLen(entry) > changelogBulletBudget {
+			findings = append(findings, formatFinding("CHANGELOG.md", lineNo,
+				"entry is "+strconv.Itoa(utf8RuneLen(entry))+" runes, budget is "+strconv.Itoa(changelogBulletBudget)+
+					": split it, or point at the doc that owns the identifier list", line))
+		}
+	}
+
+	// Same invariant as the two gates above: a budget nobody is measured
+	// against is not a lenient gate, it is no gate. Both counters can be
+	// zeroed independently — the version regex drifting means sectionsGoverned
+	// collapses to 0 while bulletsChecked stays high, and a file whose entries
+	// all lost their "- " prefix collapses the other one.
+	if sectionsGoverned == 0 {
+		t.Fatal("gate would pass vacuously: no CHANGELOG version section matched changelogVersionRE or the contract floor")
+	}
+	if bulletsChecked == 0 {
+		t.Fatal("gate would pass vacuously: no CHANGELOG entries were examined")
+	}
+	if len(findings) > 0 {
+		t.Fatalf("CHANGELOG.md violates its own writing contract (%d version sections governed, %d entries examined):\n%s",
+			sectionsGoverned, bulletsChecked, strings.Join(findings, "\n"))
+	}
+}
+
+func atoiOrZero(s string) int {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func versionCompare(a, b [3]int) int {
+	for i := range a {
+		if a[i] != b[i] {
+			if a[i] < b[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+func utf8RuneLen(s string) int {
+	return len([]rune(s))
 }


### PR DESCRIPTION
**Observed failure: none from a deployed user.** Admission basis: operator instruction to ablate `CHANGELOG.md` under the neat-freak philosophy, plus this file having regressed twice and both times being caught by a human reading it rather than by anything mechanical — #1236 (three things the file asserted about itself were untrue) and #1245 (the version narrative had grown back into the forensic record its own contract forbids).

## 1. What was actually wrong

Not the wording. The file had a **length cliff**: v0.9.0–v0.16.12 entries median 28–92 runes, v0.16.13–v0.19.0 median 192 and longest **744**. Same file, two different disciplines.

And the contract at the top already forbade exactly what the content did:

> 一条 = 一行结论 + 至多一句因果 … 取证过程、测试与门禁的形状、行数增减、内部文件清单不进本文件

Measured over the governed region before this PR: 21 forensic `⇒` arrows, 9 internal Go symbol names (`service.RedactAccountSecrets`, `store.GetDB`, `proxy.ExplainNoChannel` …), and second copies of identifier lists whose owner is `docs/` **and is already guarded by a parity gate**.

The previous compression round set the verbatim-preservation boundary at v0.16.17 — which is the single densest version in the file (median 308). The boundary was protecting the worst offender.

## 2. Three levers, none of them rewording

| | before | after |
|---|---|---|
| entries | 108 | 110 |
| runes | 21799 | 15553 (**−29%**) |
| median entry | 192 | 144 |
| longest entry | 744 | **220** |
| `⇒` | 21 | **0** |
| `pkg.Symbol` | 9 | **0** |

**a. Point instead of copy.** An env-var list, an errorCode table and a cooldown-reason vocabulary each have exactly one owner in `docs/`. The changelog was a second copy, and a second copy has to be long. It now names the knob and cites the owner.

**b. Aggregate by family.** Same root cause / same batch collapses into one `××批（#a、#b、#c）`; `开发者可见` is capped at one section per version, because this file's reader deploys and calls Metapi and is not the reader of gate design.

**c. Enforce it.** `TestChangelogStaysANarrativeNotAForensicRecord` decides the part of the contract that needs no judgement. Whether an entry is worth writing at all stays with the reviewer — the test says so in a comment instead of pretending to decide it.

Entry count went **up** by two. That is the honest result: entries that fell out of budget after the fact restorations were *split*, not trimmed.

## 3. The first cut removed too much, and the audit caught it

I am not presenting a clean arc. The first pass hit −37% by cutting into the contract's one non-negotiable class ("要运维动手的必须显式写"). A conservation audit diffing the governed region against the pre-pass snapshot caught all of it:

- deleted endpoints written as prose (`/api/update-center/check`, `PUT /config`, `/deploy`, `/rollback`, `/tasks/{id}/stream`)
- `api_token`, `schema_migrations`, `value_status`, `x-channels-snapshot-cache`
- quota error codes `over_requests` / `over_cost` / `key_expired`
- `CHECKIN_INTERVAL_HOURS`, `PROXY_LOG_RETENTION_DAYS`, `PROXY_EMPTY_CONTENT_FAIL`, `RESPONSES_COMPACT_FALLBACK_TO_RESPONSES_ENABLED`, `SYSTEM_NAME`/`LOGO`/`FOOTER`/`ABOUT`
- `EXPECT_SERVER_COMMIT` — **which has no documentation owner anywhere in the repo**, so dropping it would have orphaned the fact
- the literal `duplicate key value violates unique constraint "sites_pkey"` that an operator greps for
- `Integrity check failed`, the string a contributor greps when a required check goes red

All restored. Final conservation over the governed region:

| class | before | after | verdict |
|---|---|---|---|
| issue/PR numbers | 132 | **132** | zero loss |
| product-emitted literals | 27 | **27** | zero loss |
| endpoints | 41 | 40 | the one is `docs/api/**`, a doc glob, not an endpoint |
| env-shaped tokens | 100 | 74 | every loss is a SQL/protocol keyword, or a registered pointer |
| snake_case identifiers | 83 | 70 | 9 cooldown codes → `docs/api/routes.md`; 3 error codes → `docs/api/proxy.md` |

**Every "point at the owner" exemption is grep-verified by the audit**: it opens the claimed owner file and fails if the token is not in it. A claimed pointer that does not resolve is worse than a long entry.

## 4. Mutation probe — the gate must be able to go red

11 arms, run against the committed tree, each materialised with `git show <rev>:CHANGELOG.md` (never `git checkout --`):

| arm | mutation | expect | got | reason the test gave |
|---|---|---|---|---|
| A | none (baseline) | GREEN | GREEN | `ok` |
| B | pad a governed entry to 294 runes | RED | RED | `entry is 294 runes, budget is 220` |
| C | insert `⇒` | RED | RED | `forensic mechanism arrow` |
| D | insert `` `store.PruneProbeResults` `` | RED | RED | `internal Go symbol` |
| E | insert `scheduler/retention.go` | RED | RED | `Go file name` |
| F | insert `TestRetentionPrunesProbeResults` | RED | RED | `Go test name` |
| G | rename a section to `观测与遥测` | RED | RED | `unknown section heading` |
| H | add a second `开发者可见` to one version | RED | RED | `more than one 开发者可见 section` |
| I | strip `[` from every version heading | RED | RED | `gate would pass vacuously: no version section matched` |
| J | turn every `- ` into `* ` | RED | RED | `gate would pass vacuously: no entries were examined` |
| K | 250-rune entry **below** the floor (v0.16.12) | GREEN | GREEN | boundary is real, not "everything red" |

A second pass re-ran arms B–J capturing the *reason line*, because "red" alone cannot distinguish the intended rule firing from an unrelated parse error. Both logs are in the private layer.

The 220 budget deliberately does not reach v0.16.12 and earlier: the contract promises those verbatim, and two of them are 231 and 259 runes. The gate's floor **is** that boundary, so the promise and the rule cannot drift apart silently.

## 5. Two harness defects, disclosed

1. **I ran the probe before committing.** Its `restore` step does `git show HEAD:CHANGELOG.md > CHANGELOG.md`, which wiped 11 uncommitted fact restorations. This is exactly what the "commit before probes" rule exists for and I broke it. Recovery was not a retype: the restorations are now a single idempotent script keyed on entry anchors (`apply-restorations.py`, 28 edits, re-runnable), so the final state is reproducible from the committed tree rather than from my scrollback. Post-recovery metrics differ from pre-loss by 5 runes out of 15558, and the audit re-passes identically.
2. **The audit's first tokenizer split backtick contents on whitespace**, turning `` `column … is of type integer` `` into `of`/`is`/`integer` and burying real losses under 65 fragments. Replaced with four targeted classes (endpoints / env / snake_case / whole tokens), then the whole-token class was dropped as the wrong shape and replaced by an explicit list of product-emitted literals — a distinct contract class, pinned item by item.
3. The gate's first run failed on the contract preamble itself, which names `⇒` as a banned token. Correct finding, wrong scope: the preamble is the rule, not an entry. Entry rules now apply only below the first version heading.

## 6. Found by this audit, deliberately not fixed here

`over_requests` and `over_cost` — two of the eight downstream-admission reasons in `auth/downstream.go`, and precisely the two a caller receives as `429` when exceeding `maxRequests` / `maxCost` — appear in **no** documentation. Their six siblings (`missing`, `invalid`, `disabled`, `expired`, `over_rpm`, `over_tpm`) are all in `docs/api/proxy.md`. The env-var and route-inventory families have parity gates; this family has none, which is why the gap survived.

That is a separate finding with its own root cause, so it is recorded rather than folded into this PR.

## 7. Verification

- `go test ./docs/ -count=1` → `ok` (whole package, not just the new test)
- `gofmt -l docs/` → empty
- `go vet ./docs/` → clean
- conservation audit → `PASS：治理区内无未登记的运维事实丢失；所有「指向 owner」豁免均已当场验证`
- 38 version sections intact; v0.16.12-and-earlier tail byte-identical to before
- release-body forbidden-token scan over the whole file → clean
- `scripts/release.sh` and the tag-time extractor are unaffected: the `## [vX.Y.Z]` heading shape is untouched, and published release pages are snapshots, so they do not change

No release — accumulates into v0.19.1 per Law 3.
