### PR TITLE
refactor: two vocabularies had a second copy each, and an ablation showed nothing would notice if the copies disagreed

### DIFF
--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -205,16 +205,16 @@ func (h *accountTokensHandler) createLocalToken(body payloads.AccountTokenCreate
 		return nil, fmt.Errorf("failed to load existing tokens: %w", err)
 	}
 
-	valueStatus := TokenValueStatusReady
+	valueStatus := service.TokenValueStatusReady
 	if IsMaskedTokenValue(tokenValue) {
-		valueStatus = TokenValueStatusMaskedPending
+		valueStatus = service.TokenValueStatusMaskedPending
 	}
-	enabled := valueStatus == TokenValueStatusReady
+	enabled := valueStatus == service.TokenValueStatusReady
 	if body.Enabled != nil {
 		enabled = *body.Enabled
 	}
 	isDefault := false
-	if valueStatus == TokenValueStatusReady && body.IsDefault != nil {
+	if valueStatus == service.TokenValueStatusReady && body.IsDefault != nil {
 		isDefault = *body.IsDefault
 	}
 
@@ -261,7 +261,7 @@ func (h *accountTokensHandler) createLocalToken(body payloads.AccountTokenCreate
 	}
 
 	// Set as default if appropriate
-	if valueStatus == TokenValueStatusReady && (isDefault || (len(existingTokens) == 0 && enabled)) {
+	if valueStatus == service.TokenValueStatusReady && (isDefault || (len(existingTokens) == 0 && enabled)) {
 		if ok, err := service.SetDefaultToken(h.db, tokenID); err != nil {
 			cleanupInsertedToken()
 			return nil, fmt.Errorf("failed to set default token: %w", err)
@@ -269,7 +269,7 @@ func (h *accountTokensHandler) createLocalToken(body payloads.AccountTokenCreate
 			cleanupInsertedToken()
 			return nil, fmt.Errorf("failed to set default token")
 		}
-	} else if valueStatus == TokenValueStatusReady && !hasDefaultToken(existingTokens) && enabled {
+	} else if valueStatus == service.TokenValueStatusReady && !hasDefaultToken(existingTokens) && enabled {
 		if ok, err := service.SetDefaultToken(h.db, tokenID); err != nil {
 			cleanupInsertedToken()
 			return nil, fmt.Errorf("failed to set default token: %w", err)
@@ -423,9 +423,9 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 		}
 		updates["token"] = tv
 		if IsMaskedTokenValue(tv) {
-			nextValueStatus = TokenValueStatusMaskedPending
+			nextValueStatus = service.TokenValueStatusMaskedPending
 		} else {
-			nextValueStatus = TokenValueStatusReady
+			nextValueStatus = service.TokenValueStatusReady
 		}
 		updates["valueStatus"] = nextValueStatus
 	}
@@ -436,7 +436,7 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 		updates["source"] = strings.TrimSpace(*body.Source)
 	}
 
-	if nextValueStatus == TokenValueStatusMaskedPending {
+	if nextValueStatus == service.TokenValueStatusMaskedPending {
 		updates["enabled"] = false
 		updates["isDefault"] = false
 	} else {

--- a/handler/admin/account_tokens_sync.go
+++ b/handler/admin/account_tokens_sync.go
@@ -509,11 +509,3 @@ func countPersistedAccountTokens(db *sqlx.DB, accountID int64) int {
 	}
 	return count
 }
-
-// ---- Helper functions ----
-
-// TokenValueStatusReady and MaskedPending
-const (
-	TokenValueStatusReady         = "ready"
-	TokenValueStatusMaskedPending = "masked_pending"
-)

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
 )
 
 func setupTokensTest(t *testing.T) (*store.DB, chi.Router) {
@@ -710,7 +711,7 @@ func TestTokens_Update_MaskedToken(t *testing.T) {
 	json.Unmarshal(resp.Body.Bytes(), &result)
 	tok, _ := result["token"].(map[string]any)
 	vs, _ := tok["value_status"].(string)
-	if vs != TokenValueStatusMaskedPending {
+	if vs != service.TokenValueStatusMaskedPending {
 		t.Logf("value_status after masked update: %q", vs)
 	}
 	// After masked update, token should be disabled and not default

--- a/routing/cooldown.go
+++ b/routing/cooldown.go
@@ -3,16 +3,17 @@ package routing
 import (
 	"math"
 	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
 )
 
 // ---- Cooldown constants ----
 
 const (
-	FailureBackoffBaseSec                   = 15
-	ShortWindowLimitCooldownMs              = 5 * 60 * 1000
-	MaxFailureBackoffSec                    = 30 * 24 * 60 * 60 // 30 days
-	RoundRobinFailureThreshold              = 3
-	TokenRouterFailureCooldownMaxSecCeiling = MaxFailureBackoffSec
+	FailureBackoffBaseSec      = 15
+	ShortWindowLimitCooldownMs = 5 * 60 * 1000
+	MaxFailureBackoffSec       = 30 * 24 * 60 * 60 // 30 days
+	RoundRobinFailureThreshold = 3
 )
 
 // RoundRobinCooldownLevelsSec defines tiered cooldown for round-robin: [0s, 10min, 1h, 24h].
@@ -46,7 +47,7 @@ func ResolveFailureBackoffSec(failCount *int64) int64 {
 // ResolveConfiguredFailureCooldownMaxMs returns the configured max cooldown in ms.
 func ResolveConfiguredFailureCooldownMaxMs(configuredMaxSec int) int64 {
 	if configuredMaxSec <= 0 {
-		configuredMaxSec = TokenRouterFailureCooldownMaxSecCeiling
+		configuredMaxSec = config.TokenRouterFailureCooldownMaxSecCeiling
 	}
 	normalized := int64(configuredMaxSec) * 1000
 	if normalized < 1000 {

--- a/routing/router.go
+++ b/routing/router.go
@@ -39,7 +39,7 @@ func NewTokenRouter(
 	rt := config.Runtime()
 	configuredMaxSec := rt.TokenRouterFailureCooldownMaxSec
 	if configuredMaxSec <= 0 {
-		configuredMaxSec = TokenRouterFailureCooldownMaxSecCeiling
+		configuredMaxSec = config.TokenRouterFailureCooldownMaxSecCeiling
 	}
 
 	fallbackUnitCost := rt.RoutingFallbackUnitCost

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -129,8 +129,8 @@ func newTestTokenRouter(db *routerTestDB) *TokenRouter {
 func TestNewTokenRouter_AppliesDefaults(t *testing.T) {
 	db := &routerTestDB{}
 	tr := NewTokenRouter(db, &config.Config{}, nil, nil)
-	if tr.configuredMaxSec != TokenRouterFailureCooldownMaxSecCeiling {
-		t.Fatalf("configuredMaxSec = %d, want ceiling %d when config is 0", tr.configuredMaxSec, TokenRouterFailureCooldownMaxSecCeiling)
+	if tr.configuredMaxSec != config.TokenRouterFailureCooldownMaxSecCeiling {
+		t.Fatalf("configuredMaxSec = %d, want ceiling %d when config is 0", tr.configuredMaxSec, config.TokenRouterFailureCooldownMaxSecCeiling)
 	}
 	if tr.fallbackUnitCost != 1 {
 		t.Fatalf("fallbackUnitCost = %v, want 1 when config is 0", tr.fallbackUnitCost)


### PR DESCRIPTION
refactor: two vocabularies had a second copy each, and an ablation showed nothing would notice if the copies disagreed

Observed failure: none from a deployed user. Admission basis is the ablation
below — each duplicate was mutated and the whole affected test surface stayed
green, which is the same evidence standard #1255 used, and the same defect
family #1243 folded on the frontend (two verbatim-identical owners of one wire
contract, changing one is silent).

Found by extending #1255's census from "zero callers" to #1243's shape: every
top-level exported name declared in two or more packages. 1724 declarations →
63 names in ≥2 packages. Most are ordinary Go (`Error`, `Start`, `Get`, `Close`
methods on unrelated types, per-protocol `ParseRequest`/`ParseResponse`). Four
looked like duplicate contract owners; each was read, and **two of the four are
kept** — the adjudications are at the bottom, because "same name in two
packages" is mostly not a defect and saying so is the point.

## The two that were duplicates

**1. `value_status` — a persisted column with two copies of its vocabulary.**

`service/account_token_service.go` and `handler/admin/account_tokens_sync.go`
each declared, verbatim:

    TokenValueStatusReady         = "ready"
    TokenValueStatusMaskedPending = "masked_pending"

`value_status` is a real column on `account_tokens`, written by handler/admin
and read back by `service` and by `handler/proxy/channel_health_probe.go`.
`masked_pending` is the state #1179/#1187 made load-bearing: it is how the
system says "the upstream only gave us a masked key, hydration failed, this
token is not routable". Two spellings of it, one per side of a write/read pair.

The sharpest evidence is inside a single file: `handler/admin/account_tokens.go`
already calls `service.ResolveAccountTokenValueStatus(...)` at three sites to
*compute* the status, then compares the result against its **own** copy of the
literals at eight others. One file, both owners, in adjacent lines.

Fold direction is forced and free: `handler/admin` already imports `service`,
and `service` imports no handler, so `service` is the single owner. Deleted
handler/admin's copy (and the `// ---- Helper functions ----` header it left
empty), repointed 9 production sites + 1 test site.

**2. `TokenRouterFailureCooldownMaxSecCeiling` — two 30-day ceilings.**

`config/defaults.go` declared `= 30 * 24 * 60 * 60`; `routing/cooldown.go`
declared `= MaxFailureBackoffSec`, which is also `30 * 24 * 60 * 60`. Same
number, two independent spellings, nothing relating them.

They are used on two sides of one operator setting: `config` clamps
`TOKEN_ROUTER_FAILURE_COOLDOWN_MAX_SEC` to its copy, `routing` falls back to its
own copy when the configured value is absent or non-positive
(`cooldown.go:49`, `router.go:42`). Disagreeing copies mean the operator's
setting is accepted at one ceiling and applied at another — the "配了不生效 /
两个答案" class this window has already fixed for settings hydration (#1156),
`checkin_interval_hours` (#1166) and the channels snapshot cache (#1167).

Fold direction is forced the same way: `routing` imports `config` in two files
already and `config` imports no routing (the reverse would be a cycle), so
`config` — the package that owns configuration vocabulary — is the single owner.
`routing`'s alias is deleted and both use sites read `config.*`.

`MaxFailureBackoffSec` stays in `routing` and is deliberately **not** pinned
equal to the ceiling: it caps the fibonacci backoff, while the ceiling bounds
what an operator may configure, and the applied cooldown is
`min(backoff, configuredMax)`. They are equal today by choice, not by
invariant, so a cross-package equality test would pin something that is not
true. The old alias asserted that coupling by spelling it; the values being one
owner's now is stronger than an assertion that they match.

## Ablation — the reason these two and not the other two

Each candidate was mutated on the pre-change tree and the affected packages run:

| mutation (pre-change tree) | result | verdict |
|---|---|---|
| handler/admin's `TokenValueStatusReady` → `"READY"` | **green** across handler/admin, service, auth, routing | unowned ⇒ fold |
| `config`'s ceiling → 1 day (routing's stays 30) | **green** across config, routing, handler/admin | unowned ⇒ fold |
| `scheduler.normalizeCronExpr` stops prefixing the seconds field | **red ×6** (`expected exactly 6 fields, found 5` across checkin catch-up, daily summary, balance kill-switch, model sync) | owned ⇒ **do not touch** |

The third row is the control that makes the first two mean something: the same
harness goes red when a duplicated behaviour *is* covered, so "green" here is a
measurement and not a default.

## Kept, with reasons (2 of the 4 candidates)

- **`DownstreamRoutingPolicy` / `EmptyDownstreamRoutingPolicy` in `auth` and
  `routing`**: not a duplicate. `auth`'s is the persistence/wire shape —
  snake_case JSON tags, `[]ExcludedCredentialRef`. `routing`'s is the selection
  input — no JSON tags, `[]CredentialRef` (whose `Kind` is a plain string
  because it also carries the legacy empty value `auth`'s typed enum does not
  have), plus `RequestedContextTokens`, which `auth`'s does not. Different
  fields, different ref types, different jobs; folding would couple persistence
  to selection. The shared name is a reading trap, not a contract with two
  owners.
- **`ValidateCronExpr` in `config` and `scheduler`**: `scheduler`'s is a
  three-line delegation (`return config.ValidateCronExpr(expr)`) with a comment
  naming config as canonical, and it has **five production callers** in
  `handler/admin` (checkin schedule, three settings-apply paths, WebDAV backup
  auto-sync). One implementation, one deliberate re-export at a package boundary
  handlers already depend on. Removing the re-export would make five call sites
  reach into `config` for a scheduler concern.
- Also recorded, not changed: `value_status`'s **third** value `'expired'`
  exists only as a SQL literal in seven queries in
  `handler/admin/stats_marketplace.go`, and `store/migrate_runner.go:976`
  coalesces a NULL to a bare `"ready"`. Neither can join the Go constant —
  boundary rule 1 forbids `store ↛ service` outright, and parameterizing seven
  queries to avoid a string literal risks query-plan changes for zero behaviour
  gain. Declaring `TokenValueStatusExpired` with no consumer would recreate
  exactly the dead-constant shape #1255 retired.

## Mutation probe — 7 arms

| arm | state | expect | got |
|---|---|---|---|
| A | HEAD baseline (4 packages) | green | green |
| **B** | **before**: handler/admin's copy → `"READY"` | **green** (unowned) | green, 0 FAIL |
| **C** | **after**: same mutation attempted | **cannot be applied** | structural assert holds: no second declaration, no bare reference left in handler/admin |
| **D** | **before**: `config`'s ceiling → 1 day | **green** (unowned) | green, 0 FAIL |
| **E** | **after**: declaration sites of the ceiling | routing 0, config 1 | routing=0 config=1 |
| **F** | **control**: `scheduler.normalizeCronExpr` stops prefixing seconds | **red** | red, **10 FAIL** |
| **G** | **after**: the single owner's value → `"READY"` | **red** | red — `account_tokens_test.go:311: expected valueStatus='ready', got READY` |

**B → G is the payoff pair**: the same class of change is invisible before the fold and caught after it, because handler/admin's test now writes through the admin path and reads back the literal `'ready'` that the single owner no longer produces. **F is the control** that makes B and D mean something — the same harness goes red when a duplicated behaviour *is* covered, so "green" here is a measurement rather than a default. C and E are structural rather than behavioural: after a fold the strongest statement available is that the second copy cannot be written down at all.

The probe script needed one fix before it was trustworthy, recorded rather than quietly repaired: arm E had a shell typo (`n routing=$(…)` parsed as a command) which, under `set -u`, aborted the run — so the first log only covers A–D and the checked-in log is the second, complete run.

Script + log: `.dev-local/overhaul-20260904/stability-v019/dup-owner-ablation/mutation-probe.{sh,log}`.

## Verification

- `go build ./...` ok, `go vet ./...` ok — vet earned its keep here: it caught
  `undefined: service` in `account_tokens_test.go`, which `go build` cannot see
  because it does not compile test files.
- `go test -count=1` ok on all 21 affected packages: handler/admin (+payloads),
  routing, service (+11 subpackages), config, auth, store, scheduler.
- diff is 6 files, +21/−28, all of it the two folds. One unrelated hunk my own
  `gofmt -w` introduced (two pre-existing EOF blank lines in `routing/router.go`)
  was reverted: this repository is not plain-gofmt-clean — 337 files on master
  differ, almost all only by trailing blank lines, and CI's lint job is
  golangci-lint with govet/errcheck/staticcheck/ineffassign/unused/gosimple, no
  gofmt linter — so "fixing" one file's EOF is noise, not hygiene.
- mutation probe: `.dev-local/…/dup-owner-ablation/mutation-probe.{sh,log}`

No release — accumulates into v0.19.1 per Law 3.

- Census instruments (both re-runnable, both archived with their output):
  `.dev-local/…/go-deadcensus/census.py` — zero-caller census, 1728 → 1724 declarations, DEAD 1 → 0, TESTONLY 26 → 22 after #1255, with `ADJUDICATION.md` recording all 22 kept candidates and why (`deadcode` from x/tools is OOM-killed on this node, so do not retry it).
  the ≥2-package same-name census that found these four candidates is inlined in the PR discussion and reproducible from `census.py`'s index.
- leak-guard run explicitly on the push range: clean, exit 0 (negative control with `AKIAIOSFODNN7EXAMPLE` in a scratch repo fires and exits 1).
- Pushed with `--no-verify` per this node's documented 2C convention; deferred to GHA are the frontend suite and the full `-race` suite. This change touches no frontend surface, and the 21 Go packages that own or consume the two vocabularies were run here.
