### PR TITLE
fix(platform): sub2api invented a "default" group when it could not reach the upstream, and the invention beat the truthful fallback

### DIFF
--- a/platform/oneapi_test.go
+++ b/platform/oneapi_test.go
@@ -310,17 +310,24 @@ func TestOneApiAdapter_GetAPITokens(t *testing.T) {
 	}
 }
 
-func TestOneApiAdapter_GetUserGroupsDefault(t *testing.T) {
+// Renamed from TestOneApiAdapter_GetUserGroupsDefault, which accepted "error or
+// [\"default\"]" and so could not fail: one-api has carried the terminalError
+// guard since before this test was written, so an unreachable upstream has only
+// ever produced an error. Accepting both is what let the same shape go
+// unguarded in sub2api unnoticed — the family contract was written down here as
+// "either is fine".
+func TestOneApiAdapter_GetUserGroups_UnreachableIsAFailureNotADefaultGroup(t *testing.T) {
 	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	// On unreachable URL, terminalError from failed HTTP propagates as error
-	_, err := o.GetUserGroups(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Logf("GetUserGroups error on unreachable (expected): %v", err)
+	groups, err := o.GetUserGroups(ctx, unreachableBaseURL(t), "token", nil, nil)
+	if err == nil {
+		t.Fatalf("want an error, got groups=%#v — a failure to ask was reported as an answer", groups)
 	}
-	// Either way: error or ["default"] is acceptable
+	if groups != nil {
+		t.Fatalf("want nil groups alongside the error, got %#v", groups)
+	}
 }
 
 // `false, nil` means "the upstream answered and refused", which is why a failed

--- a/platform/sub2api.go
+++ b/platform/sub2api.go
@@ -315,17 +315,48 @@ func pickKeyForGroup(tokens []ApiTokenInfo, group string) *string {
 }
 
 // GetUserGroups: 5 endpoint fallback + key-based inference.
+// GetUserGroups asks the upstream which groups exist.
+//
+// ["default"] is this family's last resort, not an answer: newapi and oneapi
+// both reach it only after every rung answered and none of them refused. This
+// adapter used to reach it unconditionally, so an unreachable site, an expired
+// credential or an upstream refusal all reported a group the upstream never
+// advertised. That is worse here than elsewhere, because the caller prefers any
+// non-blank upstream answer over the fallback it already has — so the fabricated
+// "default" beat GetLocalTokenGroups' truthful DISTINCT token_group, and the
+// operator saw one invented group instead of the real ones.
+//
+// The refusal message this now surfaces was already written and already
+// unreachable for sub2api accounts: resolveGroupFetchErrorMessage renders an
+// expired session as "账号会话可能已过期，请重新登录后再拉取分组".
 func (s *Sub2ApiAdapter) GetUserGroups(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) ([]string, error) {
 	normalized := normalizeBaseURL(baseURL)
 
-	directGroups := s.listGroups(ctx, normalized, accessToken, proxy)
+	// The two rungs are a preference order — ask the group endpoint, else derive
+	// from existing keys — so the FIRST reason is kept, the decision
+	// modelFetchLadder documents. The opposite of the version-skew ladders inside
+	// each rung, which keep the last. Both differences are deliberate; do not
+	// "unify" them.
+	var terminalError string
+
+	directGroups, err := s.listGroups(ctx, normalized, accessToken, proxy)
+	if err != nil {
+		terminalError = err.Error()
+	}
 	if len(directGroups) > 0 {
 		return directGroups, nil
 	}
 
-	inferredFromKeys := s.inferGroupsFromKeys(ctx, normalized, accessToken, proxy)
+	inferredFromKeys, err := s.inferGroupsFromKeys(ctx, normalized, accessToken, proxy)
+	if err != nil && terminalError == "" {
+		terminalError = err.Error()
+	}
 	if len(inferredFromKeys) > 0 {
 		return inferredFromKeys, nil
+	}
+
+	if terminalError != "" {
+		return nil, fmt.Errorf("%s", terminalError)
 	}
 
 	return []string{"default"}, nil

--- a/platform/sub2api_group_test.go
+++ b/platform/sub2api_group_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -182,5 +183,234 @@ func TestFetchModelsByToken_CtxCancelledMidLoop(t *testing.T) {
 	// ctx.Err() check should break before hitting the server again.
 	if got := atomic.LoadInt32(&hitCount); got > 1 {
 		t.Fatalf("expected at most 1 endpoint hit after mid-loop cancel, got %d", got)
+	}
+}
+
+// --- GetUserGroups: a failure to ask is not an answer ----------------------
+//
+// The discovery path had no coverage at all (this file pinned pickKeyForGroup
+// and parseSub2ApiUserGroup only), which is how an unconditional ["default"]
+// survived: the caller, GetTokenGroups, prefers any non-blank upstream answer
+// over the local fallback it already has, and the service-level test for that
+// fallback (TestGetTokenGroups_FallbackOnErrorEmptyNilAdapter) can only run when
+// an adapter returns an error. This one never did.
+
+// sub2GroupsStub serves every path the two ladders try. Paths absent from the
+// map answer 404, which is what a version-skewed upstream does to the paths it
+// does not have.
+func sub2GroupsStub(t testing.TB, byPath map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := byPath[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":404,"message":"not found"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func sub2GroupPaths() []string {
+	return []string{
+		"/api/v1/groups/available",
+		"/api/v1/groups",
+		"/api/v1/group",
+		"/api/v1/keys",
+		"/api/v1/api-keys",
+	}
+}
+
+func sub2AllPaths(body string) map[string]string {
+	out := make(map[string]string)
+	for _, p := range sub2GroupPaths() {
+		out[p] = body
+	}
+	return out
+}
+
+func TestSub2ApiAdapter_GetUserGroups_FailureIsNotADefaultGroup(t *testing.T) {
+	const sessionRewrite = "账号会话可能已过期，请重新登录后再拉取分组"
+	cases := []struct {
+		name       string
+		baseURL    func(t testing.TB) string
+		wantSubstr string
+	}{
+		{
+			// The reported defect: nothing was reachable, and the operator got a
+			// group the upstream never advertised.
+			name:       "unreachable",
+			baseURL:    unreachableBaseURL,
+			wantSubstr: "fetch groups",
+		},
+		{
+			name: "refused with a reason",
+			baseURL: func(t testing.TB) string {
+				return sub2GroupsStub(t, sub2AllPaths(`{"code":1,"message":"groups endpoint refused"}`)).URL
+			},
+			wantSubstr: "groups endpoint refused",
+		},
+		{
+			// sub2api's own fixtures use a string code, which the numeric
+			// code==0 check never treated as success — so this shape used to
+			// parse to nothing and fall through to ["default"].
+			name: "string code UNAUTHORIZED",
+			baseURL: func(t testing.TB) string {
+				return sub2GroupsStub(t, sub2AllPaths(`{"code":"UNAUTHORIZED","message":"authorization header is required"}`)).URL
+			},
+			wantSubstr: "authorization header is required",
+		},
+		{
+			// The message the family already wrote for an expired session, and
+			// that a sub2api account could never reach.
+			name: "expired session reaches the family message",
+			baseURL: func(t testing.TB) string {
+				return sub2GroupsStub(t, sub2AllPaths(`{"code":1,"message":"未登录"}`)).URL
+			},
+			wantSubstr: sessionRewrite,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			groups, err := a.GetUserGroups(ctx, tc.baseURL(t), "token", nil, nil)
+			if err == nil {
+				t.Fatalf("want an error, got groups=%#v — a failure to ask was reported as an answer", groups)
+			}
+			if groups != nil {
+				t.Fatalf("want nil groups alongside the error, got %#v", groups)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("error %q does not carry %q", err.Error(), tc.wantSubstr)
+			}
+			for _, invented := range []string{"default"} {
+				for _, g := range groups {
+					if g == invented {
+						t.Fatalf("fabricated %q group survived", invented)
+					}
+				}
+			}
+		})
+	}
+}
+
+// The other face of the same defect: an upstream that really has no groups must
+// still be told the truth, so ["default"] stays reachable when — and only when —
+// something answered.
+func TestSub2ApiAdapter_GetUserGroups_AnsweredEmptyIsStillTrue(t *testing.T) {
+	srv := sub2GroupsStub(t, sub2AllPaths(`{"code":0,"data":[]}`))
+	a := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	groups, err := a.GetUserGroups(ctx, srv.URL, "token", nil, nil)
+	if err != nil {
+		t.Fatalf("an answered empty is a true statement, want nil error, got %v", err)
+	}
+	if len(groups) != 1 || groups[0] != "default" {
+		t.Fatalf("want the family's last resort [\"default\"], got %#v", groups)
+	}
+}
+
+// A 404 on an older path is version skew, not a failure: the predicate is
+// "did anything answer", not "did anything error".
+func TestSub2ApiAdapter_GetUserGroups_VersionSkewIsNotAFailure(t *testing.T) {
+	srv := sub2GroupsStub(t, map[string]string{
+		"/api/v1/groups": `{"code":0,"data":[{"id":7,"name":"vip"}]}`,
+	})
+	a := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	groups, err := a.GetUserGroups(ctx, srv.URL, "token", nil, nil)
+	if err != nil {
+		t.Fatalf("version skew must not become a failure: %v", err)
+	}
+	if len(groups) == 0 {
+		t.Fatalf("want the groups the upstream advertised, got %#v", groups)
+	}
+}
+
+// The predicate is "did anything answer", not "did anything error", and the case
+// that separates them is a deployment where one alternative 404s and another
+// answers with an empty list. Without this the two predicates are
+// indistinguishable: when some rung does return groups the ladder returns early
+// and never reaches the check at all (which is what VersionSkewIsNotAFailure
+// covers), so a mutation of `!answered && lastReason != ""` to
+// `lastReason != ""` went unnoticed until the probe tried it.
+func TestSub2ApiAdapter_GetUserGroups_AnsweredEmptyAlongsideAFailedAlternativeIsNotAFailure(t *testing.T) {
+	srv := sub2GroupsStub(t, map[string]string{
+		// /api/v1/groups/available and /api/v1/group are absent -> 404, the way a
+		// version without those paths answers.
+		"/api/v1/groups":   `{"code":0,"data":[]}`,
+		"/api/v1/api-keys": `{"code":0,"data":[]}`,
+	})
+	a := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	groups, err := a.GetUserGroups(ctx, srv.URL, "token", nil, nil)
+	if err != nil {
+		t.Fatalf("one alternative 404ing must not become a failure when another answered: %v", err)
+	}
+	if len(groups) != 1 || groups[0] != "default" {
+		t.Fatalf("want the family's last resort [\"default\"], got %#v", groups)
+	}
+}
+
+// Preference order is preserved: ask the group endpoint first, derive from
+// existing keys second.
+func TestSub2ApiAdapter_GetUserGroups_FallsBackToInferringFromKeys(t *testing.T) {
+	srv := sub2GroupsStub(t, map[string]string{
+		"/api/v1/groups":   `{"code":0,"data":[]}`,
+		"/api/v1/group":    `{"code":0,"data":[]}`,
+		"/api/v1/keys":     `{"code":0,"data":[{"id":1,"group_id":3}]}`,
+		"/api/v1/api-keys": `{"code":0,"data":[]}`,
+	})
+	a := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	groups, err := a.GetUserGroups(ctx, srv.URL, "token", nil, nil)
+	if err != nil {
+		t.Fatalf("GetUserGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0] != "3" {
+		t.Fatalf("want the group id inferred from keys, got %#v", groups)
+	}
+}
+
+// The two rungs are a preference order, so the FIRST reason is the one reported
+// — the group endpoint is the question the operator actually asked. The ladders
+// inside each rung keep the last, because those endpoints are equivalent
+// version-skew alternatives. Both are deliberate.
+func TestSub2ApiAdapter_GetUserGroups_KeepsTheFirstReason(t *testing.T) {
+	srv := sub2GroupsStub(t, map[string]string{
+		"/api/v1/groups/available": `{"code":1,"message":"groups rung refused"}`,
+		"/api/v1/groups":           `{"code":1,"message":"groups rung refused"}`,
+		"/api/v1/group":            `{"code":1,"message":"groups rung refused"}`,
+		"/api/v1/keys":             `{"code":1,"message":"keys rung refused"}`,
+		"/api/v1/api-keys":         `{"code":1,"message":"keys rung refused"}`,
+	})
+	a := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := a.GetUserGroups(ctx, srv.URL, "token", nil, nil)
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	if !strings.Contains(err.Error(), "groups rung refused") {
+		t.Fatalf("want the first rung's reason, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "keys rung refused") {
+		t.Fatalf("the second rung's reason displaced the first: %q", err.Error())
 	}
 }

--- a/platform/sub2api_groups.go
+++ b/platform/sub2api_groups.go
@@ -6,7 +6,16 @@ import (
 	"strings"
 )
 
-func (s *Sub2ApiAdapter) listGroups(ctx context.Context, baseURL, accessToken string, proxy *ProxyConfig) []string {
+// listGroups asks the group endpoints. The five endpoints are version-skew
+// alternatives of the same question, so — exactly as listAPIKeys documents for
+// its two — the reason kept is the LAST one: any of them is representative, and
+// a 404 on an older path must not become the verdict when a newer path replies.
+//
+// The returned error is nil whenever at least one endpoint actually answered,
+// including when the answer was "there are no groups". An answered empty is a
+// true statement about the upstream; turning it into a failure would be the same
+// defect wearing the other face.
+func (s *Sub2ApiAdapter) listGroups(ctx context.Context, baseURL, accessToken string, proxy *ProxyConfig) ([]string, error) {
 	endpoints := []string{
 		"/api/v1/groups/available",
 		"/api/v1/groups?page=1&page_size=100",
@@ -16,19 +25,48 @@ func (s *Sub2ApiAdapter) listGroups(ctx context.Context, baseURL, accessToken st
 	}
 
 	headers := authBearerHeaders(accessToken)
+	answered := false
+	var lastReason string
 	for _, endpoint := range endpoints {
 		resp, err := fetchJSON(ctx, baseURL+endpoint, "GET", nil, headers, proxy)
 		if err != nil {
+			lastReason = err.Error()
 			continue
 		}
 
+		if reason, refused := s.groupEnvelopeRefusal(resp); refused {
+			lastReason = reason
+			continue
+		}
+
+		answered = true
 		parsed := s.tryParseEnvelope(resp)
 		groups := s.parseGroupItems(parsed)
 		if len(groups) > 0 {
-			return groups
+			return groups, nil
 		}
 	}
-	return nil
+	if !answered && lastReason != "" {
+		return nil, fmt.Errorf("fetch groups: %s", lastReason)
+	}
+	return nil, nil
+}
+
+// groupEnvelopeRefusal separates "the upstream answered" from "the upstream
+// refused". sub2api's success code is numeric 0; anything else carrying a `code`
+// — a non-zero number, or a string code such as "UNAUTHORIZED" — is a refusal
+// whose `message` the family already knows how to render. A payload with no
+// `code` key at all is one of the bare array/list shapes parseGroupItems accepts
+// and counts as an answer.
+func (s *Sub2ApiAdapter) groupEnvelopeRefusal(resp map[string]interface{}) (string, bool) {
+	code, ok := resp["code"]
+	if !ok {
+		return "", false
+	}
+	if f, isFloat := code.(float64); isFloat && f == 0 {
+		return "", false
+	}
+	return resolveGroupFetchErrorMessage(resp), true
 }
 
 func (s *Sub2ApiAdapter) tryParseEnvelope(resp map[string]interface{}) map[string]interface{} {
@@ -112,26 +150,42 @@ func (s *Sub2ApiAdapter) parseGroupItems(payload map[string]interface{}) []strin
 	return groups
 }
 
-func (s *Sub2ApiAdapter) inferGroupsFromKeys(ctx context.Context, baseURL, accessToken string, proxy *ProxyConfig) []string {
+// inferGroupsFromKeys derives the group list from the keys that already exist,
+// for upstreams that expose no group endpoint. Same answered/refused split as
+// listGroups, and the same last-reason choice for the same reason: the two
+// endpoints are version-skew alternatives.
+func (s *Sub2ApiAdapter) inferGroupsFromKeys(ctx context.Context, baseURL, accessToken string, proxy *ProxyConfig) ([]string, error) {
 	endpoints := []string{
 		"/api/v1/keys?page=1&page_size=100",
 		"/api/v1/api-keys?page=1&page_size=100",
 	}
 
 	headers := authBearerHeaders(accessToken)
+	answered := false
+	var lastReason string
 	for _, endpoint := range endpoints {
 		resp, err := fetchJSON(ctx, baseURL+endpoint, "GET", nil, headers, proxy)
 		if err != nil {
+			lastReason = err.Error()
 			continue
 		}
 
+		if reason, refused := s.groupEnvelopeRefusal(resp); refused {
+			lastReason = reason
+			continue
+		}
+
+		answered = true
 		parsed := s.tryParseEnvelope(resp)
 		groupIDs := s.parseGroupIDsFromTokenPayload(parsed)
 		if len(groupIDs) > 0 {
-			return groupIDs
+			return groupIDs, nil
 		}
 	}
-	return nil
+	if !answered && lastReason != "" {
+		return nil, fmt.Errorf("fetch groups from keys: %s", lastReason)
+	}
+	return nil, nil
 }
 
 func (s *Sub2ApiAdapter) parseGroupIDsFromTokenPayload(payload map[string]interface{}) []string {

--- a/platform/sub2api_test.go
+++ b/platform/sub2api_test.go
@@ -307,18 +307,12 @@ func TestSub2ApiAdapter_ResolveModelEndpoints(t *testing.T) {
 	}
 }
 
-func TestSub2ApiAdapter_GetUserGroups(t *testing.T) {
-	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
-	ctx := context.Background()
-
-	groups, err := s.GetUserGroups(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(groups) != 1 || groups[0] != "default" {
-		t.Errorf("GetUserGroups on unreachable should return ['default'], got %v", groups)
-	}
-}
+// TestSub2ApiAdapter_GetUserGroups used to live here and asserted that an
+// unreachable upstream returns ["default"] with no error — it pinned the defect
+// as the contract, which is why the fabrication survived. Its one scenario is
+// now the "unreachable" arm of
+// TestSub2ApiAdapter_GetUserGroups_FailureIsNotADefaultGroup in
+// sub2api_group_test.go, with the expectation inverted.
 
 // sub2apiKeyUpstream stands in for a sub2api version: `allow` decides which of the
 // two version-dependent endpoint families exists, and every other path 404s the way


### PR DESCRIPTION
**Observed failure: none from a deployed user.** Admission basis is Law 6 plus the exhaustive census that followed #1244 — this was the single entry in its 31-row adjudication left as "candidate, unscheduled", and it closes the last of the three families that census opened (tokens #1244/#1246/#1247 · model discovery #1248 · groups: this).

## The finding

`Sub2ApiAdapter.GetUserGroups` ran two ladders that both swallow everything, then returned `[]string{"default"}, nil` unconditionally. Five group endpoints and two key endpoints could all fail — unreachable site, expired credential, an upstream refusal — and the answer was still a group nobody advertised.

## Why it is worse than a wrong string

The consequence is not in the adapter. `GetTokenGroups` prefers any non-blank upstream answer over the fallback it already has, so `hasValue` was true and **the fabricated `"default"` beat `GetLocalTokenGroups`' truthful `DISTINCT token_group`**. The operator saw one invented group instead of the real ones.

That caller is correct and is tested — `TestGetTokenGroups_FallbackOnErrorEmptyNilAdapter` pins "adapter error → local groups" against real rows — and it could never run for a sub2api account, because this adapter never returned an error. A truthful fallback that an untruthful adapter makes unreachable.

## The fix follows the family, not a new shape

newapi and oneapi both keep a `terminalError` and reach `["default"]` only when every rung answered and none refused. sub2api was the **only fetcher** missing it, so this brings it to the pattern its two siblings already had, and reuses the family's `resolveGroupFetchErrorMessage` instead of writing a second message shaper.

Two reason-keeping decisions, both already documented in this package, both deliberate, so neither is "unified" here:

| scope | keeps | why | precedent |
|---|---|---|---|
| inside a rung | **last** reason | the endpoints are version-skew alternatives of one question; a 404 on an older path is not a verdict | `listAPIKeys` |
| across the two rungs | **first** reason | a preference order — ask the group endpoint, else derive from keys — and the group endpoint is what the operator asked | `modelFetchLadder.fail` (#1248) |

The predicate is **"did anything answer"**, not "did anything error". An answered `{"code":0,"data":[]}` still yields `["default"]` with no error, because an answered empty is a true statement and turning it into a failure would be the same defect wearing the other face. A refusal is not an answer: sub2api's own fixtures use a string code (`{"code":"UNAUTHORIZED",...}`), which the numeric `code == 0` check never treated as success, so that shape used to parse to nothing and fall through.

One user-facing string becomes reachable that was already written: an expired session now surfaces `账号会话可能已过期，请重新登录后再拉取分组` instead of an invented group.

## Tests

The discovery path had **zero** coverage — `sub2api_group_test.go` pinned `pickKeyForGroup` and `parseSub2ApiUserGroup` only, which is how this survived. Six new tests: failure is not a default group (4 arms: unreachable · refused with a reason · string-code `UNAUTHORIZED` · expired session reaching the family message) · answered empty is still true · version skew is not a failure · answered-empty-alongside-a-404 is not a failure · preference order falls back to inferring from keys · first reason is kept (asserting the second rung's reason does **not** displace it).

**Two existing tests were wrong and are changed**, both inside this finding's family:

- `TestSub2ApiAdapter_GetUserGroups` asserted that an unreachable upstream returns `["default"]` with no error — it **pinned the defect as the contract**. Deleted; its one scenario is the "unreachable" arm of the new table with the expectation inverted, so no coverage is lost.
- `TestOneApiAdapter_GetUserGroupsDefault` accepted "error or `["default"]`" and therefore **could not fail**: one-api has carried the `terminalError` guard since before that test was written, so unreachable has only ever produced an error. Renamed and tightened. Writing the family contract down as "either is fine" is what let the unguarded sibling go unnoticed.

Capability declarations are untouched and stay correct: `BaseAdapter.GetUserGroups` returns `["default"]` **without making a request**, and `AnyRouterAdapter` inherits it. A platform with no group concept answering "default" is a statement about the platform; a fetcher answering "default" for a site it never reached is a lie.

## Mutation probe — 7 arms, each names the test that must notice

| arm | decision removed | expect red | got |
|---|---|---|---|
| A | none (baseline, 11 passes) | — | OK |
| B | whole production fix reverted to master | Failure… + KeepsTheFirstReason | OK |
| C | only `GetUserGroups`' terminalError exit | Failure… + KeepsTheFirstReason | OK |
| D | refusals no longer detected as refusals | Failure… + KeepsTheFirstReason | OK |
| E | rungs keep **last** instead of first reason | KeepsTheFirstReason only | OK |
| F | predicate becomes "did anything error" | AnsweredEmptyAlongsideAFailedAlternative only | OK |
| G | one-api's pre-existing guard removed | the tightened one-api test only | OK |

Arm G is the proof the tightened test can now fail; arm F is the proof the `answered` predicate has a test that discriminates it.

## Two harness defects found by the probe, disclosed

1. **ARM F initially reported "no test discriminated this" and that was false.** Removing the `!answered` half leaves `answered` write-only, Go refuses to build, `go test` emits no `--- FAIL` lines, and the harness read "nothing ran" as "(none) = all green". It presented *the arm never executing* as *the tests having no discriminating power* — the same shape as a SKIP masquerading as a PASS. Fixed both sides: the mutation now carries an explicit `_ = answered` so it stays a semantic mutation, and the harness separates `BUILD-FAILED` / `NO-TESTS-RAN(pass=n)` / `(none)` into three distinct verdicts.
2. **That fix then needed its own negative proof**, or the new verdict path is dead code: raising the pass-count baseline from the measured 11 to 99 makes arm A report `NO-TESTS-RAN(pass=11) MISMATCH` instead of a benign `(none)`. Recorded in the probe log.
3. ARM F also exposed a **real gap in my test set**, not just in the harness: `VersionSkewIsNotAFailure` returns early as soon as a rung yields groups, so it never reaches the predicate. The case the predicate exists for — one alternative 404s, another answers empty — was unpinned. That is the sixth test above.

Local gates: `gofmt` clean on the five files touched (the four `platform/` files `gofmt -l` flags are pre-existing and not mine) · `go vet ./platform/` clean · `go test ./platform/ ./service/... ./handler/...` all ok.

No release — accumulates into v0.19.1 per Law 3.
