### PR TITLE
test(auth): give the session-purge test a whole-second margin — expires_at is stored at second precision, and a 1s TTL made the flake a ~1% dice roll

### DIFF
--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -107,13 +107,21 @@ func TestSessionSlidingExpiry(t *testing.T) {
 }
 
 func TestSessionCreatePurgesExpiredRows(t *testing.T) {
-	sm := newTestSessionManager(t, time.Second)
+	// TTL 2s, not 1s: expires_at is stored at SECOND precision (RFC3339 without
+	// fractional part), so a row's real lifetime can be up to 1s shorter than
+	// the TTL depending on where inside the second it was created. With a 1s
+	// TTL the window between Create #2 and Count could cross a whole-second
+	// boundary and count the brand-new row as already expired (observed as a
+	// CI red on a docs-only PR: "Count = 0, want 1"). A 2s TTL leaves a full
+	// second of margin, which no scheduler stall between two local SQL
+	// statements can eat.
+	sm := newTestSessionManager(t, 2*time.Second)
 	ctx := context.Background()
 
 	if _, _, err := sm.Create(ctx, "", ""); err != nil {
 		t.Fatalf("Create #1: %v", err)
 	}
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(2100 * time.Millisecond)
 	if _, _, err := sm.Create(ctx, "", ""); err != nil {
 		t.Fatalf("Create #2: %v", err)
 	}


### PR DESCRIPTION
test(auth): give the session-purge test a whole-second margin — expires_at is stored at second precision, and a 1s TTL made the flake a ~1% dice roll

Observed failure: CI shard (2,4) went red on a docs-only PR with
`TestSessionCreatePurgesExpiredRows: Count = 0, want 1 (expired row purged
on login)`.

Mechanism (read from auth/session.go, not guessed): `formatSessionTime`
stores RFC3339 **without** a fractional part, so a row's real lifetime is
`TTL - fraction-of-second-at-creation`. The test used TTL=1s and slept
1.1s, so row #1 is correctly purged by Create #2 — but row #2's stored
expiry can be as little as ~0ms ahead of the next whole second. `Count`
counts `expires_at > now` at the same second precision, so if the few
milliseconds between Create #2's INSERT and Count's SELECT cross a
whole-second boundary, the brand-new row counts as expired and Count
returns 0. A ~1% roll per run; slow shared runners widen the window.

Fix is test-side and keeps the assertion's meaning: TTL 2s + sleep 2.1s
leaves a full second of margin between "row #1 is purgeable" and "row #2
is still live", which no scheduler stall between two local SQL statements
can eat. The product behaviour (second-precision expiry, purge-on-login)
is unchanged — a session expiring up to 1s early is the documented
precision of the stored format, not a defect worth a storage-format change.

Local: -count=40 green (85.7s), full auth package green.
