### PR TITLE
test(scheduler): assert the jitter we assign, not the instant the OS schedules it — the spread gate reddened master on a commit whose own PR run was green

### DIFF
--- a/scheduler/startup_jitter_test.go
+++ b/scheduler/startup_jitter_test.go
@@ -97,23 +97,72 @@ func TestIntervalRunnerStopDuringJitterDropsRun(t *testing.T) {
 	}
 }
 
-// TestIntervalRunnerImmediateRunsSpreadOut starts several runners with the
-// real (random) jitter and asserts their first-run times are spread out
-// instead of firing in the same instant.
+// TestIntervalRunnerStartupJitterFallsBackToDefault owns the production
+// fallback: a runner with no injected jitter must reach defaultStartupJitter.
+// Every other test in this file injects `jitter`, so without this one the
+// `r.jitter == nil` branch -- the branch every real scheduler takes -- would
+// have no owner, and a regression to `return 0` there would leave the whole
+// suite green while every immediate first run fired in the same instant
+// (the exact bug this feature was written for).
+func TestIntervalRunnerStartupJitterFallsBackToDefault(t *testing.T) {
+	const interval = 2 * time.Second // spread [0, 200ms)
+	r := &intervalRunner{}           // no injected jitter: the production shape
+	if r.jitter != nil {
+		t.Fatal("precondition: this runner must have no injected jitter")
+	}
+	seen := map[time.Duration]struct{}{}
+	for i := 0; i < 200; i++ {
+		d := r.startupJitter(interval)
+		if d < 0 || d >= interval/10 {
+			t.Fatalf("fallback jitter %v outside [0, %v)", d, interval/10)
+		}
+		seen[d] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Fatalf("200 fallback draws produced no variation: %v", seen)
+	}
+}
+
+// TestIntervalRunnerImmediateRunsSpreadOut starts several runners together and
+// asserts each one drew its OWN startup jitter, and that those draws are spread
+// across the window rather than colliding.
+//
+// What it measures, and why it changed (this gate reddened master once):
+// the previous version recorded time.Since(t0) inside each immediate run and
+// required max-min >= 30ms. That observes assigned delay + goroutine scheduling
+// latency, and only the delay is ours. On a loaded runner the six callbacks
+// bunched into a 27.8ms band and the required check test-pg went red on a
+// commit whose own PR run had been green (run 33987131273, 2026-09-05). It was
+// a dice roll on its own terms as well: six uniform draws in [0, 200ms) land
+// within 30ms of each other about once in 2500 runs even with fair scheduling.
+// Both halves are fixed here -- the assertion reads the delay the runner was
+// actually given (through the same injectable seam its siblings use, wrapping
+// the REAL defaultStartupJitter), and 16 draws make the 30ms threshold a ~7e-12
+// event instead of a ~4e-4 one. The behavioural half (an immediate run really
+// happens) is still asserted via the WaitGroup, but carries no timing claim;
+// "the delay is honored" is owned deterministically by
+// TestIntervalRunnerImmediateRunHonorsInjectedJitter.
 func TestIntervalRunnerImmediateRunsSpreadOut(t *testing.T) {
-	const n = 6
+	const n = 16
 	// interval 2s => default jitter spread [0, 200ms). The ticker interval is
-	// irrelevant to the test: the CAS guard records only the first run.
+	// irrelevant to the test: the CAS guard admits only the first run.
 	const interval = 2 * time.Second
 
 	var mu sync.Mutex
-	offsets := make([]time.Duration, 0, n)
+	delays := make([]time.Duration, 0, n)
 	var wg sync.WaitGroup
-	t0 := time.Now()
 
 	runners := make([]*intervalRunner, n)
 	for i := 0; i < n; i++ {
-		r := &intervalRunner{}
+		// Wrap the real jitter so the spread claim reads the assigned delay
+		// instead of the instant the OS happened to schedule the callback.
+		r := &intervalRunner{jitter: func(iv time.Duration) time.Duration {
+			d := defaultStartupJitter(iv)
+			mu.Lock()
+			delays = append(delays, d)
+			mu.Unlock()
+			return d
+		}}
 		runners[i] = r
 		var first atomic.Bool
 		wg.Add(1)
@@ -121,10 +170,6 @@ func TestIntervalRunnerImmediateRunsSpreadOut(t *testing.T) {
 			if !first.CompareAndSwap(false, true) {
 				return
 			}
-			off := time.Since(t0)
-			mu.Lock()
-			offsets = append(offsets, off)
-			mu.Unlock()
 			wg.Done()
 		}); err != nil {
 			t.Fatalf("start runner %d failed: %v", i, err)
@@ -145,16 +190,29 @@ func TestIntervalRunnerImmediateRunsSpreadOut(t *testing.T) {
 		_ = r.stop()
 	}
 
-	minOff, maxOff := offsets[0], offsets[0]
-	for _, o := range offsets[1:] {
-		if o < minOff {
-			minOff = o
+	mu.Lock()
+	got := append([]time.Duration(nil), delays...)
+	mu.Unlock()
+
+	// One draw per runner: a single shared draw is exactly the regression this
+	// gate exists for, and it is invisible to both sibling tests (the jitter
+	// function would still vary, and each runner would still honor "a" delay).
+	if len(got) != n {
+		t.Fatalf("startup jitter was drawn %d times for %d runners: %v", len(got), n, got)
+	}
+	minD, maxD := got[0], got[0]
+	for _, d := range got {
+		if d < 0 || d >= interval/10 {
+			t.Fatalf("assigned jitter %v outside [0, %v): %v", d, interval/10, got)
 		}
-		if o > maxOff {
-			maxOff = o
+		if d < minD {
+			minD = d
+		}
+		if d > maxD {
+			maxD = d
 		}
 	}
-	if spread := maxOff - minOff; spread < 30*time.Millisecond {
-		t.Fatalf("immediate first runs were not spread out: offsets %v (spread %v)", offsets, spread)
+	if spread := maxD - minD; spread < 30*time.Millisecond {
+		t.Fatalf("assigned startup jitter was not spread out: %v (spread %v)", got, spread)
 	}
 }


### PR DESCRIPTION
## Observed failure

`master` is red on `a4584c07`, and the same commit was green as a PR head.

| | `test-pg` |
|---|---|
| PR run (`5e584616`, merged as `a4584c07`) | **SUCCESS** |
| post-merge master run [`33987131273`](https://github.com/DeliciousBuding/metapi-go/actions/runs/33987131273), same commit | **FAILURE** |

```
--- FAIL: TestIntervalRunnerImmediateRunsSpreadOut (0.14s)
    startup_jitter_test.go:158: immediate first runs were not spread out:
    offsets [109.326762ms 124.552578ms 125.703491ms 127.886834ms 134.003049ms 137.152328ms]
    (spread 27.825566ms)
FAIL	github.com/deliciousbuding/metapi-go/scheduler	15.498s
```

`test-pg` is one of the 12 required status checks. The gate whose job is to say "PostgreSQL is fine" said "something is broken" about a commit that touches nothing near PostgreSQL. Detail and admission self-check: #1270.

## Root cause

The test started 6 runners with the real random jitter and required `max(observed) - min(observed) >= 30ms`, where `observed` was `time.Since(t0)` recorded **inside the immediate-run callback**. That value is

```
the delay defaultStartupJitter assigned     <- ours; the property under test
+ goroutine scheduling latency + timer granularity   <- the runner's, not ours
```

On a loaded machine the second term compresses the callbacks into a band narrower than the first term spread them. The assertion was aimed at the wrong quantity.

It was a dice roll even with fair scheduling — six uniform draws in `[0, 200ms)` land within a 30ms band with probability `n(r/L)^(n-1) − (n−1)(r/L)^n = 3.99e-4`, about 1 in 2500 runs, and `test-pg` runs on every PR and every push to master.

The file already documented the rule this test broke: `TestIntervalRunnerImmediateRunHonorsInjectedJitter` says *"pins the jitter via the injectable hook (tests never depend on the random draw)"*.

Same family as #1265 (`TestSessionCreatePurgesExpiredRows`, 1s TTL against a second-precision `expires_at`, "~1% dice roll", which reddened `test-sqlite-shard (2, 4)` on `1cf0be38`).

## Change

**Test-only. `scheduler/cron.go` is untouched** — the production behaviour was correct, the assertion was wrong.

1. `TestIntervalRunnerImmediateRunsSpreadOut` now reads **the delay each runner was assigned**, through the same injectable seam its siblings use, wrapping the real `defaultStartupJitter`. Runners 6 → 16, which moves the same 30ms threshold from `3.99e-4` to `~7e-12`. The behavioural half (every immediate run really fires) is still asserted via the WaitGroup, with no timing claim.
2. New `TestIntervalRunnerStartupJitterFallsBackToDefault` owns the `r.jitter == nil` branch of `startupJitter`. Every other test in the file injects `jitter`, so that branch — the one every real scheduler takes — had **no owner**: a regression to `return 0` there would leave the whole suite green while every immediate first run fired in the same instant, which is the exact bug the jitter feature exists to prevent.

## Mutation probe

| Arm | Mutation | `WithinBounds` | **`FallsBackToDefault`** | `SpreadOut` | injected-jitter tests |
|---|---|---|---|---|---|
| A | `defaultStartupJitter` → constant `0` | RED | **RED** | RED | GREEN |
| B | `startupJitter` fallback → one shared cached draw | GREEN | **RED** | GREEN | GREEN |
| C | restored | GREEN | **GREEN** | GREEN | GREEN |

Arm B is why this adds a test instead of only fixing one: a single shared draw is invisible to every pre-existing test in the file (the jitter function still varies when called directly, and each runner still honors *a* delay). Only the new fallback owner sees it.

## Verification on this machine

- `go test ./scheduler/ -run 'StartupJitter|ImmediateRun|SpreadOut|Degenerate' -v` → 5/5 PASS
- `-count=200` across the three variation/spread gates → **0 failures, 40.5s**
- `go test ./scheduler/...` → ok (16.4s)
- `go build ./...` → 0 · `go vet ./scheduler/...` → 0 · `go test ./docs/...` → 0
- `leak_guard.py --range master..HEAD` → 0

Pushed with `--no-verify` under this node's documented 2-core convention (`.githooks/pre-push-project` would additionally re-run the whole frontend suite and the full `-race` suite; this diff touches one file in `scheduler/` and no `web/` file, and the gates that could see it were run above). GHA is the judge of record.

## Not doing

- No change to `defaultStartupJitter` or `intervalRunner.start`.
- No new CI gate for flakiness: this failure *is* a gate misfiring, so the fix belongs in the test.
- Not widening the threshold to paper over it — a wider window on the wrong quantity still measures the scheduler.
