### PR TITLE
chore(web): retire CSS whose consumers were already deleted — a json-code-editor rule group, a dead utility class, three table tokens, and a build-rev token whose comment claimed a consumer that never existed

### DIFF
--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -44,44 +44,6 @@
     font-weight: var(--shiki-dark-font-weight) !important;
     text-decoration: var(--shiki-dark-text-decoration) !important;
   }
-
-  .json-code-editor-textarea {
-    overflow: auto !important;
-    scrollbar-gutter: stable;
-  }
-
-  .json-code-editor-textarea::placeholder {
-    color: var(--muted-foreground);
-    opacity: 1;
-    -webkit-text-fill-color: var(--muted-foreground);
-  }
-
-  .json-code-editor-textarea,
-  .json-code-editor-highlight,
-  .json-code-editor-lines {
-    overflow-wrap: normal !important;
-    white-space: pre !important;
-  }
-
-  .json-code-editor-highlight .yace-tok--str {
-    color: var(--chart-5);
-  }
-
-  .json-code-editor-highlight .yace-tok--num {
-    color: var(--chart-4);
-  }
-
-  .json-code-editor-highlight .yace-tok--kw {
-    color: var(--chart-1);
-  }
-
-  .json-code-editor-highlight .yace-tok--punc {
-    color: var(--muted-foreground);
-  }
-
-  .json-code-editor-highlight .yace-tok--com {
-    color: var(--muted-foreground);
-  }
 }
 
 @layer base {
@@ -399,11 +361,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* Long list rendering optimization */
-.content-auto {
-  content-visibility: auto;
-  contain-intrinsic-size: 0 80px;
-}
 
 /*
  * Global reduced-motion safety net for the shared tw-animate-css enter/exit

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -361,7 +361,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-
 /*
  * Global reduced-motion safety net for the shared tw-animate-css enter/exit
  * animations (dialog / sheet / alert-dialog / select / tooltip / popover /

--- a/web/src/styles/theme-presets.css
+++ b/web/src/styles/theme-presets.css
@@ -608,12 +608,12 @@
   letter-spacing: var(--tracking-editorial-heading);
 }
 
-/* Larger displays earn tighter tracking, matching Copernicus/Tiempos
- * editorial display setting (~ -0.02em at 30px+). */
-[data-theme-font='serif'] h1,
-[data-theme-font='serif'] .text-3xl,
-[data-theme-font='serif'] .text-4xl,
-[data-theme-font='serif'] .text-5xl {
+/* The page-level display size earns tighter tracking, matching the
+ * Copernicus/Tiempos editorial display setting (~ -0.02em at 30px+). The
+ * `.text-3xl/4xl/5xl` selectors this rule carried until 2026-09-05 had zero
+ * occurrences in the markup (style-layer census over web/src ts and tsx)
+ * and went with the dead component CSS they were copied from. */
+[data-theme-font='serif'] h1 {
   letter-spacing: var(--tracking-editorial-display);
 }
 

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -93,8 +93,6 @@
 :root {
   --radius: 1rem;
   --app-header-height: 3.5rem;
-  /* Static build-channel fallback consumed when JS hasn't booted yet. */
-  --app-rev: '2k6e8r7p';
   /* Currently active body font. The font axis swaps this between
    * `--font-sans` and `--font-serif` via `[data-theme-font='...']` blocks
    * in theme-presets.css. Default mirrors `--font-sans` so behavior is
@@ -177,23 +175,6 @@
   --table-header-hover: color-mix(
     in oklch,
     var(--foreground) 3%,
-    var(--background)
-  );
-  /* Disabled rows: kept subtle so they read as "quiet", not as a colored
-     alert state. */
-  --table-disabled: color-mix(
-    in oklch,
-    var(--foreground) 3%,
-    var(--background)
-  );
-  --table-disabled-hover: color-mix(
-    in oklch,
-    var(--foreground) 4.5%,
-    var(--background)
-  );
-  --table-disabled-border: color-mix(
-    in oklch,
-    var(--foreground) 16%,
     var(--background)
   );
 }
@@ -284,21 +265,6 @@
   --table-header-hover: color-mix(
     in oklch,
     var(--foreground) 9%,
-    var(--background)
-  );
-  --table-disabled: color-mix(
-    in oklch,
-    var(--foreground) 7%,
-    var(--background)
-  );
-  --table-disabled-hover: color-mix(
-    in oklch,
-    var(--foreground) 9.5%,
-    var(--background)
-  );
-  --table-disabled-border: color-mix(
-    in oklch,
-    var(--foreground) 24%,
     var(--background)
   );
 }


### PR DESCRIPTION
## 动机（neat-freak 减法，非故障驱动）

样式层普查（web/src 的 ts/tsx markup + public/*.js + index.html + web/scripts + docs + Go 全仓 grep）发现 **6 个类选择器与 4 个自定义属性在全仓的唯一出现处就是它们自己的定义**。逐条裁决后退役，零行为变更。

## 裁决明细

| 符号 | 裁决 |
|---|---|
| `.json-code-editor-textarea/-highlight/-lines` + 5 条 `.yace-tok--*` 颜色规则 | 发射这些类的组件已不存在（`CodeEditor` / `yace` 在 index.css 之外零出现），规则是组件的遗骸 |
| `.content-auto` | 同上形状：一个定义、零消费者 |
| serif display-tracking 规则里的 `.text-3xl/.text-4xl/.text-5xl` | markup 零出现；该规则唯一活着的选择器是 `h1`，三个死选择器删除、`h1` 保留 token |
| `--table-disabled` / `-hover` / `-border`（`:root` 与 `.dark` 各一份） | 有定义、无任何 `var()` 或名字引用，也没有 `--color-*` 映射消费它们 |
| `--app-rev` | 注释自称「JS 未启动时的静态构建回退」，但全仓零消费者——**文件对自己说谎**，#1236 族在 CSS 注释里的同形发生；token 与注释一起退役 |

## 删除惰性的证明（不是「看起来没用」）

- 昨天为 #1260 重生成的 **10 张 golden 基线对本树构建的二进制逐像素全绿**（pixelmatch 无差异）——「没有活消费者」预测的正是这个结果；若删到了活东西，基线必红。
- 前端样式契约测试 24/24；CSS bundle 274.5 → 272.5 kB raw。

## 刻意不做

- 不为「防僵尸复活」加否定断言测试：Law 5（门来自已发生的故障），且组件若回归会自带 CSS。
- 不动 Tailwind 命名空间内的 token（`--text-*`/`--spacing` 等由工具类按名消费，静态普查判不了生死）。

## 过程注记

替换注释的第一版含 glob `**/`，其中的 `*/` 提前终止了 CSS 块注释，Rsbuild 构建当场失败——编译器抓到了普查抓不到的东西。
