### PR TITLE
chore(config): five documented env vars outlived the code that read them, and one of them documented a prerequisite that never existed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,10 +35,9 @@ FOOTER=
 ABOUT=
 SERVER_ADDRESS=
 
-# Optional OAuth overrides. Fill the matching credentials when an override is enabled;
-# Claude requires a client secret with no fallback.
+# Optional OAuth overrides.
+# Claude is a PKCE public client, so the override only needs CLAUDE_CLIENT_ID.
 CLAUDE_CLIENT_ID=
-CLAUDE_CLIENT_SECRET=
 
 # Codex OAuth override only needs CODEX_CLIENT_ID.
 CODEX_CLIENT_ID=
@@ -182,12 +181,9 @@ PROXY_MAX_CHANNEL_ATTEMPTS=3
 PROXY_EMPTY_CONTENT_FAIL=
 PROXY_ERROR_KEYWORDS=
 # Sticky-session and per-session channel concurrency.
-PROXY_STICKY_SESSION_ENABLED=
 PROXY_STICKY_SESSION_TTL_MS=1800000
 PROXY_SESSION_CHANNEL_CONCURRENCY_LIMIT=2
 PROXY_SESSION_CHANNEL_QUEUE_WAIT_MS=1500
-PROXY_SESSION_CHANNEL_LEASE_TTL_MS=90000
-PROXY_SESSION_CHANNEL_LEASE_KEEPALIVE_MS=15000
 DISABLE_CROSS_PROTOCOL_FALLBACK=
 # Proxy log batch writer (async INSERT batching). Default async=true so
 # production gets the latency/SQLite-lock-contention win automatically; set
@@ -239,8 +235,6 @@ LOG_CLEANUP_PROGRAM_LOGS_ENABLED=
 LOG_CLEANUP_RETENTION_DAYS=30
 
 # ---- Codex / Responses compatibility ----
-CODEX_HEADER_DEFAULTS_USER_AGENT=
-CODEX_HEADER_DEFAULTS_BETA_FEATURES=
 CODEX_UPSTREAM_WEBSOCKET_ENABLED=
 CODEX_RESPONSES_WEBSOCKET_BETA=
 

--- a/config/config.go
+++ b/config/config.go
@@ -36,12 +36,6 @@ func GetSafe() *Config {
 	return staticCfg.Load()
 }
 
-// CodexHeaderDefaults holds Codex-specific HTTP header defaults.
-type CodexHeaderDefaults struct {
-	UserAgent    string
-	BetaFeatures string
-}
-
 // RoutingWeights holds the weight factors for the routing algorithm.
 type RoutingWeights struct {
 	BaseWeightFactor float64
@@ -58,9 +52,8 @@ type Config struct {
 	AccountCredentialSecret string
 	CodexClientId           string
 
-	// OAuth Clients (4 fields)
+	// OAuth Clients (3 fields)
 	ClaudeClientId        string
-	ClaudeClientSecret    string
 	GeminiCliClientId     string
 	GeminiCliClientSecret string
 
@@ -218,13 +211,9 @@ type Config struct {
 	PricingCatalogRefreshMin int
 	PricingCatalogURL        string
 
-	// Proxy: Channel (3 fields)
-	ProxyMaxChannelAttempts   int
-	ProxyStickySessionEnabled bool
-	ProxyStickySessionTtlMs   int
-
-	ProxySessionChannelLeaseTtlMs       int
-	ProxySessionChannelLeaseKeepaliveMs int
+	// Proxy: Channel (2 fields)
+	ProxyMaxChannelAttempts int
+	ProxyStickySessionTtlMs int
 
 	// ProxyMaxStreamResponseBytes caps the total bytes relayed for a single
 	// SSE stream before a controlled termination (default 1 MB). Parsed once
@@ -248,9 +237,8 @@ type Config struct {
 	PromptFilterEnabled      bool
 	PromptFilterDenyPatterns []string
 
-	// Codex-specific (3 fields)
+	// Codex-specific (2 fields)
 	CodexResponsesWebsocketBeta string
-	CodexHeaderDefaults         CodexHeaderDefaults
 
 	// Model Probe (3 fields; ModelAvailabilityProbeEnabled is runtime-mutable
 	// and lives in RuntimeSettings)
@@ -497,7 +485,6 @@ func Load(env map[string]string) (*Config, *RuntimeSettings) {
 
 	// ---- §3.2 OAuth Clients ----
 	cfg.ClaudeClientId = firstNonEmpty(parseOptionalSecret(get("CLAUDE_CLIENT_ID")), DefaultClaudeClientId)
-	cfg.ClaudeClientSecret = parseOptionalSecret(get("CLAUDE_CLIENT_SECRET"))
 	cfg.GeminiCliClientId = firstNonEmpty(parseOptionalSecret(get("GEMINI_CLI_CLIENT_ID")), DefaultGeminiCliClientId)
 	cfg.GeminiCliClientSecret = firstNonEmpty(parseOptionalSecret(get("GEMINI_CLI_CLIENT_SECRET")), DefaultGeminiCliClientSecret)
 
@@ -707,14 +694,11 @@ func Load(env map[string]string) (*Config, *RuntimeSettings) {
 	// consumer (GetProxyMaxChannelAttempts) already clamps <=0 to 1, so the
 	// only observable effect of a negative is the startup warning.
 	cfg.ProxyMaxChannelAttempts = int(math.Trunc(parseNumber(get("PROXY_MAX_CHANNEL_ATTEMPTS"), DefaultProxyMaxChannelAttempts)))
-	cfg.ProxyStickySessionEnabled = parseBoolean(get("PROXY_STICKY_SESSION_ENABLED"), true)
 	cfg.ProxyStickySessionTtlMs = max(30000, int(math.Trunc(parseNumber(get("PROXY_STICKY_SESSION_TTL_MS"), float64(DefaultProxyStickySessionTtlMs)))))
 
 	// ---- §3.16 Proxy: Session ----
 	rt.ProxySessionChannelConcurrencyLimit = max(0, int(math.Trunc(parseNumber(get("PROXY_SESSION_CHANNEL_CONCURRENCY_LIMIT"), DefaultProxySessionChannelConcurrencyLimit))))
 	rt.ProxySessionChannelQueueWaitMs = max(0, int(math.Trunc(parseNumber(get("PROXY_SESSION_CHANNEL_QUEUE_WAIT_MS"), DefaultProxySessionChannelQueueWaitMs))))
-	cfg.ProxySessionChannelLeaseTtlMs = max(5000, int(math.Trunc(parseNumber(get("PROXY_SESSION_CHANNEL_LEASE_TTL_MS"), DefaultProxySessionChannelLeaseTtlMs))))
-	cfg.ProxySessionChannelLeaseKeepaliveMs = max(1000, int(math.Trunc(parseNumber(get("PROXY_SESSION_CHANNEL_LEASE_KEEPALIVE_MS"), DefaultProxySessionChannelLeaseKeepaliveMs))))
 
 	// ---- §3.17 Proxy: Misc ----
 	rt.CodexUpstreamWebsocketEnabled = parseBoolean(get("CODEX_UPSTREAM_WEBSOCKET_ENABLED"), false)
@@ -751,10 +735,6 @@ func Load(env map[string]string) (*Config, *RuntimeSettings) {
 		parseOptionalSecret(get("CODEX_RESPONSES_WEBSOCKET_BETA")),
 		"responses_websockets=2026-02-06",
 	)
-	cfg.CodexHeaderDefaults = CodexHeaderDefaults{
-		UserAgent:    parseOptionalSecret(get("CODEX_HEADER_DEFAULTS_USER_AGENT")),
-		BetaFeatures: parseOptionalSecret(get("CODEX_HEADER_DEFAULTS_BETA_FEATURES")),
-	}
 
 	// ---- §3.20 Model Probe ----
 	rt.ModelAvailabilityProbeEnabled = parseBoolean(get("MODEL_AVAILABILITY_PROBE_ENABLED"), false)

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -131,8 +131,6 @@ const (
 	DefaultProxyStickySessionTtlMs             = 30 * 60 * 1000 // 30 minutes
 	DefaultProxySessionChannelConcurrencyLimit = 2
 	DefaultProxySessionChannelQueueWaitMs      = 1500
-	DefaultProxySessionChannelLeaseTtlMs       = 90000
-	DefaultProxySessionChannelLeaseKeepaliveMs = 15000
 
 	DefaultModelAvailabilityProbeIntervalMs  = 30 * 60 * 1000 // 30 minutes
 	DefaultModelAvailabilityProbeTimeoutMs   = 15000

--- a/config/validate.go
+++ b/config/validate.go
@@ -175,26 +175,6 @@ func (c *Config) Validate() []error {
 		})
 	}
 
-	// --- Critical/Warning: Lease keepalive vs TTL sanity ---
-	// keepalive > TTL is a genuine correctness bug: the lease expires before
-	// the renewal heartbeat can land, so sessions silently drop. keepalive ==
-	// TTL is borderline (no renewal headroom) and only warrants a warning.
-	if c.ProxySessionChannelLeaseKeepaliveMs > c.ProxySessionChannelLeaseTtlMs {
-		errs = append(errs, &configError{
-			field:    "proxy_session_channel_lease_keepalive_ms",
-			value:    fmt.Sprintf("%d > %d (ttl)", c.ProxySessionChannelLeaseKeepaliveMs, c.ProxySessionChannelLeaseTtlMs),
-			msg:      "keepalive interval must be < lease TTL — leases expire before renewal",
-			critical: true,
-		})
-	} else if c.ProxySessionChannelLeaseKeepaliveMs == c.ProxySessionChannelLeaseTtlMs && c.ProxySessionChannelLeaseTtlMs > 0 {
-		errs = append(errs, &configError{
-			field:    "proxy_session_channel_lease_keepalive_ms",
-			value:    fmt.Sprintf("%d == %d (ttl)", c.ProxySessionChannelLeaseKeepaliveMs, c.ProxySessionChannelLeaseTtlMs),
-			msg:      "keepalive equals TTL — set keepalive strictly less than TTL for renewal headroom",
-			critical: false,
-		})
-	}
-
 	// --- Warning: negative values silently disable limits ---
 	// Consumers treat <=0 as disabled, so a negative configures "disabled"
 	// without the operator realizing it. Recommend 0 for explicit disable.
@@ -224,11 +204,14 @@ func (c *Config) Validate() []error {
 	}
 
 	// --- Warning: range checks for proxy session / router knobs ---
-	if c.ProxyStickySessionEnabled && c.ProxyStickySessionTtlMs <= 0 {
+	// Unconditional now that PROXY_STICKY_SESSION_ENABLED is gone: the Codex WS
+	// runtime always applies ProxyStickySessionTtlMs, so a non-positive TTL was
+	// never "disabled", it was just clamped away by Load.
+	if c.ProxyStickySessionTtlMs <= 0 {
 		errs = append(errs, &configError{
 			field:    "proxy_sticky_session_ttl_ms",
 			value:    fmt.Sprintf("%d", c.ProxyStickySessionTtlMs),
-			msg:      "should be > 0 when sticky sessions are enabled",
+			msg:      "should be > 0",
 			critical: false,
 		})
 	}

--- a/config/validate_hardening_test.go
+++ b/config/validate_hardening_test.go
@@ -11,24 +11,21 @@ import (
 // appears. Runtime-mutable fields live on validBaseRuntime.
 func validBaseConfig() *Config {
 	return &Config{
-		AccountCredentialSecret:             "credential-secret-1234567890",
-		ClaudeClientId:                      "claude-client-id",
-		CodexClientId:                       "codex-client-id",
-		GeminiCliClientId:                   "gemini-cli-client-id",
-		Port:                                4000,
-		ListenHost:                          "0.0.0.0",
-		DbMaxOpenConns:                      10,
-		DbMaxIdleConns:                      3,
-		DbConnMaxLifetimeSec:                1800,
-		DbConnMaxIdleTimeSec:                300,
-		ProxyRateLimitRPM:                   60,
-		ProxyGlobalTokenRPM:                 0,
-		ProxyMaxChannelAttempts:             3,
-		ProxyStickySessionEnabled:           false,
-		ProxyStickySessionTtlMs:             30 * 60 * 1000,
-		TokenRouterCacheTtlMs:               1500,
-		ProxySessionChannelLeaseTtlMs:       90000,
-		ProxySessionChannelLeaseKeepaliveMs: 15000,
+		AccountCredentialSecret: "credential-secret-1234567890",
+		ClaudeClientId:          "claude-client-id",
+		CodexClientId:           "codex-client-id",
+		GeminiCliClientId:       "gemini-cli-client-id",
+		Port:                    4000,
+		ListenHost:              "0.0.0.0",
+		DbMaxOpenConns:          10,
+		DbMaxIdleConns:          3,
+		DbConnMaxLifetimeSec:    1800,
+		DbConnMaxIdleTimeSec:    300,
+		ProxyRateLimitRPM:       60,
+		ProxyGlobalTokenRPM:     0,
+		ProxyMaxChannelAttempts: 3,
+		ProxyStickySessionTtlMs: 30 * 60 * 1000,
+		TokenRouterCacheTtlMs:   1500,
 	}
 }
 
@@ -106,26 +103,6 @@ func assertNoErrorIn(t *testing.T, errs []error, substr string) {
 	}
 }
 
-func TestValidateLeaseKeepaliveExceedsTtlIsCritical(t *testing.T) {
-	cfg := validBaseConfig()
-	cfg.ProxySessionChannelLeaseKeepaliveMs = 30000
-	cfg.ProxySessionChannelLeaseTtlMs = 10000
-	assertHasError(t, cfg, "proxy_session_channel_lease_keepalive_ms", true)
-}
-
-func TestValidateLeaseKeepaliveEqualsTtlIsWarning(t *testing.T) {
-	cfg := validBaseConfig()
-	cfg.ProxySessionChannelLeaseKeepaliveMs = 30000
-	cfg.ProxySessionChannelLeaseTtlMs = 30000
-	assertHasError(t, cfg, "proxy_session_channel_lease_keepalive_ms", false)
-}
-
-func TestValidateLeaseKeepaliveBelowTtlIsClean(t *testing.T) {
-	cfg := validBaseConfig()
-	// keepalive (15000) < ttl (90000): the healthy default path must not warn.
-	assertNoErrorFor(t, cfg, "proxy_session_channel_lease_keepalive_ms")
-}
-
 func TestValidateNegativeProxyRateLimitRPMIsWarning(t *testing.T) {
 	cfg := validBaseConfig()
 	cfg.ProxyRateLimitRPM = -5
@@ -173,16 +150,8 @@ func TestValidateConcurrencyLimitBelowOneIsWarning(t *testing.T) {
 
 func TestValidateStickySessionTtlNonPositiveIsWarning(t *testing.T) {
 	cfg := validBaseConfig()
-	cfg.ProxyStickySessionEnabled = true
 	cfg.ProxyStickySessionTtlMs = 0
 	assertHasError(t, cfg, "proxy_sticky_session_ttl_ms", false)
-}
-
-func TestValidateStickySessionDisabledSkipsTtlCheck(t *testing.T) {
-	cfg := validBaseConfig()
-	cfg.ProxyStickySessionEnabled = false
-	cfg.ProxyStickySessionTtlMs = 0 // disabled, so ttl is irrelevant
-	assertNoErrorFor(t, cfg, "proxy_sticky_session_ttl_ms")
 }
 
 func TestValidateTokenRouterCacheTtlNonPositiveIsWarning(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,12 +113,9 @@ silent until their URL/key is set. Every other provider needs its
 | `PROXY_EMPTY_CONTENT_FAIL` | empty | Treat empty upstream content as failure. |
 | `PROXY_ERROR_KEYWORDS` | empty | Extra keywords marking upstream responses as errors. |
 | `DISABLE_CROSS_PROTOCOL_FALLBACK` | empty | Disable OpenAI ⇄ Claude cross-protocol fallback. |
-| `PROXY_STICKY_SESSION_ENABLED` | empty | Pin a session to one channel (process-local). |
 | `PROXY_STICKY_SESSION_TTL_MS` | `1800000` | Sticky binding TTL. |
 | `PROXY_SESSION_CHANNEL_CONCURRENCY_LIMIT` | `2` | Concurrent streams per session-channel lease. |
 | `PROXY_SESSION_CHANNEL_QUEUE_WAIT_MS` | `1500` | Queue wait for a busy session channel. |
-| `PROXY_SESSION_CHANNEL_LEASE_TTL_MS` | `90000` | Session-channel lease lifetime in ms. |
-| `PROXY_SESSION_CHANNEL_LEASE_KEEPALIVE_MS` | `15000` | Keepalive interval that renews an in-use session-channel lease; floored at 1000 ms. |
 | `PROXY_CONNECT_TIMEOUT_SEC` | `2` | TCP dial (connect) timeout for outbound upstream requests. |
 | `PROXY_TLS_HANDSHAKE_TIMEOUT_SEC` | `10` | TLS handshake timeout. |
 | `PROXY_RESPONSE_HEADER_TIMEOUT_SEC` | `30` | How long to wait for upstream response headers. |
@@ -216,7 +213,7 @@ upstream request; …`), since it describes a static misconfiguration.
 
 | Variable | Description |
 |:---------|:------------|
-| `CLAUDE_CLIENT_ID` / `CLAUDE_CLIENT_SECRET` | Override bundled Claude OAuth app (secret has no fallback). |
+| `CLAUDE_CLIENT_ID` | Override bundled Claude OAuth app (PKCE public client; no secret). |
 | `CODEX_CLIENT_ID` | Override bundled Codex OAuth app. |
 | `GEMINI_CLI_CLIENT_ID` / `GEMINI_CLI_CLIENT_SECRET` | Gemini CLI override (set both). |
 
@@ -226,8 +223,6 @@ upstream request; …`), since it describes a static misconfiguration.
 |:---------|:--------|:------------|
 | `CODEX_UPSTREAM_WEBSOCKET_ENABLED` | empty | Codex upstream WebSocket transport (C3); non-upgrade GETs get an honest 426. |
 | `CODEX_RESPONSES_WEBSOCKET_BETA` | empty | Responses-over-WS beta header. |
-| `CODEX_HEADER_DEFAULTS_USER_AGENT` | empty | `User-Agent` sent to Codex upstreams; empty keeps the built-in default. |
-| `CODEX_HEADER_DEFAULTS_BETA_FEATURES` | empty | Anthropic `anthropic-beta`-style feature header value sent to Codex upstreams; empty keeps the built-in default. |
 
 ## Misc
 

--- a/e2e/e2e_flow_test.go
+++ b/e2e/e2e_flow_test.go
@@ -40,7 +40,6 @@ func TestSiteCreateToProxyFlow(t *testing.T) {
 		AccountCredentialSecret:   "test-cred-secret",
 		DataDir:                   t.TempDir(),
 		ProxyMaxChannelAttempts:   3,
-		ProxyStickySessionEnabled: false,
 		ProxyStickySessionTtlMs:   30000,
 		TokenRouterCacheTtlMs:     1500,
 		RequestBodyLimit:          20 * 1024 * 1024,

--- a/e2e/e2e_shutdown_test.go
+++ b/e2e/e2e_shutdown_test.go
@@ -61,7 +61,6 @@ func TestShutdownUnderStreamingLoad(t *testing.T) {
 		AccountCredentialSecret:   "test-cred-secret-shutdown",
 		DataDir:                   dataDir,
 		ProxyMaxChannelAttempts:   3,
-		ProxyStickySessionEnabled: false,
 		ProxyStickySessionTtlMs:   30000,
 		TokenRouterCacheTtlMs:     1500,
 		RequestBodyLimit:          20 * 1024 * 1024,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -264,15 +264,12 @@ func makeChannel(id int64, upstreamURL string, actualModel string) *routing.Sele
 // makeTestConfig creates a minimal static Config for testing.
 func makeTestConfig() *config.Config {
 	return &config.Config{
-		Port:                                4000,
-		ListenHost:                          "127.0.0.1",
-		DataDir:                             "./data",
-		ProxyMaxChannelAttempts:             3,
-		ProxyStickySessionEnabled:           false,
-		ProxyStickySessionTtlMs:             30000,
-		ProxySessionChannelLeaseTtlMs:       5000,
-		ProxySessionChannelLeaseKeepaliveMs: 1000,
-		TokenRouterCacheTtlMs:               1500,
+		Port:                    4000,
+		ListenHost:              "127.0.0.1",
+		DataDir:                 "./data",
+		ProxyMaxChannelAttempts: 3,
+		ProxyStickySessionTtlMs: 30000,
+		TokenRouterCacheTtlMs:   1500,
 	}
 }
 


### PR DESCRIPTION
chore(config): five documented env vars outlived the code that read them, and one of them documented a prerequisite that never existed (#1257)

Observed failure: none from a deployed user for four of the five. The fifth is a
documentation defect an operator can hit today — `.env.example` and
`docs/configuration.md` both said that overriding the Claude OAuth app "requires
a client secret with no fallback", and no code path reads one.

Admission basis is the one #1234 / #1239 / #1253 / #1255 used — a census proving
zero consumers — pointed at a surface none of them covered: config knobs.

## Why the existing 4-way gate let these through

`docs/env_parity_test.go` requires every `.env.example` key to also appear in
`docs/configuration.md`, in a `get("…")` inside `config.Load`, and among the
environment readers across the Go sources. All five knobs pass it, and the gate
is not wrong: its rule proves a key is *read out of the environment*. Whether
anything *acts on the value afterwards* is a semantic question no regexp can
settle without false positives. So the honest split is — gate the first half
mechanically, adjudicate the second by hand. That second half is this PR.

## The census, and the flaw in its first instrument

`.dev-local/…/settings-consumption/census.py`: index every `Config` /
`RuntimeSettings` field, count references outside `config/`.

First run said 16 candidates and was wrong. It matched on `\b` word boundaries,
so a field reached through a longer identifier scored zero — `GlobalAllowedModels`
is read as `h.loadGlobalAllowedModels()`. Added embedded-substring matching for
names ≥8 chars: 16 → 14. Recorded because that instrument's false positives
would have retired live configuration. Every remaining candidate was then read.

## The five, each with its proof

**1. `CLAUDE_CLIENT_SECRET` — a documented prerequisite for a flow that cannot
use it.** `service/oauth/claude.go` is a PKCE public client: `code_challenge` +
`code_challenge_method=S256` at authorize, `code_verifier` at token exchange, no
`client_secret` anywhere. `Validate` requires only `ClaudeClientId`. Yet the docs
listed both variables as one row and `.env.example` called the secret mandatory
with no fallback — so an operator following the documentation to override the
Claude app goes hunting for a secret the flow cannot consume. Field, env line and
doc row retired; both now say PKCE public client, ID only.

**2/3. `CODEX_HEADER_DEFAULTS_USER_AGENT` / `..._BETA_FEATURES` — a header
override whose headers are constants.** `service/oauth/codex.go` sets
`User-Agent` from `codexCLIUserAgent` (line 166) and
`codexSessionBrowserUserAgent` (line 252), both package constants. Neither reads
`cfg.CodexHeaderDefaults`. "Empty keeps the built-in default" was true only in
that the built-in default was the sole reachable value. The
`CodexHeaderDefaults` struct went with them; it had no other field.

**4. `PROXY_STICKY_SESSION_ENABLED` — a disable flag nothing consults.** The
only sticky-session consumer is `codexSessionTTL()`
(`handler/proxy/codex_ws_runtime.go:89`), which reads `ProxyStickySessionTtlMs`
unconditionally and floors it at `codexSessionTTLMin`. `false` changed nothing.
It was documented as "Pin a session to one channel (process-local)" — an
operator-facing promise about a switch never wired to the behaviour it named.

With the flag gone, the `Validate` warning gated on it becomes unconditional.
Not a production behaviour change: `Load` clamps `max(30000, …)`, so env-supplied
values never reached that warning either way. It only affects hand-built `Config`
structs, and for those the TTL is in fact always applied.

**5. `PROXY_SESSION_CHANNEL_LEASE_TTL_MS` / `..._LEASE_KEEPALIVE_MS` — two knobs
whose subsystem this repository already deleted.** The best evidence is the
repository's own comment, `proxy/session.go:21`:

    Sticky-session leases (AcquireChannelLease / BindStickyChannel, the waiter
    queue, and lease keepalive/expiry goroutines) are DEFERRED: no caller in the
    proxy acquires leases today, so that machinery was removed in
    chore/rm-dead-proxy-routing …

Neither symbol exists in the tree; the only hit is that comment. An earlier wave
retired the implementation and these two knobs plus their defaults survived it.

They were not merely inert. `Validate` carried a ~1.1 KB critical/warning
cross-check asserting keepalive < TTL, reasoning that otherwise "the lease
expires before the renewal heartbeat can land, so sessions silently drop" — a
genuine bug shape, in a subsystem that does not exist. It could go **critical**
and block startup over two numbers nothing reads.

Three tests covered that check, but only two of them falsifiably: the third
asserts the *absence* of a diagnostic, so deleting the rule leaves it green. Arm
A5 below measures exactly that — red x2, not x3.

## Kept, with reasons

- **`PROXY_STICKY_SESSION_TTL_MS`** — live (`codexSessionTTL()`). Kept, warning kept.
- **`PROXY_SESSION_CHANNEL_CONCURRENCY_LIMIT`** — live
  (`proxy/session.go:channelConcurrencyLimit`, read off the runtime snapshot per
  acquire so a settings change hot-applies).
- **`GlobalAllowedModels`** — live end to end: hydrate (`store/settings.go:482`),
  write (`settings_apply.go:711`), serialize (`settings.go:147`), and a real
  consumer at `stats.go:1241` → `loadGlobalAllowedModels()` →
  `buildTokenCandidateModels`. This is the one the `\b` instrument misreported.
- **`LogCleanupEnvEnabled` / `Tz` / `Footer` / `Logo` / `ServerAddress`** —
  legitimate; consumed on display/frontend paths a Go-side census cannot see.

## Two findings I am deliberately NOT acting on

The census also surfaced two knobs wired UI → persist → hydrate with **no
behavioural consumer**, i.e. the same defect as the lease pair but with a visible
control:

- **`PROXY_SESSION_CHANNEL_QUEUE_WAIT_MS`** — full round trip
  (`proxy-transport-section.tsx` form field + zod schema + payload, i18n in both
  locales, `settings_apply.go:372`, `store/settings.go:434`), and nothing ever
  waits on it. The waiter queue is the machinery `proxy/session.go` says was
  removed.
- **`GlobalBlockedBrands`** — written by `allowlist-section.tsx:147`, persisted
  and served back, and no Go path enforces it.

Note that "has a live UI control" is not evidence of life here; it is what makes
the defect operator-visible — the 配了不生效 class. Both are left alone because
retiring them removes a visible control, which is a product-surface decision
rather than a dead-code one, and one of them (brand blocking) is a security
question. Recorded for operator adjudication instead of folded into a
config-only PR.

Precedent for this shape: v0.17.0 retired `HOME_PAGE_CONTENT` (same defect —
documented, parsed, unread); v0.18.0 retired whole unwired subsystems.

## Verification

- `go build ./...` ok; `go vet ./...` ok. vet is load-bearing: it compiles test
  files, so a surviving reference in any of the four test files touched here
  fails there instead of silently at test time.
- `go test -count=1` ok on `config`, `docs`, `e2e`, plus the five packages that
  consume this config at runtime: `proxy`, `handler/proxy`, `service/oauth`,
  `routing`, `router`.
- `docs/env_parity_test.go` green, which is the point — it is a 4-way gate, so
  dropping the `get("…")` calls without dropping the `.env.example` lines and doc
  rows would have gone red. All three surfaces were edited symmetrically.
- Test count went **down by four**, not up. The three lease cross-check tests die
  with the check they pinned. `TestValidateStickySessionDisabledSkipsTtlCheck`
  dies because its premise — a disable flag — no longer exists; its assertion
  (`Enabled=false`, TTL=0 → no warning) is now *false*, so keeping it green would
  have meant re-adding the flag for the sake of a test. The surviving
  `TestValidateStickySessionTtlNonPositiveIsWarning` covers the rule that is
  actually unconditional now.
- diff is 9 files, +34/−120. Two `e2e/` files were hand-edited without `gofmt`
  because they are already not gofmt-clean at HEAD; the four files I did run
  `gofmt -w` on were gofmt-clean at HEAD, so every formatting hunk here is
  struct-literal realignment caused by my own deletions — no unrelated noise.
## Mutation probe

Every arm ran on the pre-change tree (merge-base `f100b2c7`, never `HEAD^`), with
a full restore before each arm, and `mut()` exiting 4 on a no-op so a silent
non-mutation cannot masquerade as a green arm. Surface: config, store, proxy,
handler/proxy, service/oauth, e2e.

| arm (pre-change tree) | result | verdict |
|---|---|---|
| baseline, unmutated | green | harness sane |
| A1 invert `PROXY_STICKY_SESSION_ENABLED` semantics | **green** | nothing consumes the flag |
| A2 `CLAUDE_CLIENT_SECRET` → `"MUTATED-CLIENT-SECRET"` | **green** | nothing consumes it |
| A3 `CODEX_HEADER_DEFAULTS_*` → `"MUTATED-UA"`/`"MUTATED-BETA"` | **green** | nothing consumes them |
| A4 load lease keepalive `999999` > ttl `1` — the state the code itself calls *critical* | **green** | no runtime path exists to break |
| A5 delete `Validate`'s lease cross-check | **red x2** | the check was the knobs' only reader |
| CONTROL remove the `max(0, …)` floor on `PROXY_SESSION_CHANNEL_CONCURRENCY_LIMIT` (live, pinned by `store`'s env round-trip) | **red** | the greens above are measurements |

A4 is the one worth sitting with: the pre-change tree could be put into a state
its own validator describes as "leases expire before the renewal heartbeat can
land, so sessions silently drop", and all six packages stayed green — because
there is no lease. A5 and the CONTROL are what make A1–A4 mean something: the
same harness goes red when a knob *is* owned, in the same `Load()` function.

Script + log: `.dev-local/…/settings-consumption/mutation-probe.{sh,log}`

No release — accumulates into v0.19.1 per Law 3.
