### PR TITLE
fix(checkin): a successful check-in never reached the event feed — the runner sent a param the registry does not declare

### DIFF
--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -543,11 +543,21 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 		} else if normalizedStatus == CheckinSkipped {
 			eventRef.Key = "checkinSkipped"
 		}
-		eventRef.Params = map[string]any{
+		params := map[string]any{
 			"account": orUsername(account.Username, accountID),
 			"site":    site.Name,
-			"reason":  logMessage,
 		}
+		if eventRef.Key == "checkinSuccess" {
+			// The registry's success definition carries the reward, not a reason:
+			// its MessageEn is the historical "{{account}} @ {{site}}: {{reward}}",
+			// and WriteEvent rejects params a definition does not declare. Sending
+			// reason for every key made each successful check-in lose its event and
+			// leave a WARN behind, so the feed only ever showed failures and skips.
+			params["reward"] = logReward
+		} else {
+			params["reason"] = logMessage
+		}
+		eventRef.Params = params
 		if err := events.WriteEvent(db, eventRef, events.Options{Level: eventLevel, RelatedID: accountID, RelatedType: "account"}); err != nil {
 			slog.Warn("CheckinAccount: failed to persist event", "accountID", accountID, "error", err)
 		}

--- a/service/checkin/checkin_success_event_test.go
+++ b/service/checkin/checkin_success_event_test.go
@@ -1,0 +1,106 @@
+package checkin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// Observed failure: the check-in runner sent one param map — {account, site,
+// reason} — for all four check-in event keys, while the structured-event
+// registry declares {account, site, reward} for checkinSuccess (its MessageEn is
+// the historical "{{account}} @ {{site}}: {{reward}}"). WriteEvent rejects a
+// param the definition does not declare, so every successful check-in lost its
+// event and left "events: checkinSuccess does not declare param \"reason\"" in
+// the log. The operator's feed showed failures and skips only — the one thing
+// worth seeing, a check-in that worked, was the one row that never arrived.
+func TestCheckinAccount_SuccessPersistsItsEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/user/self":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				// quota rises by 5000 (=0.01 in the 500k-per-unit convention) so the
+				// reward is inferred the same way production infers it.
+				"data": map[string]any{"id": 11, "username": "success-user", "quota": 505000, "used_quota": 0},
+			})
+		case "/api/user/checkin":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"message": "签到成功",
+				"data":    map[string]any{"quota_awarded": 5000, "checkin_date": "2026-09-06"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	siteRes, err := db.Exec(
+		"INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, 'new-api', 'active', ?, ?)",
+		"checkin success upstream", server.URL, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := siteRes.LastInsertId()
+	acctRes, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, balance, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', TRUE, ?, ?)",
+		siteID, "success-user", "dashboard-pat", 1.0, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := acctRes.LastInsertId()
+
+	// Events stay on: the persisted event is the thing under test.
+	result := CheckinAccount(&config.Config{}, db.DB, accountID, &CheckinOptions{ScheduleMode: "manual"})
+	if !result.Success || result.Status != CheckinSuccess {
+		t.Fatalf("result = %+v, want a successful check-in", result)
+	}
+
+	var count int
+	if err := db.Get(&count, "SELECT COUNT(*) FROM events WHERE related_id = ? AND related_type = 'account'", accountID); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("persisted events = %d, want exactly the one checkinSuccess row (0 means WriteEvent rejected the params)", count)
+	}
+
+	var titleKey, level, message string
+	var params *string
+	if err := db.QueryRow(
+		"SELECT COALESCE(title_key,''), level, COALESCE(message,''), params FROM events WHERE related_id = ? AND related_type = 'account'", accountID,
+	).Scan(&titleKey, &level, &message, &params); err != nil {
+		t.Fatalf("read event: %v", err)
+	}
+	if titleKey != "checkinSuccess" {
+		t.Fatalf("title_key = %q, want checkinSuccess", titleKey)
+	}
+	if level != "info" {
+		t.Fatalf("level = %q, want info", level)
+	}
+	if params == nil || strings.Contains(*params, `"reason"`) {
+		t.Fatalf("params = %v, want the declared reward shape and no undeclared reason", params)
+	}
+	if !strings.Contains(message, "success-user") || !strings.Contains(message, "checkin success upstream") {
+		t.Fatalf("rendered message = %q, want account and site", message)
+	}
+}


### PR DESCRIPTION
Observed failure — found by #1268's new already-checked-in test, then reproduced
on its own. Every successful check-in logged

    WARN CheckinAccount: failed to persist event accountID=1
      error="events: checkinSuccess does not declare param \"reason\""

and wrote no event row. The runner builds one param map for all four check-in
event keys — `{account, site, reason}` — while the structured-event registry
declares `{account, site, reward}` for `checkinSuccess`, whose `MessageEn` is the
historical `{{account}} @ {{site}}: {{reward}}`. `WriteEvent` rejects a param the
definition does not declare (that strictness is what surfaced this), so the one
outcome worth seeing in the feed — a check-in that worked — was the only row that
never arrived, while failures and skips kept showing up. On any deployment where
check-in works this repeats every cycle, with a WARN each time.

Census of the class, so this is not a one-off guess: the registry holds 4
definitions (the check-in family, batch 1 of the F5 structured-event migration)
and the repo has 4 producer sites, all in `service/checkin/checkin.go` — three
inline `checkinSkipped` writes whose params match, and the shared block whose key
can become `checkinSuccess` / `checkinFailed` / `checkinFailedCloudflare` /
`checkinSkipped`. Exactly one mismatch: this one. (Instrument and the full
family census: `.dev-local/overhaul-20260904/stability-v019/vocab-census/ADJUDICATION.md` §2.)

Fix: send the params the chosen definition declares — `reward` for
`checkinSuccess`, `reason` for the other three. The registry is the contract
owner and its shape is the historical one that legacy consumers (notifications,
CSV export, history fallback) were migrated against, so it does not move.

Test: `service/checkin/checkin_success_event_test.go` runs `CheckinAccount` with
events enabled against an upstream that answers success, and asserts exactly one
persisted row, `title_key=checkinSuccess`, `level=info`, a rendered message
carrying account and site, and no undeclared `reason` in params.

Mutation probe (committed first, revert by `git checkout --`):

| arm | mutation | expect | got |
|---|---|---|---|
| 0 | none | green | green |
| A | shared `reason` param restored | red | **red** — `persisted events = 0` |
| — | restored | green | green, tree clean |

Local: `go build ./...` clean; targeted suites (platform, service and all
subpackages, handler/*, docs, store, proxy/*, scheduler, auth, routing) — see the
run summary below.
