### PR TITLE
fix(tokens): converge the default relay credential when the upstream rotates its key — re-login answered success:true while relay stayed dead

### DIFF
--- a/handler/admin/account_tokens_sync.go
+++ b/handler/admin/account_tokens_sync.go
@@ -325,12 +325,32 @@ func executeAccountTokenSync(ctx context.Context, db *sqlx.DB, cfg *config.Confi
 	}
 	base["message"] = fmt.Sprintf("sync completed: %d created, %d updated, %d total", syncResult.Created, syncResult.Updated, syncResult.Total)
 
+	eventTitle := "Account token sync completed"
+	eventLevel := "info"
+	if switched := syncResult.DefaultSwitch; switched != nil {
+		base["defaultSwitched"] = true
+		base["defaultSwitchedFrom"] = map[string]any{"id": switched.FromTokenID, "name": switched.FromTokenName}
+		base["defaultSwitchedTo"] = map[string]any{"id": switched.ToTokenID, "name": switched.ToTokenName}
+		base["message"] = base["message"].(string) + fmt.Sprintf(
+			"; default relay token switched: %q is no longer listed upstream, now using %q",
+			switched.FromTokenName, switched.ToTokenName,
+		)
+		// The account's relay credential moved without the operator clicking
+		// anything. That is the fact they need after an upstream key rotation, so
+		// it gets its own event at warning instead of folding into a routine
+		// success line.
+		eventTitle = "Account token sync switched the default relay token"
+		eventLevel = "warning"
+	} else if reason := syncResult.DefaultSwitchSkipped; reason != "" {
+		base["defaultSwitchSkipped"] = reason
+	}
+
 	_ = service.CreateEvent(
 		db,
 		"token_sync",
-		"Account token sync completed",
+		eventTitle,
 		base["message"].(string),
-		"info",
+		eventLevel,
 		accountID,
 		"account",
 	)

--- a/handler/admin/accounts_login_token_rotation_test.go
+++ b/handler/admin/accounts_login_token_rotation_test.go
@@ -1,0 +1,145 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Observed failure (v0.19 stability window, reproduced against a real New API
+// upstream and a real relay): the operator rotated their upstream API key —
+// deleted the old one, created a new one. Re-logging the account in is the only
+// recovery step the docs teach, and it answered success:true while relay stayed
+// dead: the revoked key remained the account's default credential, so
+// accounts.api_token kept the dead value, the model refresh failed with
+// "API key is invalid", the route rebuild was skipped along with it, and the
+// chain only came back after a manual set-default plus a manual route rebuild.
+//
+// This test drives the same sequence through the login handler: after the
+// upstream rotates the key, one more login must leave the account relaying with
+// the key the upstream still lists, and must say so in its own response.
+func TestAccounts_LoginConvergesDefaultRelayTokenAfterUpstreamRotation(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+
+	var rotated atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/api/user/login":
+			fmt.Fprint(w, `{"success":true,"data":{"access_token":"dashboard-pat"}}`)
+		case req.Method == http.MethodGet && strings.HasPrefix(req.URL.Path, "/api/token/"):
+			if rotated.Load() {
+				fmt.Fprint(w, `{"success":true,"data":{"items":[{"id":2,"name":"metapi-aged-2","key":"sk-live-key","status":1}]}}`)
+				return
+			}
+			fmt.Fprint(w, `{"success":true,"data":{"items":[{"id":1,"name":"metapi-aged","key":"sk-revoked-key","status":1}]}}`)
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/models":
+			// The relay key is the only credential that can list models here, so a
+			// stale default is visible as a failed refresh — exactly what the real
+			// upstream answered ("model fetch failed: API key is invalid"). The key
+			// the upstream honours is the one it still lists.
+			liveKey := "sk-revoked-key"
+			if rotated.Load() {
+				liveKey = "sk-live-key"
+			}
+			if req.Header.Get("Authorization") == "Bearer "+liveKey {
+				fmt.Fprint(w, `{"object":"list","data":[{"id":"gpt-4o-mini","object":"model"},{"id":"claude-3-5-sonnet-20241022","object":"model"}]}`)
+				return
+			}
+			http.Error(w, `{"error":{"message":"Invalid token","type":"new_api_error"}}`, http.StatusUnauthorized)
+		case req.Method == http.MethodGet && req.URL.Path == "/api/user/self":
+			fmt.Fprint(w, `{"success":true,"data":{"id":1,"username":"root"}}`)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "token rotation",
+		"url":      upstream.URL,
+		"platform": "new-api",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	if err := json.Unmarshal(siteResp.Body.Bytes(), &site); err != nil {
+		t.Fatalf("decode site: %v", err)
+	}
+	siteID := int64(site["id"].(float64))
+
+	firstLogin := doPostJSON(t, r, "/api/accounts/login", map[string]any{
+		"siteId": siteID, "username": "root", "password": "metapi123",
+	})
+	if firstLogin.Code != http.StatusOK {
+		t.Fatalf("first login: %d %s", firstLogin.Code, firstLogin.Body.String())
+	}
+	var first map[string]any
+	if err := json.Unmarshal(firstLogin.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode first login: %v", err)
+	}
+	accountID := int64(first["account"].(map[string]any)["id"].(float64))
+	if refresh, _ := first["modelRefresh"].(map[string]any); refresh == nil || refresh["success"] != true {
+		t.Fatalf("baseline modelRefresh = %#v, want success before the rotation", first["modelRefresh"])
+	}
+
+	// The operator rotates the upstream key: the old one stops existing.
+	rotated.Store(true)
+
+	secondLogin := doPostJSON(t, r, "/api/accounts/login", map[string]any{
+		"siteId": siteID, "username": "root", "password": "metapi123",
+	})
+	if secondLogin.Code != http.StatusOK {
+		t.Fatalf("second login: %d %s", secondLogin.Code, secondLogin.Body.String())
+	}
+	var second map[string]any
+	if err := json.Unmarshal(secondLogin.Body.Bytes(), &second); err != nil {
+		t.Fatalf("decode second login: %v", err)
+	}
+
+	// 1. The credential the account relays with is the key upstream still lists.
+	var apiToken *string
+	if err := db.Get(&apiToken, `SELECT api_token FROM accounts WHERE id = ?`, accountID); err != nil {
+		t.Fatalf("read accounts.api_token: %v", err)
+	}
+	if apiToken == nil || *apiToken != "sk-live-key" {
+		t.Fatalf("accounts.api_token = %v, want sk-live-key after the documented recovery step", apiToken)
+	}
+
+	// 2. The default moved, and the revoked row is still there as a record.
+	var defaultName string
+	if err := db.Get(&defaultName, `SELECT name FROM account_tokens WHERE account_id = ? AND is_default = TRUE`, accountID); err != nil {
+		t.Fatalf("read default token: %v", err)
+	}
+	if defaultName != "metapi-aged-2" {
+		t.Fatalf("default token = %q, want metapi-aged-2", defaultName)
+	}
+	var revokedRows int
+	if err := db.Get(&revokedRows, `SELECT COUNT(*) FROM account_tokens WHERE account_id = ? AND token = 'sk-revoked-key'`, accountID); err != nil {
+		t.Fatalf("count revoked token rows: %v", err)
+	}
+	if revokedRows != 1 {
+		t.Fatalf("revoked token rows = %d, want 1 (converged, not deleted)", revokedRows)
+	}
+
+	// 3. The loop closes on its own: with a live default the model refresh
+	//    succeeds, which is what makes the route rebuild run instead of being
+	//    skipped along with the failure.
+	refresh, _ := second["modelRefresh"].(map[string]any)
+	if refresh == nil || refresh["success"] != true {
+		t.Fatalf("modelRefresh after rotation = %#v, want success (the refresh must use the converged credential)", second["modelRefresh"])
+	}
+
+	// 4. The response says the credential moved. An operator who rotated a key
+	//    upstream has to be able to see that Metapi followed, without reading the
+	//    database.
+	message, _ := second["tokenSyncMessage"].(string)
+	if !strings.Contains(message, "default relay token switched") || !strings.Contains(message, "metapi-aged-2") {
+		t.Fatalf("tokenSyncMessage = %q, want it to name the switch and the key now in use", message)
+	}
+}

--- a/platform/adapter.go
+++ b/platform/adapter.go
@@ -120,6 +120,15 @@ type TokenVerifyResult struct {
 	Models    []string
 }
 
+// UpstreamTokenListPageLimit is the per-endpoint page size every adapter uses
+// when it lists a site's upstream API tokens (new-api/one-api pass it as
+// `size=`, sub2api as `page_size=`). It is exported because a caller that
+// reasons about "this key is not in the upstream list" has to know whether the
+// list could have been truncated: sub2api lists two endpoints, so its combined
+// answer can reach twice this size, and an absent key only proves revocation
+// when the listing was complete.
+const UpstreamTokenListPageLimit = 100
+
 // ApiTokenInfo describes a single API key/token.
 type ApiTokenInfo struct {
 	Name       string `json:"name"`

--- a/platform/newapi_tokens.go
+++ b/platform/newapi_tokens.go
@@ -9,6 +9,14 @@ import (
 
 // --- Token CRUD ---
 
+// apiTokenListPath is the new-api/one-api token listing path with the shared
+// page limit applied, so the six call sites across the two adapters cannot
+// drift from UpstreamTokenListPageLimit (the service-layer convergence guard
+// reads the same constant to decide whether a listing could be truncated).
+func apiTokenListPath() string {
+	return fmt.Sprintf("/api/token/?p=0&size=%d", UpstreamTokenListPageLimit)
+}
+
 func (n *NewApiAdapter) GetAPIToken(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) (*string, error) {
 	tokens, err := n.GetAPITokens(ctx, baseURL, accessToken, platformUserId, proxy)
 	if err != nil {
@@ -35,7 +43,7 @@ func (n *NewApiAdapter) getAPITokenWithUser(ctx context.Context, baseURL, access
 func (n *NewApiAdapter) getAPITokensWithUser(ctx context.Context, baseURL, accessToken string, userID *int, proxy *ProxyConfig) ([]ApiTokenInfo, error) {
 	// Try Bearer auth
 	headers := n.authHeaders(accessToken, userID)
-	resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, headers, proxy)
+	resp, err := fetchJSON(ctx, baseURL+apiTokenListPath(), "GET", nil, headers, proxy)
 	if err == nil {
 		items := parseTokenItemsFromMap(resp)
 		normalized, normalizeErr := n.normalizeListedTokens(ctx, baseURL, items, headers, proxy)
@@ -78,7 +86,7 @@ func (n *NewApiAdapter) getAPITokensByCookie(ctx context.Context, baseURL, token
 			headers[k] = v
 		}
 
-		resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, headers, proxy)
+		resp, err := fetchJSON(ctx, baseURL+apiTokenListPath(), "GET", nil, headers, proxy)
 		if err != nil {
 			continue
 		}
@@ -241,7 +249,7 @@ func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 	reason := ""
 
 	// Try Bearer auth list
-	resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, n.authHeaders(accessToken, resolvedUserID), proxy)
+	resp, err := fetchJSON(ctx, baseURL+apiTokenListPath(), "GET", nil, n.authHeaders(accessToken, resolvedUserID), proxy)
 	if err != nil {
 		reason = err.Error()
 	} else {
@@ -276,7 +284,7 @@ func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 
 		// List if not already found
 		if tokenID == nil {
-			resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, headers, proxy)
+			resp, err := fetchJSON(ctx, baseURL+apiTokenListPath(), "GET", nil, headers, proxy)
 			if err != nil {
 				reason = err.Error()
 			} else {

--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -293,7 +293,7 @@ func (o *OneApiAdapter) GetModels(ctx context.Context, baseURL string, apiToken 
 // GetAPITokens: GET /api/token/?p=0&size=100 (Bearer auth).
 func (o *OneApiAdapter) GetAPITokens(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) ([]ApiTokenInfo, error) {
 	headers := authBearerHeaders(accessToken)
-	resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, headers, proxy)
+	resp, err := fetchJSON(ctx, baseURL+apiTokenListPath(), "GET", nil, headers, proxy)
 	if err != nil {
 		// Propagate: an unreachable or unauthorized token listing is not the same
 		// fact as "this account has no tokens". Returning an empty list here made
@@ -401,7 +401,7 @@ func (o *OneApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 	headers := authBearerHeaders(accessToken)
 
 	// List tokens
-	resp, err := fetchJSON(ctx, baseURL+"/api/token/?p=0&size=100", "GET", nil, headers, proxy)
+	resp, err := fetchJSON(ctx, baseURL+apiTokenListPath(), "GET", nil, headers, proxy)
 	if err != nil {
 		return fmt.Errorf("list upstream tokens: %w", err)
 	}

--- a/platform/sub2api.go
+++ b/platform/sub2api.go
@@ -711,8 +711,8 @@ func (s *Sub2ApiAdapter) resolveManagementBaseURL(baseURL string) string {
 
 func (s *Sub2ApiAdapter) listAPIKeys(ctx context.Context, baseURL, accessToken string, proxy *ProxyConfig) ([]sub2apiKeyItem, error) {
 	endpoints := []string{
-		"/api/v1/keys?page=1&page_size=100",
-		"/api/v1/api-keys?page=1&page_size=100",
+		fmt.Sprintf("/api/v1/keys?page=1&page_size=%d", UpstreamTokenListPageLimit),
+		fmt.Sprintf("/api/v1/api-keys?page=1&page_size=%d", UpstreamTokenListPageLimit),
 	}
 
 	headers := authBearerHeaders(accessToken)

--- a/service/account_token_service.go
+++ b/service/account_token_service.go
@@ -485,6 +485,16 @@ type UpstreamAPIToken struct {
 	TokenGroup string
 }
 
+// TokenDefaultSwitch records one convergence SyncTokensFromUpstream had to
+// perform: the stored default relay credential is no longer listed upstream, so
+// the default moved to a key the upstream still lists.
+type TokenDefaultSwitch struct {
+	FromTokenID   int64
+	FromTokenName string
+	ToTokenID     int64
+	ToTokenName   string
+}
+
 // TokenSyncResult summarizes SyncTokensFromUpstream outcomes.
 type TokenSyncResult struct {
 	Created         int
@@ -493,6 +503,13 @@ type TokenSyncResult struct {
 	PendingTokenIDs []int64
 	Total           int
 	DefaultTokenID  *int64
+	// DefaultSwitch is non-nil when the default relay credential moved because
+	// the key it pointed at is gone upstream.
+	DefaultSwitch *TokenDefaultSwitch
+	// DefaultSwitchSkipped names why an absent default was deliberately NOT
+	// re-elected, so a caller can tell "nothing to converge" from "could not
+	// prove the listing was complete". Empty when no skip decision was made.
+	DefaultSwitchSkipped string
 }
 
 // PlatformAPITokensToUpstream converts platform.ApiTokenInfo values to the
@@ -698,6 +715,16 @@ func SyncTokensFromUpstream(db *sqlx.DB, accountID int64, upstreamTokens []Upstr
 		}
 	}
 
+	// Converge the default relay credential before repairing it: an operator who
+	// rotated their upstream key must get a working default from the sync itself,
+	// not from a second manual "set default" click (see the function comment).
+	switched, skipReason, err := convergeDefaultTokenOnUpstreamAbsence(db, accountID, existing, upstreamTokens)
+	if err != nil {
+		return nil, err
+	}
+	result.DefaultSwitch = switched
+	result.DefaultSwitchSkipped = skipReason
+
 	repaired, err := RepairDefaultToken(db, accountID)
 	if err != nil {
 		return nil, err
@@ -708,6 +735,102 @@ func SyncTokensFromUpstream(db *sqlx.DB, accountID int64, upstreamTokens []Upstr
 	}
 	result.Total = len(existing)
 	return result, nil
+}
+
+// convergeDefaultTokenOnUpstreamAbsence re-elects the account's default relay
+// credential when the key it points at is provably gone upstream.
+//
+// Observed failure (v0.19 stability window, Aged run on master 693e4050): an
+// operator deleted one New API key and created another. Re-logging the account
+// in — the one recovery step the docs teach — synced the new key into
+// account_tokens but left the revoked one as is_default, so accounts.api_token
+// kept the dead value, the model refresh failed with "API key is invalid", the
+// route rebuild was skipped with it, and relay stayed 401 then 503 "no available
+// channels" until someone set the default by hand and rebuilt routes. The sync
+// answered success:true the whole time.
+//
+// "Not in the listing" only proves revocation when the listing is the whole
+// truth, so three guards gate the switch:
+//   - the listing is shorter than the adapters' page limit (a full listing may
+//     be truncated, and sub2api answers from two endpoints);
+//   - no listed key is a masked display value (a hydrated real key never equals
+//     its own mask, so absence there would be a hydration artifact, #1179);
+//   - the stored default is a ready row, i.e. its value is comparable at all.
+//
+// Operator intent is never overridden: the replacement must already be enabled,
+// and an absent default with no enabled replacement is left exactly as it was —
+// the relay failure stays loud instead of being traded for a silent guess.
+func convergeDefaultTokenOnUpstreamAbsence(
+	db *sqlx.DB,
+	accountID int64,
+	tokens []store.AccountToken,
+	upstream []UpstreamAPIToken,
+) (*TokenDefaultSwitch, string, error) {
+	var current *store.AccountToken
+	for i := range tokens {
+		if tokens[i].IsDefault {
+			current = &tokens[i]
+			break
+		}
+	}
+	if current == nil || ResolveAccountTokenValueStatus(current) != TokenValueStatusReady {
+		return nil, "", nil
+	}
+	if len(upstream) >= platform.UpstreamTokenListPageLimit {
+		return nil, "upstream_listing_may_be_truncated", nil
+	}
+
+	listed := make(map[string]struct{}, len(upstream))
+	for _, item := range upstream {
+		key := strings.TrimSpace(item.Key)
+		if key == "" {
+			continue
+		}
+		if IsMaskedTokenValue(key) {
+			return nil, "upstream_listing_is_masked", nil
+		}
+		listed[key] = struct{}{}
+	}
+	if _, ok := listed[strings.TrimSpace(current.Token)]; ok {
+		return nil, "", nil
+	}
+
+	var candidate *store.AccountToken
+	for i := range tokens {
+		row := &tokens[i]
+		if row.ID == current.ID || !row.Enabled {
+			continue
+		}
+		if ResolveAccountTokenValueStatus(row) != TokenValueStatusReady {
+			continue
+		}
+		if _, ok := listed[strings.TrimSpace(row.Token)]; !ok {
+			continue
+		}
+		if candidate == nil || row.ID < candidate.ID {
+			candidate = row
+		}
+	}
+	if candidate == nil {
+		return nil, "no_enabled_token_listed_upstream", nil
+	}
+
+	// SetDefaultToken is the existing owner of "which credential does this
+	// account relay with": it clears the other defaults, enables the chosen row
+	// and rewrites accounts.api_token in one transaction.
+	switched, err := SetDefaultToken(db, candidate.ID)
+	if err != nil {
+		return nil, "", err
+	}
+	if !switched {
+		return nil, "replacement_not_usable", nil
+	}
+	return &TokenDefaultSwitch{
+		FromTokenID:   current.ID,
+		FromTokenName: current.Name,
+		ToTokenID:     candidate.ID,
+		ToTokenName:   candidate.Name,
+	}, "", nil
 }
 
 // GetDefaultTokenForAccount returns the default token for an account.

--- a/service/account_token_sync_convergence_test.go
+++ b/service/account_token_sync_convergence_test.go
@@ -1,0 +1,183 @@
+package service
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/platform"
+)
+
+// Observed failure (v0.19 stability window, Aged run on a real New API
+// upstream): the operator deleted one upstream key and created another. The
+// documented recovery — re-login the account — synced the new key in but left
+// the revoked one as the default, so accounts.api_token kept the dead value and
+// relay stayed 401/503 until someone set the default by hand and rebuilt
+// routes. Sync answered success:true the whole time.
+func TestSyncTokensFromUpstreamSwitchesDefaultWhenStoredDefaultGoneUpstream(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "ConvergeDefaultSite", "https://converge-default.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("converge-user"), "dashboard-pat")
+	revokedID := createTestAccountToken(t, db, accountID, "metapi-aged", "sk-revoked-key", true)
+	if _, err := db.Exec("UPDATE accounts SET api_token = ? WHERE id = ?", "sk-revoked-key", accountID); err != nil {
+		t.Fatalf("seed accounts.api_token: %v", err)
+	}
+
+	result, err := SyncTokensFromUpstream(db.DB, accountID, []UpstreamAPIToken{
+		{Name: "metapi-aged-2", Key: "sk-live-key", Enabled: true, TokenGroup: "default"},
+	})
+	if err != nil {
+		t.Fatalf("SyncTokensFromUpstream: %v", err)
+	}
+	if result.Created != 1 {
+		t.Fatalf("created = %d, want 1", result.Created)
+	}
+	if result.DefaultSwitchSkipped != "" {
+		t.Fatalf("DefaultSwitchSkipped = %q, want empty", result.DefaultSwitchSkipped)
+	}
+	sw := result.DefaultSwitch
+	if sw == nil {
+		t.Fatal("DefaultSwitch = nil, want the default relay credential to move to the key upstream still lists")
+	}
+	if sw.FromTokenID != revokedID || sw.FromTokenName != "metapi-aged" {
+		t.Fatalf("DefaultSwitch.From = (%d, %q), want (%d, %q)", sw.FromTokenID, sw.FromTokenName, revokedID, "metapi-aged")
+	}
+	if sw.ToTokenName != "metapi-aged-2" {
+		t.Fatalf("DefaultSwitch.ToTokenName = %q, want metapi-aged-2", sw.ToTokenName)
+	}
+
+	assertTokenDefaultState(t, db, revokedID, false)
+	assertTokenDefaultState(t, db, sw.ToTokenID, true)
+
+	var apiToken *string
+	if err := db.QueryRow("SELECT api_token FROM accounts WHERE id = ?", accountID).Scan(&apiToken); err != nil {
+		t.Fatalf("read accounts.api_token: %v", err)
+	}
+	if apiToken == nil || *apiToken != "sk-live-key" {
+		t.Fatalf("accounts.api_token = %v, want the live upstream key (this is the credential relay and the model refresh use)", apiToken)
+	}
+	if result.DefaultTokenID == nil || *result.DefaultTokenID != sw.ToTokenID {
+		t.Fatalf("DefaultTokenID = %v, want %d", result.DefaultTokenID, sw.ToTokenID)
+	}
+
+	// The revoked row is a record, not garbage: it stays readable and enabled
+	// state is untouched, so an operator can still see what was replaced.
+	var stillThere int
+	var enabled bool
+	if err := db.QueryRow("SELECT COUNT(*), MAX(enabled) FROM account_tokens WHERE id = ?", revokedID).Scan(&stillThere, &enabled); err != nil {
+		t.Fatalf("read revoked row: %v", err)
+	}
+	if stillThere != 1 {
+		t.Fatal("the revoked token row was deleted; sync must converge the default, not destroy history")
+	}
+}
+
+func TestSyncTokensFromUpstreamLeavesDefaultAloneWhenStillListedUpstream(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "ConvergeNoopSite", "https://converge-noop.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("noop-user"), "dashboard-pat")
+	defaultID := createTestAccountToken(t, db, accountID, "kept", "sk-kept-key", true)
+
+	result, err := SyncTokensFromUpstream(db.DB, accountID, []UpstreamAPIToken{
+		{Name: "kept", Key: "sk-kept-key", Enabled: true, TokenGroup: "default"},
+		{Name: "second", Key: "sk-second-key", Enabled: true, TokenGroup: "default"},
+	})
+	if err != nil {
+		t.Fatalf("SyncTokensFromUpstream: %v", err)
+	}
+	if result.DefaultSwitch != nil {
+		t.Fatalf("DefaultSwitch = %#v, want nil while the default key is still listed upstream", result.DefaultSwitch)
+	}
+	if result.DefaultSwitchSkipped != "" {
+		t.Fatalf("DefaultSwitchSkipped = %q, want empty (no absence, no skip decision)", result.DefaultSwitchSkipped)
+	}
+	assertTokenDefaultState(t, db, defaultID, true)
+}
+
+// A listing that fills the page may be truncated, and "absent from a truncated
+// listing" does not prove revocation. Guessing here would move the default away
+// from a perfectly good key.
+func TestSyncTokensFromUpstreamSkipsDefaultSwitchOnTruncatedListing(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "ConvergeTruncatedSite", "https://converge-truncated.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("truncated-user"), "dashboard-pat")
+	defaultID := createTestAccountToken(t, db, accountID, "kept", "sk-kept-key", true)
+
+	upstream := make([]UpstreamAPIToken, 0, platform.UpstreamTokenListPageLimit)
+	for i := 0; i < platform.UpstreamTokenListPageLimit; i++ {
+		upstream = append(upstream, UpstreamAPIToken{
+			Name:       "filler",
+			Key:        "sk-filler-" + strconv.Itoa(i),
+			Enabled:    true,
+			TokenGroup: "default",
+		})
+	}
+
+	result, err := SyncTokensFromUpstream(db.DB, accountID, upstream)
+	if err != nil {
+		t.Fatalf("SyncTokensFromUpstream: %v", err)
+	}
+	if result.DefaultSwitch != nil {
+		t.Fatalf("DefaultSwitch = %#v, want nil when the listing may be truncated", result.DefaultSwitch)
+	}
+	if result.DefaultSwitchSkipped != "upstream_listing_may_be_truncated" {
+		t.Fatalf("DefaultSwitchSkipped = %q, want upstream_listing_may_be_truncated", result.DefaultSwitchSkipped)
+	}
+	assertTokenDefaultState(t, db, defaultID, true)
+}
+
+// New API lists masked keys (`sk-****`) unless the batch-keys endpoint hydrates
+// them (#1179). A hydrated real key never equals its own mask, so absence in a
+// masked listing is an artifact of hydration, not a revocation.
+func TestSyncTokensFromUpstreamSkipsDefaultSwitchOnMaskedListing(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "ConvergeMaskedSite", "https://converge-masked.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("masked-user"), "dashboard-pat")
+	defaultID := createTestAccountToken(t, db, accountID, "hydrated", "sk-real-key-value", true)
+
+	result, err := SyncTokensFromUpstream(db.DB, accountID, []UpstreamAPIToken{
+		{Name: "hydrated", Key: "sk-r*********alue", Enabled: true, TokenGroup: "default"},
+	})
+	if err != nil {
+		t.Fatalf("SyncTokensFromUpstream: %v", err)
+	}
+	if result.DefaultSwitch != nil {
+		t.Fatalf("DefaultSwitch = %#v, want nil when the listing only carries masked display values", result.DefaultSwitch)
+	}
+	if result.DefaultSwitchSkipped != "upstream_listing_is_masked" {
+		t.Fatalf("DefaultSwitchSkipped = %q, want upstream_listing_is_masked", result.DefaultSwitchSkipped)
+	}
+	assertTokenDefaultState(t, db, defaultID, true)
+}
+
+// Operator intent outranks convergence: a key the operator disabled is not an
+// eligible replacement, and sync must not re-enable it (existing contract).
+func TestSyncTokensFromUpstreamSkipsDefaultSwitchWhenReplacementIsOperatorDisabled(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "ConvergeDisabledSite", "https://converge-disabled.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("disabled-user"), "dashboard-pat")
+	defaultID := createTestAccountToken(t, db, accountID, "revoked-default", "sk-revoked-key", true)
+	disabledID := createTestAccountTokenWithEnabled(t, db, accountID, "ops-disabled", "sk-live-key", false, false)
+
+	result, err := SyncTokensFromUpstream(db.DB, accountID, []UpstreamAPIToken{
+		{Name: "ops-disabled", Key: "sk-live-key", Enabled: true, TokenGroup: "default"},
+	})
+	if err != nil {
+		t.Fatalf("SyncTokensFromUpstream: %v", err)
+	}
+	if result.DefaultSwitch != nil {
+		t.Fatalf("DefaultSwitch = %#v, want nil: the only listed key is operator-disabled", result.DefaultSwitch)
+	}
+	if result.DefaultSwitchSkipped != "no_enabled_token_listed_upstream" {
+		t.Fatalf("DefaultSwitchSkipped = %q, want no_enabled_token_listed_upstream", result.DefaultSwitchSkipped)
+	}
+	assertTokenDefaultState(t, db, defaultID, true)
+	assertTokenDefaultState(t, db, disabledID, false)
+
+	var enabled bool
+	if err := db.QueryRow("SELECT enabled FROM account_tokens WHERE id = ?", disabledID).Scan(&enabled); err != nil {
+		t.Fatalf("read disabled token: %v", err)
+	}
+	if enabled {
+		t.Fatal("sync re-enabled an operator-disabled token while looking for a replacement")
+	}
+}


### PR DESCRIPTION
Observed failure: v0.19 stability window, Aged state, against a real New API
upstream (candidate bytes = master `693e4050`, one-shot instance + empty
DATA_DIR, and a **dedicated upstream user** so the long-running testbed instance
shared no credential with the experiment). The upstream key was deleted and a new
one created through New API's own API — no Metapi database was edited.
Re-logging the account in, the only recovery step the docs teach, answered
`success:true` / `tokenSyncMessage: "sync completed: 1 created, 0 updated, 2 total"`
and relay still did not come back:

  * the revoked key stayed `is_default=1` / `value_status=ready`, so
    `accounts.api_token` kept the dead value;
  * the model refresh therefore failed with `errorCode=unauthorized`
    ("model fetch failed: API key is invalid") and the route rebuild was skipped
    along with it (`rebuild: {}`);
  * relay returned the upstream's structured 401, then 503 "no available
    channels: 冷却中" once both channels sat in `auth_error` cooldown;
  * clicking sync again reported `defaultTokenId` = the revoked row.

Recovery took two calls that nothing in the UI or the response mentioned —
`POST /api/account-tokens/{id}/default` then `POST /api/routes/rebuild` — before a
completion reached the upstream again (mock upstream log confirms the expected
model). Full run: `.dev-local/overhaul-20260904/stability-v019/master-verify/aged/EVIDENCE.md` §3b.

Mechanism (read from the code, not guessed): `SyncTokensFromUpstream` only
upserts — it matches stored rows by exact key value, creates what is new, and
preserves local enable state. It never asks whether the key the account relays
with is still listed upstream. `RepairDefaultToken` runs afterwards but only
elects when there is *no* usable default, so a revoked default was carried
forward verbatim while a live key sat beside it unused. The failure semantics
themselves held — this is not a `[] + nil` regression; every layer said what it
knew, the account just never converged.

Fix stays in the owner that already has the data:

  * after the upsert, when the stored default is a ready row whose key the
    upstream no longer lists, re-elect through the existing `SetDefaultToken`
    (one transaction: clears the other defaults, enables the chosen row,
    rewrites `accounts.api_token`). The login path re-reads the account for its
    model refresh, so a single re-login now closes the loop — refresh succeeds,
    rebuild runs, channels converge;
  * the switch is reported (`defaultSwitched`, `defaultSwitchedFrom|To`, plus a
    sentence appended to `message`, which is what `tokenSyncMessage` carries into
    the account-created toast) and written to the event feed at `warning`: the
    relay credential moved without the operator clicking anything, so it must not
    fold into a routine success line;
  * the revoked row is left in place — converged, not deleted.

"Absent from the listing" only proves revocation when the listing is the whole
truth, so three guards gate the switch and each records a skip reason instead of
a silent no-op: shorter than the adapters' page limit
(`upstream_listing_may_be_truncated`; sub2api answers from two endpoints, so its
list can reach 2×), no masked display value anywhere in the listing
(`upstream_listing_is_masked` — a hydrated real key never equals its own mask,
the #1179 shape), and the replacement already operator-enabled
(`no_enabled_token_listed_upstream`). Operator intent still outranks
convergence: sync neither re-enables a disabled key nor elects one.

`platform.UpstreamTokenListPageLimit` becomes the single owner of the page size
the token-listing call sites ask for (new-api ×4, one-api ×2, sub2api ×2), so the
guard and the fetch cannot drift apart — a service-local copy of `100` would
silently switch this fix off the day someone widens the page.

Tests: `service/account_token_sync_convergence_test.go` (the observed failure +
the three guards + the no-op) and
`handler/admin/accounts_login_token_rotation_test.go` (the path a user actually
walks: rotate the upstream key, log in once, assert `accounts.api_token`, the
default row, a successful model refresh, and a response that names the switch).

Mutation probes — committed first, so every revert was a plain
`git checkout --` with no uncommitted work at stake:

| arm | mutation | result |
|---|---|---|
| 0 | none (baseline) | green |
| A | drop the convergence call | **red** (service + handler) |
| B | truncation guard → `1<<30` | **red** |
| C | masked-listing guard removed | **red** |
| D | `!row.Enabled` candidate filter removed | **red** |
| — | restored | green, tree clean |

Local: `go build ./...` and `go vet ./...` clean; staticcheck clean on
platform / service / handler-admin; targeted suites green — platform, service
(+14 subpackages), handler/admin (47.7s), handler/admin/payloads, handler/proxy,
handler/shared, docs, store: **21/21 packages ok**, scope verified with
`go list` (0 packages skipped). leak-guard `--range master..HEAD` exit 0 with a
staged-fake-token negative control exit 1.

Not in scope, recorded instead of fixed here: the same run found that an
upstream whose check-in is disabled ("签到功能未启用") is bucketed as an unknown
failure — account `unhealthy` + an `error`-level `checkinFailed` event — because
`isUnsupportedCheckinMessage` only knows the English phrasings. That is a
separate observed failure with its own ledger row and its own PR.
