### PR TITLE
chore(web): retire the one zombie i18n key the reverse census found — a sentence-shaped top-level 'Toggle theme' left by the pre-rewrite stack, superseded by theme.toggle

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2729,7 +2729,6 @@
     "Sidebar": "Sidebar",
     "Displays the mobile sidebar.": "Displays the mobile sidebar.",
     "Toggle Sidebar": "Toggle Sidebar",
-    "Toggle theme": "Toggle theme",
     "theme": {
       "title": "Appearance",
       "reset": "Reset",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2729,7 +2729,6 @@
     "Sidebar": "侧边栏",
     "Displays the mobile sidebar.": "显示移动端侧边栏。",
     "Toggle Sidebar": "切换侧边栏",
-    "Toggle theme": "切换主题",
     "theme": {
       "title": "外观",
       "reset": "重置",


### PR DESCRIPTION
chore(web): retire the one zombie i18n key the reverse census found — a sentence-shaped top-level 'Toggle theme' left by the pre-rewrite stack, superseded by theme.toggle

The existing gate (web/src/i18n/__tests__/i18n-keys.test.ts) owns one
direction: every referenced key must exist in both locales. Nothing owned the
reverse: keys that are defined but never referenced. A reverse census over
the same four channels (t() literals, assertBusinessOk fallbacks,
locale-rooted key-shaped literals, template prefixes) found exactly one:

  defined=2516  exactRefs=2384  prefixRefs=20  DEAD=1

- the dead one is the top-level sentence-shaped key "Toggle theme"
  (en 'Toggle theme' / zh '切换主题'), a leftover of the pre-rewrite i18n
  dictionary; the live key since the rewrite is `theme.toggle`, which the
  theme button's aria-label already uses;
- its four apparent "references" in tests are accessible-name matchers
  (getByRole name 'Toggle theme'), i.e. they match the RENDERED VALUE of
  `theme.toggle`, not the key — verified by reading interface-controls.tsx;
- the census's first run also flagged 18 plural-suffix leaves
  (`*_one` / `*_other`): false positives, because i18next resolves the suffix
  at runtime from a bare base key plus { count }. The tool now treats a
  referenced base key as keeping its suffix leaves; with that fix the dead
  set collapses to the single zombie above.

Inertness: the i18n gate's own directions are untouched (referenced ⇒ defined
still holds; en/zh parity still bidirectional-zero), i18n tests 10/10,
oxfmt clean. Zero user-visible change, so per the writing contract this gets
no CHANGELOG entry (adjudicated, fifth seat of ADJUDICATED_NO_ENTRY).

Census tool archived at
.dev-local/overhaul-20260904/stability-v019/ablation-census/i18n-deadkeys-census.mjs
(rerunnable; its regexes mirror the gate's, and every candidate is manually
grep-adjudicated before any deletion, so regex drift cannot become a wrong
deletion).
