### PR TITLE
fix(e2e): reject failed and malformed check-in outcomes

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -201,7 +201,7 @@ PLATFORM=sub2api \
   bash scripts/e2e/verify-token-import.sh
 ```
 
-Both scripts print PASS/FAIL/WARN summaries, preserve truncated failure evidence, and exit non-zero on a failed required step.
+Both scripts print PASS/FAIL/WARN/SKIP summaries, preserve truncated failure evidence, and exit non-zero on a failed required step. Check-in verdicts follow the API's normalized `status` and `skipped` fields: a failed or malformed HTTP 200 response fails the chain, while an explicit skipped outcome is counted as SKIP, not successful check-in coverage. A run with a skipped check-in does not prove that a supported platform can complete a check-in.
 
 ## Privacy and evidence boundary
 

--- a/scripts/e2e/smoke-strict-relay-test.sh
+++ b/scripts/e2e/smoke-strict-relay-test.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Deterministic contract test for smoke.sh strict/skip relay semantics.
+# Deterministic contract tests for relay strictness and check-in verdicts.
+# These fixtures test the instruments; real-platform chains remain separate.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SMOKE_SCRIPT="${SMOKE_UNDER_TEST:-$ROOT_DIR/scripts/e2e/smoke.sh}"
+TOKEN_IMPORT_SCRIPT="${TOKEN_IMPORT_UNDER_TEST:-$ROOT_DIR/scripts/e2e/verify-token-import.sh}"
 TEST_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_DIR"' EXIT
 
@@ -48,6 +50,7 @@ case "$method $path" in
   "POST /api/accounts/login") body='{"success":true,"account":{"accessToken":"session-token"}}' ;;
   "POST /api/accounts/verify-token") body='{"tokenType":"session"}' ;;
   "GET /api/accounts") body='{"accounts":[{"id":1,"siteId":1,"username":"root"}]}' ;;
+  "PUT /api/accounts/1") body='{"id":1}' ;;
   "GET /api/accounts/1/models")
     if [ "${STRICT_CASE:-good}" = "models_empty" ]; then
       body='{"models":[],"totalCount":0}'
@@ -56,7 +59,15 @@ case "$method $path" in
     fi
     ;;
   "POST /api/accounts/1/balance") body='{"balance":10}' ;;
-  "POST /api/checkin/trigger/1") body='{"success":true}' ;;
+  "POST /api/checkin/trigger/1")
+    case "${STRICT_CASE:-good}" in
+      checkin_failed) body='{"success":false,"status":"failed","skipped":false,"message":"test upstream authentication failed"}' ;;
+      checkin_malformed) body='{"message":"missing outcome fields"}' ;;
+      checkin_contradictory) body='{"success":true,"status":"success","skipped":true}' ;;
+      checkin_skipped) body='{"success":true,"status":"skipped","skipped":true}' ;;
+      *) body='{"success":true,"status":"success","skipped":false}' ;;
+    esac
+    ;;
   "POST /api/downstream-keys") status=409; body='{"error":"duplicate"}' ;;
   "GET /api/downstream-keys") body='{"items":[{"id":9,"name":"e2e-smoke-token"}]}' ;;
   "PUT /api/downstream-keys/9") body='{"success":true}' ;;
@@ -82,19 +93,23 @@ printf '%s' "$status"
 FAKE_CURL
 chmod +x "$TEST_DIR/curl"
 
-run_smoke() {
-  local case_name="$1" output="$2"
-  shift 2
+run_chain() {
+  local script="$1" case_name="$2" output="$3"
+  shift 3
   env PATH="$TEST_DIR:$PATH" STRICT_CASE="$case_name" \
     METAPI_URL=http://127.0.0.1:4000 \
     METAPI_AUTH_TOKEN=test-admin \
     UPSTREAM_URL=http://127.0.0.1:3001 \
     UPSTREAM_USERNAME=root \
     UPSTREAM_PASSWORD=test-password \
-    PLATFORM=new-api \
+    UPSTREAM_TOKEN=test-upstream-token \
+    ACCOUNT_USERNAME=root SITE_NAME=e2e-smoke TOKEN_NAME=e2e-smoke-token \
+    PROXY_MODEL=gpt-4o-mini PLATFORM=new-api \
     EXPECTED_COMPLETION_CONTENT=metapi-e2e-marker \
-    "$@" bash "$SMOKE_SCRIPT" >"$output" 2>&1
+    "$@" bash "$script" >"$output" 2>&1
 }
+
+run_smoke() { run_chain "$SMOKE_SCRIPT" "$@"; }
 
 assert_contains() {
   local file="$1" exact="$2"
@@ -162,4 +177,42 @@ assert_contains "$good" '[PASS] token reuse (e2e-smoke-token, relay policy reass
 assert_contains "$good" '[PASS] proxy /v1/models (HTTP 200, non-empty data)'
 assert_contains "$good" '[PASS] proxy /v1/chat/completions (HTTP 200, completion content present)'
 assert_contains "$good" '== summary: 14 passed, 0 warned, 0 skipped, 0 failed =='
-echo "smoke strict relay contract: PASS"
+# Both entrypoints consume the same normalized API outcome, including the
+# token-import path that used to have no SKIP counter at all.
+for script in "$SMOKE_SCRIPT" "$TOKEN_IMPORT_SCRIPT"; do
+  chain="$(basename "$script")"
+  output="$TEST_DIR/$chain-checkin-good.log"
+  if ! run_chain "$script" good "$output"; then
+    echo "$chain: happy path failed" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  assert_contains "$output" '[PASS] checkin (success)'
+
+  for case_name in checkin_failed checkin_malformed checkin_contradictory; do
+    output="$TEST_DIR/$chain-$case_name.log"
+    if run_chain "$script" "$case_name" "$output"; then
+      echo "$chain: accepted $case_name" >&2
+      cat "$output" >&2
+      exit 1
+    fi
+    assert_contains "$output" '[FAIL] checkin (HTTP 200, expected a consistent success or skipped outcome)'
+    echo "$chain: $case_name rejected"
+  done
+
+  output="$TEST_DIR/$chain-checkin-skipped.log"
+  if ! run_chain "$script" checkin_skipped "$output"; then
+    echo "$chain: an explicit skipped outcome incorrectly failed the chain" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  assert_contains "$output" '[SKIP] checkin (status=skipped; no successful check-in verified)'
+  if grep -Fq '[PASS] checkin (' "$output" || ! grep -Eq '^== summary: .* 1 skipped, 0 failed ==$' "$output"; then
+    echo "$chain: skipped check-in was mislabeled or not counted" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  echo "$chain: explicit check-in skip counted, not PASS"
+done
+
+echo "smoke relay and check-in verdict contracts: PASS"

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -482,18 +482,24 @@ else
   fail_step "balance skipped (no account id)"
 fi
 
-# 10. checkin (POST /api/checkin/trigger/{id}); v1 may not support checkin —
-#     a 2xx with success=false is a documented unsupported result (PASS),
-#     5xx/crash is a FAIL.
+# 10. checkin: success is PASS, an explicit skipped outcome is SKIP, and
+#     failed/malformed outcomes are FAIL even when the endpoint answers 200.
 if [ -n "$ACCOUNT_ID" ]; then
   status="$(request POST "$METAPI_URL/api/checkin/trigger/$ACCOUNT_ID" "" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ]; then
     checkin_ok="$(json_value success 2>/dev/null || true)"
-    if [ "$checkin_ok" = "True" ]; then
-      pass_step "checkin (success)"
-    else
-      pass_step "checkin (documented unsupported/negative result: success=$checkin_ok)"
-    fi
+    checkin_status="$(json_value status 2>/dev/null || true)"
+    checkin_skipped="$(json_value skipped 2>/dev/null || true)"
+    # The API owns outcome normalization. Do not infer unsupported from HTTP
+    # 200 or success=false, and do not grow another message-text classifier.
+    case "$checkin_ok:$checkin_status:$checkin_skipped" in
+      True:success:False) pass_step "checkin (success)" ;;
+      True:skipped:True|False:skipped:True) skip_step "checkin (status=skipped; no successful check-in verified)" ;;
+      *)
+        fail_step "checkin (HTTP 200, expected a consistent success or skipped outcome)"
+        evidence
+        ;;
+    esac
   elif [ "$status" = "404" ]; then
     fail_step "checkin (HTTP 404 account not found)"
     evidence

--- a/scripts/e2e/verify-token-import.sh
+++ b/scripts/e2e/verify-token-import.sh
@@ -9,7 +9,7 @@
 #   -> account -> models -> balance -> checkin -> downstream token -> route
 #   -> /v1 proxy relay.
 #
-# Every step prints [PASS]/[FAIL]/[WARN] and accumulates a summary; the script
+# Every step prints [PASS]/[FAIL]/[WARN]/[SKIP] and accumulates a summary; the script
 # exits 1 when any step FAILs. FAILs print the truncated response body as
 # evidence.
 #
@@ -65,6 +65,7 @@ TOKEN_IMPORT_KEY="${TOKEN_IMPORT_KEY:-sk-e2e-token}"
 PASS_COUNT=0
 FAIL_COUNT=0
 WARN_COUNT=0
+SKIP_COUNT=0
 FAILED_NAMES=""
 
 # --- fatal setup checks ---
@@ -199,6 +200,7 @@ sys.exit(1)
 pass_step() { PASS_COUNT=$((PASS_COUNT + 1)); echo "[PASS] $1"; }
 fail_step() { FAIL_COUNT=$((FAIL_COUNT + 1)); FAILED_NAMES="$FAILED_NAMES $1"; echo "[FAIL] $1"; }
 warn_step() { WARN_COUNT=$((WARN_COUNT + 1)); echo "[WARN] $1"; }
+skip_step() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo "[SKIP] $1"; }
 
 evidence() {
   local b curl_err
@@ -401,18 +403,24 @@ else
   fail_step "balance skipped (no account id)"
 fi
 
-# 9. checkin (POST /api/checkin/trigger/{id}); token-import platforms may not
-#    support checkin — a 2xx with success=false is a documented unsupported
-#    result (PASS), 5xx/crash is a FAIL.
+# 9. checkin: a token-import platform may explicitly skip this operation.
+#    A skip is not successful coverage; failed/malformed outcomes must fail.
 if [ -n "$ACCOUNT_ID" ]; then
   status="$(request POST "$METAPI_URL/api/checkin/trigger/$ACCOUNT_ID" "" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ]; then
     checkin_ok="$(json_value success 2>/dev/null || true)"
-    if [ "$checkin_ok" = "True" ]; then
-      pass_step "checkin (success)"
-    else
-      pass_step "checkin (documented unsupported/negative result: success=$checkin_ok)"
-    fi
+    checkin_status="$(json_value status 2>/dev/null || true)"
+    checkin_skipped="$(json_value skipped 2>/dev/null || true)"
+    # The API owns outcome normalization. Do not infer unsupported from HTTP
+    # 200 or success=false, and do not grow another message-text classifier.
+    case "$checkin_ok:$checkin_status:$checkin_skipped" in
+      True:success:False) pass_step "checkin (success)" ;;
+      True:skipped:True|False:skipped:True) skip_step "checkin (status=skipped; no successful check-in verified)" ;;
+      *)
+        fail_step "checkin (HTTP 200, expected a consistent success or skipped outcome)"
+        evidence
+        ;;
+    esac
   elif [ "$status" = "404" ]; then
     fail_step "checkin (HTTP 404 account not found)"
     evidence
@@ -523,7 +531,7 @@ else
 fi
 
 # --- summary ---
-echo "== summary: $PASS_COUNT passed, $WARN_COUNT warned, $FAIL_COUNT failed =="
+echo "== summary: $PASS_COUNT passed, $WARN_COUNT warned, $SKIP_COUNT skipped, $FAIL_COUNT failed =="
 if [ "$FAIL_COUNT" -gt 0 ]; then
   echo "   failed steps:$FAILED_NAMES"
   exit 1


### PR DESCRIPTION
## Summary
- Both login and token-import smoke chains now classify the normalized check-in result as PASS, SKIP, or FAIL.
- Explicit unsupported/skipped outcomes are counted as SKIP rather than successful check-in coverage.
- HTTP 200 with a failed, missing, or contradictory outcome fails the chain.

## Validation
- Complete local project gate passed: frontend tests/typecheck/lint/format/knip/build, server build, `go vet ./...`, and the complete Go race suite.
- Deterministic instrument tests cover successful, skipped, failed, malformed, and contradictory outcomes in both entrypoints.
- Mutation proof: replacing either implementation with its pre-fix version makes the contract gate fail; restored source hashes match the tested files.

These fixtures validate the test instruments, not real upstream check-in or paid-model end-to-end behavior. Real-platform and live-model acceptance remain separate.

Closes #1272