### PR TITLE
fix(checkin): an upstream that has no check-in is not a failed check-in — one vocabulary owner, and it now knows the localized wordings

### DIFF
--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -553,6 +553,14 @@ func shouldFallbackToCookieCheckin(msg string) bool {
 		strings.Contains(lower, "未提供")
 }
 
+// isMissingCheckinEndpointMessage gates one decision only: whether the cookie
+// retry ladder is worth climbing after the Bearer attempt already said the
+// endpoint is not there. It is deliberately NOT the product-level "this site has
+// no check-in" classifier — that owner is service.IsUnsupportedCheckinMessage,
+// which also carries the localized upstream wordings (New API answers
+// 签到功能未启用) and decides status, failure_reason, runtime health and the
+// event level. platform cannot import service, so the two lists stay separate;
+// they answer different questions and only the second one is user-visible.
 func isMissingCheckinEndpointMessage(msg string) bool {
 	lower := strings.ToLower(msg)
 	return strings.Contains(lower, "invalid url (post /api/user/checkin)") ||

--- a/service/account_health.go
+++ b/service/account_health.go
@@ -133,11 +133,11 @@ func IsUnsupportedCheckinRuntimeHealth(health *RuntimeHealthEntry) bool {
 	if strings.ToLower(string(health.Source)) == "checkin" {
 		return true
 	}
-	reason := strings.ToLower(health.Reason)
-	return strings.Contains(reason, "checkin endpoint not found") ||
-		strings.Contains(reason, "invalid url (post /api/user/checkin)") ||
-		(strings.Contains(reason, "http 404") && strings.Contains(reason, "/api/user/checkin")) ||
-		strings.Contains(reason, "unsupported checkin endpoint")
+	// Reason-only fallback for entries written before the source was recorded.
+	// The vocabulary lives in IsUnsupportedCheckinMessage so this cannot drift
+	// from what the check-in runner classifies.
+	return IsUnsupportedCheckinMessage(health.Reason) ||
+		strings.Contains(strings.ToLower(health.Reason), "unsupported checkin endpoint")
 }
 
 // BuildRuntimeHealthForAccount returns the effective runtime health for admin list/detail.

--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -160,21 +160,6 @@ func isAlreadyCheckedInMessage(message string) bool {
 		strings.Contains(text, "签到达")
 }
 
-// isUnsupportedCheckinMessage detects unsupported checkin endpoints.
-func isUnsupportedCheckinMessage(message string) bool {
-	if message == "" {
-		return false
-	}
-	text := strings.ToLower(message)
-	return strings.Contains(text, "invalid url (post /api/user/checkin)") ||
-		(strings.Contains(text, "http 404") && strings.Contains(text, "/api/user/checkin")) ||
-		strings.Contains(text, "checkin endpoint not found") ||
-		strings.Contains(text, "check-in is not supported") ||
-		strings.Contains(text, "checkin is not supported") ||
-		strings.Contains(text, "does not support checkin") ||
-		strings.Contains(text, "not support checkin")
-}
-
 // isManualVerificationRequiredMessage detects Turnstile verification messages.
 func isManualVerificationRequiredMessage(message string) bool {
 	if message == "" {
@@ -456,7 +441,9 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 	// 7. Classify result
 	isCloudflare := alert.IsCloudflareChallenge(result.Message)
 	alreadyCheckedIn := isAlreadyCheckedInMessage(result.Message)
-	unsupportedCheckin := isUnsupportedCheckinMessage(result.Message)
+	// The vocabulary is shared with the failure classifier and the health
+	// reader: service.IsUnsupportedCheckinMessage.
+	unsupportedCheckin := service.IsUnsupportedCheckinMessage(result.Message)
 	manualVerificationRequired := isManualVerificationRequiredMessage(result.Message)
 	manualVerificationMessage := "the site requires Turnstile verification; manual check-in is needed"
 	logMessage := result.Message

--- a/service/checkin/checkin_test.go
+++ b/service/checkin/checkin_test.go
@@ -64,42 +64,6 @@ func TestIsAlreadyCheckedInMessage_Negative(t *testing.T) {
 	}
 }
 
-// ---- isUnsupportedCheckinMessage Tests (7 patterns) ----
-
-func TestIsUnsupportedCheckinMessage_Positive(t *testing.T) {
-	positiveCases := []string{
-		"invalid url (POST /api/user/checkin)",
-		"HTTP 404 /api/user/checkin not found",
-		"checkin endpoint not found",
-		"check-in is not supported",
-		"checkin is not supported",
-		"this site does not support checkin",
-		"does not support checkin feature",
-	}
-	for _, msg := range positiveCases {
-		t.Run(msg, func(t *testing.T) {
-			if !isUnsupportedCheckinMessage(msg) {
-				t.Errorf("expected true for: %q", msg)
-			}
-		})
-	}
-}
-
-func TestIsUnsupportedCheckinMessage_Negative(t *testing.T) {
-	negativeCases := []string{
-		"",
-		"checkin success",
-		"normal error message",
-	}
-	for _, msg := range negativeCases {
-		t.Run(msg, func(t *testing.T) {
-			if isUnsupportedCheckinMessage(msg) {
-				t.Errorf("expected false for: %q", msg)
-			}
-		})
-	}
-}
-
 // ---- isManualVerificationRequiredMessage Tests ----
 
 func TestIsManualVerificationRequiredMessage_Positive(t *testing.T) {

--- a/service/checkin/checkin_unsupported_locale_test.go
+++ b/service/checkin/checkin_unsupported_locale_test.go
@@ -1,0 +1,138 @@
+package checkin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// Observed failure (v0.19 stability window): a real New API upstream with the
+// check-in feature switched off answers its own hardcoded 签到功能未启用. That
+// string was in none of the three English-only "unsupported" lists, so binding
+// an account wrote checkin_logs.status=failed with failure_reason
+// code=unknown_error, published an error-level checkinFailed event, and set
+// runtimeHealth=unhealthy with the upstream's raw text as the reason — for an
+// account whose models, balance and relay all worked. The health entry only
+// recovered when the next hourly balance refresh overwrote it. On the
+// long-running testbed instance that added up to 71 failed check-in rows and 63
+// error events over five days, while the sibling sub2api account — whose
+// "not supported" text Metapi's own adapter writes in English — was classified
+// correctly the whole time.
+func TestCheckinAccount_UpstreamCheckinDisabledIsUnsupportedNotFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/user/self":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"id": 7, "username": "checkin-disabled-user",
+					"quota": 500000, "used_quota": 0,
+				},
+			})
+		case "/api/user/checkin":
+			// Exactly what New API's DoCheckin handler returns when the operator
+			// left the feature off.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": false,
+				"message": "签到功能未启用",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	siteRes, err := db.Exec(
+		"INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, 'new-api', 'active', ?, ?)",
+		"checkin disabled upstream", server.URL, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := siteRes.LastInsertId()
+	acctRes, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', TRUE, ?, ?)",
+		siteID, "checkin-disabled-user", "dashboard-pat", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := acctRes.LastInsertId()
+
+	// Events stay on: the event level is part of what the operator sees.
+	result := CheckinAccount(&config.Config{}, db.DB, accountID, &CheckinOptions{ScheduleMode: "manual"})
+
+	if !result.Success {
+		t.Fatalf("result.Success = false, want true: an upstream without check-in is not a failed check-in")
+	}
+	if result.Status != CheckinSkipped || !result.Skipped {
+		t.Fatalf("result.Status = %q (skipped=%v), want skipped", result.Status, result.Skipped)
+	}
+
+	var logStatus string
+	var failureReason *string
+	if err := db.QueryRow(
+		"SELECT status, failure_reason FROM checkin_logs WHERE account_id = ? ORDER BY rowid DESC LIMIT 1", accountID,
+	).Scan(&logStatus, &failureReason); err != nil {
+		t.Fatalf("read checkin_logs: %v", err)
+	}
+	if logStatus != "skipped" {
+		t.Fatalf("checkin_logs.status = %q, want skipped", logStatus)
+	}
+	if failureReason == nil {
+		t.Fatal("checkin_logs.failure_reason = NULL, want the structured checkin_not_supported classification")
+	}
+	var reason struct {
+		Code     string `json:"code"`
+		Category string `json:"category"`
+	}
+	if err := json.Unmarshal([]byte(*failureReason), &reason); err != nil {
+		t.Fatalf("decode failure_reason %q: %v", *failureReason, err)
+	}
+	if reason.Code != "checkin_not_supported" || reason.Category != "site" {
+		t.Fatalf("failure_reason = (%q, %q), want (checkin_not_supported, site)", reason.Code, reason.Category)
+	}
+
+	var healthRaw *string
+	if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&healthRaw); err != nil {
+		t.Fatalf("read accounts.extra_config: %v", err)
+	}
+	if healthRaw == nil || !strings.Contains(*healthRaw, `"state":"degraded"`) {
+		t.Fatalf("runtime health = %v, want degraded (unhealthy told the operator the account was broken)", healthRaw)
+	}
+	if !strings.Contains(*healthRaw, "does not support check-in") {
+		t.Fatalf("runtime health reason = %v, want Metapi's own unsupported wording instead of the raw upstream text", healthRaw)
+	}
+
+	var errorEvents int
+	var infoEvents int
+	if err := db.QueryRow(
+		"SELECT SUM(CASE WHEN level = 'error' THEN 1 ELSE 0 END), SUM(CASE WHEN level = 'info' THEN 1 ELSE 0 END) FROM events WHERE related_id = ? AND related_type = 'account'",
+		accountID,
+	).Scan(&errorEvents, &infoEvents); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if errorEvents != 0 {
+		t.Fatalf("error-level events = %d, want 0: an upstream without check-in is not an error", errorEvents)
+	}
+	if infoEvents != 1 {
+		t.Fatalf("info-level events = %d, want exactly the one checkinSkipped entry", infoEvents)
+	}
+}

--- a/service/checkin/failure_reason.go
+++ b/service/checkin/failure_reason.go
@@ -3,6 +3,7 @@ package checkin
 import (
 	"strings"
 
+	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/service/alert"
 )
 
@@ -68,11 +69,9 @@ func ClassifyFailureReason(input ClassifyFailureInput) FailureReason {
 	}
 
 	// Priority 2: Checkin not supported
-	if includesAny(text, []string{
-		"checkin endpoint not found", "签到端点不存在", "站点不支持签到",
-		"not support checkin", "check-in is not supported",
-		"checkin is not supported", "does not support checkin",
-	}) {
+	// Same vocabulary the check-in runner and the health reader use, so the
+	// three cannot disagree about what "this site has no check-in" means.
+	if service.IsUnsupportedCheckinMessage(rawMessage) {
 		return FailureReason{
 			Code: CodeCheckinNotSupported, Category: CategorySite,
 			Title: "Check-in not supported", ActionHint: "No retry needed (not a failure)",

--- a/service/checkin_message.go
+++ b/service/checkin_message.go
@@ -1,0 +1,61 @@
+package service
+
+import "strings"
+
+// IsUnsupportedCheckinMessage reports whether an upstream check-in answer means
+// "this site does not offer check-in" rather than "check-in failed".
+//
+// One vocabulary with three readers, which used to be three separate lists:
+// the check-in runner (status, runtime health, event level), the structured
+// failure classifier (checkin_logs.failure_reason) and
+// IsUnsupportedCheckinRuntimeHealth (whether a balance refresh may overwrite the
+// state). Each list was English-only, so a real New API upstream — whose
+// DoCheckin handler answers the hardcoded 签到功能未启用, with 簽到功能未啟用 and
+// "Check-in feature is not enabled" in its locale catalogs — matched none of
+// them. An account whose relay worked perfectly was therefore recorded as
+// checkin failed / unknown_error / runtimeHealth=unhealthy plus an error-level
+// event, and stayed that way until the next hourly balance refresh happened to
+// overwrite the health entry. The already-checked-in classifier next door has
+// been locale-aware all along; this one now is too.
+//
+// The list is enumerated from what supported upstreams actually return, not
+// guessed: adding a speculative phrasing here would silently swallow real
+// failures, which is the one thing this classifier must not do.
+func IsUnsupportedCheckinMessage(message string) bool {
+	text := strings.TrimSpace(message)
+	if text == "" {
+		return false
+	}
+	lower := strings.ToLower(text)
+
+	// Endpoint absent (one-api family and anything else with no check-in route).
+	if strings.Contains(lower, "invalid url (post /api/user/checkin)") {
+		return true
+	}
+	if strings.Contains(lower, "http 404") && strings.Contains(lower, "/api/user/checkin") {
+		return true
+	}
+	if strings.Contains(lower, "checkin endpoint not found") {
+		return true
+	}
+	if strings.Contains(lower, "签到端点不存在") {
+		return true
+	}
+
+	// Feature present but not offered / not enabled.
+	for _, phrase := range [...]string{
+		"check-in is not supported",
+		"checkin is not supported",
+		"does not support checkin",
+		"not support checkin",
+		"check-in feature is not enabled",
+		"站点不支持签到",
+		"签到功能未启用",
+		"簽到功能未啟用",
+	} {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}

--- a/service/checkin_message_test.go
+++ b/service/checkin_message_test.go
@@ -1,0 +1,87 @@
+package service
+
+import "testing"
+
+// The vocabulary moved here from three private copies (the check-in runner, the
+// structured failure classifier and IsUnsupportedCheckinRuntimeHealth), so this
+// table is the one place that decides what "this site has no check-in" means.
+// The localized cases are the observed failure: a real New API upstream answers
+// 签到功能未启用 from its DoCheckin handler, and before this change none of the
+// three lists recognized it — the account was written as checkin failed /
+// unknown_error / runtimeHealth=unhealthy with an error-level event even though
+// its relay worked.
+func TestIsUnsupportedCheckinMessage(t *testing.T) {
+	cases := []struct {
+		message string
+		want    bool
+	}{
+		// Endpoint absent.
+		{"invalid url (POST /api/user/checkin)", true},
+		{"HTTP 404 /api/user/checkin not found", true},
+		{"checkin endpoint not found", true},
+		{"签到端点不存在", true},
+		// Feature present but not offered / not enabled.
+		{"check-in is not supported", true},
+		{"checkin is not supported", true},
+		{"this site does not support checkin", true},
+		{"does not support checkin feature", true},
+		{"Check-in is not supported by Sub2API", true},
+		{"站点不支持签到", true},
+		// New API: the hardcoded answer plus its three locale catalogs.
+		{"签到功能未启用", true},
+		{"簽到功能未啟用", true},
+		{"Check-in feature is not enabled", true},
+		// Real failures must stay failures.
+		{"", false},
+		{"checkin success", false},
+		{"normal error message", false},
+		{"签到失败，请稍后重试", false},
+		{"签到失败：更新额度出错", false},
+		{"Check-in failed, please try again later", false},
+		// A different non-failure family, owned by its own classifier.
+		{"今日已签到", false},
+		{"Already checked in today", false},
+		// Credential failures must never be softened into "unsupported".
+		{"token expired", false},
+		{"401 Unauthorized", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.message, func(t *testing.T) {
+			if got := IsUnsupportedCheckinMessage(tc.message); got != tc.want {
+				t.Fatalf("IsUnsupportedCheckinMessage(%q) = %v, want %v", tc.message, got, tc.want)
+			}
+		})
+	}
+}
+
+// The health reader keeps its own state/source rule and only borrows the
+// vocabulary, so an entry written before the source was recorded is still
+// recognized by its reason.
+func TestIsUnsupportedCheckinRuntimeHealthReasonFallbackSharesVocabulary(t *testing.T) {
+	localized := &RuntimeHealthEntry{
+		State:  HealthDegraded,
+		Reason: "签到功能未启用",
+		Source: HealthSourceBalance,
+	}
+	if !IsUnsupportedCheckinRuntimeHealth(localized) {
+		t.Fatal("a degraded entry whose reason is the upstream's localized 'check-in not enabled' must be recognized as unsupported")
+	}
+
+	realFailure := &RuntimeHealthEntry{
+		State:  HealthDegraded,
+		Reason: "签到失败，请稍后重试",
+		Source: HealthSourceBalance,
+	}
+	if IsUnsupportedCheckinRuntimeHealth(realFailure) {
+		t.Fatal("a genuine check-in failure was classified as unsupported; the state would be preserved instead of re-evaluated")
+	}
+
+	wrongState := &RuntimeHealthEntry{
+		State:  HealthUnhealthy,
+		Reason: "签到功能未启用",
+		Source: HealthSourceBalance,
+	}
+	if IsUnsupportedCheckinRuntimeHealth(wrongState) {
+		t.Fatal("only a degraded entry may be preserved as unsupported check-in")
+	}
+}


### PR DESCRIPTION
Observed failure: v0.19 stability window, on the long-running testbed instance
(five days of rows) and reproduced on candidate bytes. Binding a New API account
whose check-in feature is switched off wrote

    checkin_logs.status        = failed
    checkin_logs.failure_reason= {"code":"unknown_error","category":"unknown",…}
    events                     = level=error, title_key=checkinFailed
    accounts.runtimeHealth     = {"state":"unhealthy","reason":"签到功能未启用",…}

for an account whose models, balance and relay all worked. The health entry only
recovered when the next hourly balance refresh overwrote it, so a freshly bound
account presented as broken during exactly the window a new user is looking at
it — the persona this whole release was about. Instance totals: 71 failed vs 28
skipped check-in rows, 63 error-level `checkinFailed` events. The sibling sub2api
account was classified correctly the whole time, because "Check-in is not
supported by Sub2API" is a sentence Metapi's own adapter writes in English.
Metapi's e2e harness also classified the same upstream answer correctly
(`[PASS] checkin (documented unsupported/negative result)`): the harness knew,
the product did not.

Root cause: "this site has no check-in" was decided by three separate
English-only string lists — the check-in runner (`isUnsupportedCheckinMessage`,
7 patterns), the structured failure classifier (`failure_reason.go` priority 2,
7 patterns, two of them Chinese), and `IsUnsupportedCheckinRuntimeHealth`
(4 patterns). New API's `DoCheckin` answers the hardcoded 签到功能未启用, and its
locale catalogs carry 簽到功能未啟用 and "Check-in feature is not enabled"; none of
the three lists matched, so the answer fell through to the generic failure
branch. The already-checked-in classifier in the same file has been locale-aware
all along (12 forms, 今日已签到 among them) — its neighbour never got the same
treatment.

Fix:

  * one owner. `service.IsUnsupportedCheckinMessage` holds the vocabulary and all
    three readers delegate to it, so they cannot disagree about what "no
    check-in here" means. `service/checkin` already imports `service`, so this
    folds three copies into one with no new package and no new abstraction
    (net −62 lines of duplicated matching);
  * the vocabulary gains only wordings supported upstreams actually emit, read
    out of New API's handler and its three locale catalogs rather than invented —
    a speculative phrasing here would swallow real failures, which is the one
    thing this classifier must not do. The test table pins the negatives as hard
    as the positives: 签到失败，请稍后重试 / 签到失败：更新额度出错 / "Check-in
    failed, please try again later" stay failures, 今日已签到 stays the other
    classifier's case, and `token expired` / `401 Unauthorized` must never be
    softened into "unsupported";
  * the classification the codebase already had for this situation now applies:
    status=skipped, failure_reason `checkin_not_supported` / category `site`,
    runtimeHealth=degraded with Metapi's own reason instead of the raw upstream
    text, and an info-level `checkinSkipped` event instead of an error-level one.

`platform.isMissingCheckinEndpointMessage` is deliberately left alone and now
says why in a comment: it only gates whether the cookie retry ladder is worth
climbing, `platform` cannot import `service` (the import runs the other way), and
it is not user-visible.

Tests: `service/checkin_message_test.go` (the folded table plus the health
reader's reason-only fallback) and
`service/checkin/checkin_unsupported_locale_test.go` (the observed failure end to
end through `CheckinAccount` against an upstream answering 签到功能未启用 —
status, failure_reason JSON, runtime health text, and the event level). The two
vocabulary tests that lived in `service/checkin/checkin_test.go` moved next to
the owner they now test rather than being duplicated.

Mutation probes — committed first, so every revert was a plain `git checkout --`:

| arm | mutation | result |
|---|---|---|
| 0 | none (baseline) | green |
| A | drop the three localized wordings from the owner | **red** (3 subtests + e2e) |
| B | classifier back on its own private list | **red** (failure_reason assertion) |
| C | runner back on English-only matching | **red** (status / health / event) |
| D | health reader back on its own private list | **red** (reason fallback) |
| — | restored | green, tree clean |

Local: `go build ./...` clean; targeted suites green — platform, service (+14
subpackages), handler/admin, handler/admin/payloads, handler/proxy,
handler/shared, docs, store: **21/21 packages ok** (scope cross-checked with
`go list`).

Companion to #1266: both came out of the same Aged run against a real upstream,
and both are the same family — a layer that knew the truth and did not act on it.
