### PR TITLE
docs(changelog): named two internal enum values as the wire codes a caller would receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@ Metapi-Go 的版本叙事。格式基于 [Keep a Changelog](https://keepachangel
 
 ### Added
 
-- **三个配额字段的语义（#1148）**：`maxRequests` / `maxCost` / `expiresAt` 是累计总量而非每分钟窗口（每分钟限速是另一组 `max_rpm` / `max_tpm`）、金额单位 USD 且仅成功请求计费、超限 429（`over_requests` / `over_cost`）、过期 403（`key_expired`）、留空或 0 ＝不限制。
+- **三个配额字段的语义（#1148）**：`maxRequests` / `maxCost` / `expiresAt` 是累计总量而非每分钟窗口（每分钟限速是另一组 `max_rpm` / `max_tpm`）、金额单位 USD 且仅成功请求计费、超限 429（`insufficient_quota`）、过期 403（`key_expired`）、留空或 0 ＝不限制。
 - **界面批（#1148）**：仪表盘四步旅程清单（站点 → 账号 → 路由 → 密钥，CTA 只挂在第一个缺口、四步建成后自我退役）；已有路由但下游密钥数为 0 时就地提示怎么签发第一把密钥并用它调用 `/v1`，签发后永久消失。
 
 ### Changed


### PR DESCRIPTION
**Observed failure: none from a deployed user, and none from the file's own gate** — the gate checks length and forensic markers, not whether an identifier is actually reachable by the reader. Caught by re-reading the mapping afterwards.

## The error

The v0.16.22 entry on the three quota fields told a caller that exceeding `maxRequests` / `maxCost` yields 429 with `over_requests` / `over_cost`.

Those are `Reason` values internal to `auth/downstream.go`. `proxyAuthErrorClass` maps both to `("insufficient_quota", "insufficient_quota")`, so the envelope a caller actually receives is:

```json
{"error": {"type": "insufficient_quota", "code": "insufficient_quota", ...}}
```

— which `docs/api/proxy.md` has documented in its status table all along (row: *Budget exhausted (`maxCost` / `maxRequests`)*). A caller branching on `over_requests` would be branching on a string that never leaves the process.

`over_rpm` / `over_tpm` / `key_expired` in the same entry **are** real wire codes and stay.

## How it got here, and why it matters more than one token

#1249's conservation audit classifies identifiers **by shape**, and an internal enum has the same snake_case shape as a wire code — `over_requests` and `over_rpm` look alike and only the second is documented. The audit's default verdict for an unregistered loss is FAIL, which pushed toward *restoring* the two tokens rather than *checking whether they reach a user surface*.

They were restored, and the misreading then propagated into two private artifacts:

| where | what it said | status |
|---|---|---|
| `CHANGELOG.md` (public) | caller receives `over_requests` / `over_cost` | **fixed here** |
| `STATE.md` candidate | "two quota error codes have no documentation owner … this family has no parity gate, which is why the gap survived" | retracted, with the reason kept rather than silently deleted |
| `RELEASE-v0.19.1-DRAFT.md` 已知遗留 | same claim | deleted — **this one would have shipped to users** as a statement that two error codes are undocumented |

There is no gap and no gate is needed. `insufficient_quota` is documented; the two strings are internal.

## Re-checked the rest rather than assuming

Since one "this identifier is user-visible" judgement was wrong, the other thirteen identifiers restored in the same round were verified mechanically against production (non-test) sources:

`value_status` (DB column, `service/account_token_service.go`) · `x-channels-snapshot-cache` (response header, `handler/admin/channels.go`) · `masked_pending` (service + tokens panel UI) · `ignoredTables` (`handler/admin/settings_backup.go`) · `prunedRouteIds` / `staleRouteIds` (`handler/admin/downstream_keys.go`) · `legacy_fallback` / `env_toggle` / `db_settings` (startup-log values, `store/settings.go`) · `EXPECT_SERVER_COMMIT` (`web/scripts/acceptance-e2e.mjs`) · `insufficient_quota` / `authentication_error` (`auth/proxy_errors.go`) · `over_rpm` (`auth/key_admission.go`).

**13/13 are on a user surface.** The misreading was this one entry.

## The rule this leaves behind

Recorded where the next audit will be run: every "user-visible identifier" exemption must answer **which surface it reaches** — response body field, response header, DB column, startup log, env var, or UI copy. An identifier that cannot answer is internal, whatever its shape.

This is the same limitation `law6-census/ast-census` already wrote down about itself ("the fetcher column is a hint, not a conclusion; every verdict was read by hand") and the same reason that probe's ARM F first reported a false negative. **Tools propose; the verdict is a human's.** Third time this window.

## Verification

- `go test ./docs/ -count=1` → `ok`
- conservation audit re-run against this branch: `编号 132→132` · `产品字面量 27→27` · snake_case `70 → 68` · **未登记 0** · both new exemptions grep-verified against `auth/proxy_errors.go`, so what is verified is that the *mapping* exists, not merely that the string appears somewhere
- entry stays inside the 220-rune budget (187)

No release — accumulates into v0.19.1 per Law 3.
