### PR TITLE
refactor: three declared vocabularies had no consumer, and two ablations said which of the six candidates were worth touching

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -360,7 +360,7 @@ func parseJsonValue(value string) any {
 // §1.6 parseDbType: "" → "sqlite"; trim+lower → "mysql"/"postgres"/"postgresql" → "postgres"; else "sqlite".
 func parseDbType(value string) string {
 	if value == "" {
-		return "sqlite"
+		return DefaultDbType
 	}
 	normalized := strings.ToLower(strings.TrimSpace(value))
 	switch normalized {
@@ -369,7 +369,7 @@ func parseDbType(value string) string {
 	case "postgres", "postgresql":
 		return "postgres"
 	default:
-		return "sqlite"
+		return DefaultDbType
 	}
 }
 
@@ -381,7 +381,7 @@ func inferDbType(value string, dbURL string) string {
 	if strings.HasPrefix(normalizedURL, "postgres://") || strings.HasPrefix(normalizedURL, "postgresql://") {
 		return "postgres"
 	}
-	return "sqlite"
+	return DefaultDbType
 }
 
 func normalizeDbSslMode(value string) string {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -26,7 +26,14 @@ const (
 
 	DefaultPort    = 4000
 	DefaultDataDir = "./data"
-	DefaultDbType  = "sqlite"
+	// DefaultDbType is the dialect used when DB_TYPE is unset/unrecognized and
+	// DB_URL is not a PostgreSQL URL. It is the single in-repo owner of that
+	// fallback: docs/configuration.md documents the same default, and the env
+	// parity gate compares key sets rather than default values (#1237), so this
+	// constant is the only handle on it. The mapped spellings "postgres"/"mysql"
+	// in parseDbType stay literals — the cross-package owner is store.Dialect*,
+	// which config cannot import without a cycle.
+	DefaultDbType = "sqlite"
 
 	// DefaultLogLevel is the slog threshold applied at startup when LOG_LEVEL
 	// is unset or invalid. "info" preserves the pre-config behavior so the

--- a/handler/admin/settings_notify.go
+++ b/handler/admin/settings_notify.go
@@ -27,7 +27,7 @@ func testNotify(w http.ResponseWriter, r *http.Request) {
 		rt,
 		"Test notification",
 		"This is a connectivity test notification from system settings; your notification configuration is working correctly!",
-		"info",
+		string(notify.LevelInfo),
 		&notify.SendNotificationOptions{
 			BypassThrottle: true,
 			RequireChannel: true,

--- a/handler/admin/site_announcements.go
+++ b/handler/admin/site_announcements.go
@@ -559,7 +559,7 @@ func buildAnnouncementMessage(row platform.SiteAnnouncement) string {
 func defaultLevel(level string) string {
 	level = strings.TrimSpace(level)
 	if level == "" {
-		return "info"
+		return string(notify.LevelInfo)
 	}
 	return level
 }

--- a/platform/adapter.go
+++ b/platform/adapter.go
@@ -25,15 +25,6 @@ import (
 	"encoding/json"
 )
 
-// CredentialMode indicates the credential type preference.
-type CredentialMode int
-
-const (
-	CredentialAuto    CredentialMode = iota // auto-detect (session first, then apikey)
-	CredentialSession                       // only session token
-	CredentialAPIKey                        // only API key
-)
-
 // ProxyConfig carries optional proxy settings for a single request.
 type ProxyConfig struct {
 	ProxyURL      string

--- a/platform/adapter_test.go
+++ b/platform/adapter_test.go
@@ -146,11 +146,6 @@ func TestTypeDefinitions(t *testing.T) {
 	if pc.ProxyURL != "socks5://proxy:1080" {
 		t.Error("ProxyConfig.ProxyURL mismatch")
 	}
-
-	// CredentialMode
-	if CredentialAuto != 0 || CredentialSession != 1 || CredentialAPIKey != 2 {
-		t.Error("CredentialMode values mismatch")
-	}
 }
 
 func intPtr(i int) *int { return &i }

--- a/service/alert/alert.go
+++ b/service/alert/alert.go
@@ -74,7 +74,7 @@ func ReportTokenExpired(cfg *config.RuntimeSettings, db *sqlx.DB, params TokenEx
 
 	// Send notification
 	notifypkg.SendNotification(cfg, "Token expired", message,
-		"error", &notifypkg.SendNotificationOptions{TaskTag: "token_expired"})
+		string(notifypkg.LevelError), &notifypkg.SendNotificationOptions{TaskTag: "token_expired"})
 }
 
 // LowBalanceParams holds parameters for reportLowBalance.
@@ -129,7 +129,7 @@ func ReportLowBalance(cfg *config.RuntimeSettings, db *sqlx.DB, params LowBalanc
 	service.CreateEvent(db, "balance", "Low balance", msg, "warning",
 		params.AccountID, "account")
 
-	notifypkg.SendNotification(cfg, "Low balance", msg, "warning",
+	notifypkg.SendNotification(cfg, "Low balance", msg, string(notifypkg.LevelWarning),
 		&notifypkg.SendNotificationOptions{TaskTag: "low_balance"})
 }
 
@@ -179,7 +179,7 @@ func ReportProxyAllFailed(cfg *config.RuntimeSettings, db *sqlx.DB, params Proxy
 		message, "error", 0, "route")
 
 	notifypkg.SendNotification(cfg, "All proxies failed", message,
-		"error", &notifypkg.SendNotificationOptions{TaskTag: "proxy_all_failed"})
+		string(notifypkg.LevelError), &notifypkg.SendNotificationOptions{TaskTag: "proxy_all_failed"})
 
 	_ = createdAt // already used above
 }

--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -623,7 +623,7 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 				notifypkg.SendNotification(config.RuntimeSafe(),
 					"Cloudflare challenge",
 					fmt.Sprintf("%s @ %s: %s", orUsername(account.Username, accountID), site.Name, result.Message),
-					"warning", nil,
+					string(notifypkg.LevelWarning), nil,
 				)
 			}
 
@@ -631,7 +631,7 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 				notifypkg.SendNotification(config.RuntimeSafe(),
 					"checkin failed",
 					fmt.Sprintf("%s @ %s: %s", orUsername(account.Username, accountID), site.Name, result.Message),
-					"error", nil,
+					string(notifypkg.LevelError), nil,
 				)
 			}
 		}


### PR DESCRIPTION
refactor: three declared vocabularies had no consumer, and two ablations said which of the six candidates were worth touching

Observed failure: none from a deployed user. Admission basis is the same one
#1234 / #1239 / #1253 used — a census that proves zero consumers — plus two
ablation runs that killed half the candidate list before any edit was made.

## The census

`deadcode` was the obvious instrument and does not run here: whole-program RTA
over 97k lines of production Go is OOM-killed on this node's 4 GiB / 2 vCPU, and
GOMEMLIMIT=1500MiB GOGC=40 does not save it (rc=137 both times). So the
instrument is the shape this repository already uses: a one-pass identifier
index over `git ls-files '*.go'`, counting each top-level exported declaration's
references in non-test files (minus its own declaration sites) and in test files.

367 production files / 486 test files / **1728 top-level exported declarations**
→ **DEAD 1** (zero references anywhere) and **TESTONLY 26** (nothing in
production names them). Script + JSON: `.dev-local/…/go-deadcensus/`.

The census only produces candidates. Every one was read; 22 of 27 are kept, and
the reasons are at the bottom.

## Ablation 1 — rename the declared value, see who notices

Mutated three declarations (`auth.CredentialRefAccountToken` "account_token" →
"accountToken", `config.DefaultDbType` "sqlite" → "postgres",
`notify.LevelWarning` "warning" → "warn"), built, and ran the six packages that
own or consume them.

Two of my three hypotheses were **wrong**, which is the only reason to run the
experiment instead of asserting it:

- `auth` went **red** — `TestParseExcludedCredentialRefs_Valid` and
  `TestGetManagedKeyByToken_CredentialRefsRoundtrip` pin the constant against
  the wire literal.
- `service/notify` went **red** — `TestNotificationLevels` pins `LevelWarning`.
- `config` stayed **green** — `DefaultDbType` really has no consumer.

## Ablation 2 — so mutate the consumers instead

Declarations restored; eight *consumer* literals mutated (six in
`handler/admin/downstream_keys*.go`, one in `routing/selector.go`, one
`"warning"` in `service/alert/alert.go`). Result:

- `handler/admin` **red ×6**, `routing` **red ×3** ⇒ the credential-ref wire
  value is covered on both the writing and the reading side. **Converging those
  literals to the auth constants would remove no defect**, would add six
  `string(…)` conversions, and `routing.CredentialRef.Kind` is deliberately a
  different vocabulary anyway (its own comment says `"account_token" or empty`,
  and the selector handles the legacy empty kind that `auth`'s typed enum does
  not have). **Not done.**
- `service/alert` **green** with `"warning"` → `"warn"` ⇒ the notify level at a
  call site has no owner at all. `level` is opaque downstream (dedup signature,
  forwarded to nine channels, logged; no switch, no validation), so nothing
  downstream can catch it either.

## What this PR actually changes

1. **`platform.CredentialMode` deleted** — `type CredentialMode int` plus
   `CredentialAuto` / `CredentialSession` / `CredentialAPIKey`. A dead *third*
   credential-mode vocabulary: the live one is `service.AccountCredentialMode`
   (string, `"auto"`/`"session"`/`"apikey"`, used at ~20 production sites), and
   `handler/admin/payloads` carries a separate `CredentialMode *string` wire
   field. No adapter takes this enum; nothing converts to it. Its only reference
   anywhere was `platform/adapter_test.go` asserting
   `CredentialAuto != 0 || CredentialSession != 1 || CredentialAPIKey != 2` — a
   tautology about `iota` that can only fail if someone reorders an enum nobody
   reads. Same shape as the four impossible-to-fail tests v0.18.0 retired.
   No public surface: `docs/`, both READMEs and `web/src` never mention it (the
   frontend's `CredentialMode` is its own unrelated type).

2. **`config.DefaultDbType` converged, not deleted** — `parseDbType` spelled
   `"sqlite"` twice and `inferDbType` once, while the constant documenting that
   exact default had zero consumers. Now the three fallback returns are the
   constant, so it has one job and one spelling. This is a *provable* gain:
   `config_test.go:159` asserts `DbType == "sqlite"`, so after this change
   mutating `DefaultDbType` turns `./config` red — before it, the same mutation
   was green (ablation 1). The mapped spellings `"postgres"` / `"mysql"` stay
   literals on purpose: their cross-package owner is `store.Dialect*`, and
   `config` cannot import `store` without a cycle. That reasoning is in the
   constant's comment so the asymmetry is not read as an oversight.

3. **notify levels converged to `NotificationLevel`** — seven call sites passed
   a bare literal (`service/alert` ×3, `service/checkin` ×2,
   `handler/admin/settings_notify.go`, and `defaultLevel` in
   `site_announcements.go`). `scheduler/daily_summary.go` already wrote
   `string(notifypkg.LevelInfo)`, so this follows the existing precedent rather
   than inventing one. The value's only pin is `TestNotificationLevels` on the
   constant; after convergence the call sites inherit that pin, and the
   divergence ablation 2 demonstrated (constant says `warn`, alert.go still
   sends `warning`, suite green) becomes unrepresentable.

**`SendNotification`'s `level string` signature is deliberately NOT tightened to
`NotificationLevel`.** `handler/admin/site_announcements.go` forwards
`announcement.Level`, which `handler/admin/announcements.go:36` validates as
`info|warning|critical` — so `"critical"` legitimately reaches the notify
pipeline while the enum declares only three values. A typed parameter would
either reject it or force adding a fourth member, and both are product
decisions, not cleanup. Recorded as an adjudication instead.

## Kept, with reasons (22 of the 27 candidates)

- **17 `store/schema.go` row structs** (`AdminAuditLog`, `ModelProbeResult`,
  `BalanceHistory`, …): not dead documentation — `store/schema_test.go` reflects
  over them and pins each one's column count against its DDL (`"ModelProbeResult": 10`),
  and they sit next to that DDL, which is the natural home for a row shape. The
  tables are real and read through generic helpers. Deleting them would delete a
  working schema-conformance gate, with no observed failure to justify it.
- **`sharedcount.MemoryCounter` / `NewMemoryCounter`** (11 test refs): the
  in-memory implementation of `WindowCounter`, used as the differential oracle
  against `RedisCounter` in `redis_test.go` and as the injected counter that lets
  `auth/key_admission_shared_test.go` exercise the shared path without a live
  Redis. It must live in a non-test file to be importable from another package's
  tests — exactly the reasoning #1253 applied to `internal/pgtest` and
  `internal/golden`. Production's local window is the limiter's own shard window,
  which is a different thing, not a duplicate.
- **`auth.CredentialRefAccountToken` / `CredentialRefDefaultApiKey`**: ablation 2
  showed the wire value is already covered from both sides.
- **`store.Site.IsPinnedOrFalse` / `Account.ValueScoreOrZero`**: members of a
  live nil-safe accessor family (`BalanceOrZero`, `QuotaOrZero`,
  `SortOrderOrZero`, `GlobalWeightOrZero` all have production callers) pinning
  the nullable-column bug class fixed in v0.16.8 (#943). Deleting two members
  would make the family incomplete for no gain.

## No new gate

The drift ablation 2 exposed is now unrepresentable rather than monitored: there
is one spelling left to change. A grep-shaped gate over `SendNotification` call
sites would be brittle across line breaks and would guard a state that no longer
has two copies — machinery for its own sake. Law 5 records the failure; the
convergence is the fix.

## Mutation probe — 7 arms, each isolated

| arm | state | expect | got |
|---|---|---|---|
| A | HEAD baseline | green | green |
| **B** | **after**: `DefaultDbType` value mutated | **red** | red — `config_test.go:160 DbType = "postgres", want sqlite` |
| **C** | **before**: same mutation | **green** | green |
| **D** | **after**: `LevelWarning` value mutated | **red** | red — `throttle_test.go:305 LevelWarning = "warn", want 'warning'` |
| **E** | **before**: `alert.go`'s `"warning"` literal mutated | **green** | green |
| F | `platform.CredentialMode` restored wholesale | green (nothing needed it) | green |
| G | structural invariant: bare level literals at `SendNotification` call sites | 0 | 0 |

B/C and D/E are the payoff pairs: the same mutation is green before and red after, which is the only evidence that "gave the constant an owner" means anything. F is the deletion-safety arm.

**The first run of this probe was wrong and was fixed.** Arm E reported red citing `TestNotificationLevels` — arm D's mutation had leaked in, because the helper that fetches the pre-change state restored only the *named* paths and left the previous arm's edit to a different file in place. `pre()` now full-restores before checking out the base revision, so the contamination is structurally impossible rather than avoided by care. **This bug family has now appeared three times in this repository** (#1241-era, #1249, #1254), each time failing in the direction of reporting PASS; the recorded lesson in `REALITY-REPORT.md` §流程教训 is upgraded accordingly.

## Verification

- `go build ./...` ok, `go vet ./...` ok
- `go test` ok on platform, config, service/alert, service/checkin,
  service/notify, handler/admin (+payloads), scheduler, auth, routing
- `gofmt -l` on the eight touched files: only `platform/adapter.go`, and only
  its pre-existing ASCII-art comment block — byte-identical judgement on
  `master`'s copy, one hunk, nowhere near the deletion. CI's lint job is
  golangci-lint (govet/errcheck/staticcheck/ineffassign/unused/gosimple), which
  does not run plain gofmt.
- census re-run after: DEAD **1 → 0**, TESTONLY **26 → 22**, declarations
  1728 → 1724; `DefaultDbType` prod_refs 0 → 4, `LevelWarning` 0 → 2.
- mutation probe: `.dev-local/…/vocab-ablation/mutation-probe.{sh,log}`

No release — accumulates into v0.19.1 per Law 3.

- leak-guard run explicitly on the push range: clean, exit 0 (negative control with `AKIAIOSFODNN7EXAMPLE` in a scratch repo fires and exits 1, so the clean result is a real scan).
- Pushed with `--no-verify` per this node's documented 2C convention; what is deferred to GHA is the frontend suite and the full `-race` suite. This change touches no frontend surface, and the nine Go packages that own or consume the three vocabularies were run here.
