### PR TITLE
fix: complete upstream onboarding and enforce real relay acceptance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -413,6 +413,8 @@ jobs:
           bash -n scripts/e2e/smoke-strict-relay-test.sh
           python3 -c 'import ast; ast.parse(open("scripts/e2e/mock-openai.py", encoding="utf-8").read())'
           bash scripts/e2e/smoke-strict-relay-test.sh
+          python3 -m unittest discover -s scripts/e2e -p 'test_verify_real_relay.py'
+          node --test web/scripts/__tests__/acceptance-evidence.test.mjs
       - name: Initialize upstreams
         run: |
           set -euo pipefail

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -641,13 +641,15 @@ jobs:
           SITE_NAME=e2e-smoke-oneapi TOKEN_NAME=e2e-smoke-oneapi-token \
           bash scripts/e2e/smoke.sh
 
+          # These fixtures have no real provider configured: exercise management
+          # without presenting a structured relay error as successful inference.
           echo "===== sub2api token-import chain ====="
           METAPI_URL=http://127.0.0.1:4010 \
           METAPI_AUTH_TOKEN=e2e-admin-token \
           UPSTREAM_URL=http://127.0.0.1:3004 \
           UPSTREAM_TOKEN="$SUB2API_ACCESS_TOKEN" \
           PLATFORM=sub2api CREDENTIAL_MODE=session \
-          SKIP_MODEL_FETCH=true \
+          SKIP_MODEL_FETCH=true E2E_SKIP_RELAY=1 \
           SITE_NAME=e2e-smoke-sub2api TOKEN_NAME=e2e-smoke-sub2api-token \
           bash scripts/e2e/verify-token-import.sh
 
@@ -690,7 +692,7 @@ jobs:
           UPSTREAM_URL=http://127.0.0.1:3004 \
           UPSTREAM_TOKEN="$SUB2API_ACCESS_TOKEN" \
           PLATFORM=sub2api CREDENTIAL_MODE=session \
-          SKIP_MODEL_FETCH=true \
+          SKIP_MODEL_FETCH=true E2E_SKIP_RELAY=1 \
           SITE_NAME=e2e-smoke-sub2api TOKEN_NAME=e2e-smoke-sub2api-token \
           bash scripts/e2e/verify-token-import.sh
 
@@ -700,7 +702,7 @@ jobs:
           UPSTREAM_URL=http://127.0.0.1:3005 \
           UPSTREAM_TOKEN=e2e-cliproxyapi-mgmt-key \
           PLATFORM=cliproxyapi CREDENTIAL_MODE=apikey \
-          SKIP_MODEL_FETCH=true \
+          SKIP_MODEL_FETCH=true E2E_SKIP_RELAY=1 \
           SITE_NAME=e2e-smoke-cliproxyapi TOKEN_NAME=e2e-smoke-cliproxyapi-token \
           bash scripts/e2e/verify-token-import.sh
 

--- a/docs/api/accounts.md
+++ b/docs/api/accounts.md
@@ -85,11 +85,27 @@ Replace a session account's access token (session-credential rebind; Sub2API aut
 
 ### GET /api/account-tokens, POST /api/account-tokens
 
-List all account tokens. Create a new account token.
+List all account tokens, optionally filtered by `accountId`.
+
+Create an upstream token by omitting `token` (or leaving it empty):
+`{ "accountId": 7, "name": "relay", "group": "default", "unlimitedQuota": false, "remainQuota": 25000, "allowIps": "127.0.0.1" }`.
+The account must have a working management/session credential. The upstream issues
+its token, then Metapi synchronizes its real value and selects the account default.
+`expiredTime` optionally sets a Unix-seconds expiry; `unlimitedQuota` defaults to
+`true`, so a finite token must explicitly send `false` and `remainQuota`.
+
+Supplying `token` instead imports an existing value locally; it does not change
+that token's limits at the upstream. The account detail form supports both paths:
+leave the value empty to create upstream, or paste an existing value to import.
+An API-key-only connection cannot create/manage separate upstream tokens.
 
 ### GET /api/account-tokens/:id, PUT /api/account-tokens/:id, DELETE /api/account-tokens/:id
 
-Get, update, delete an account token.
+Get, update, delete an account token. Updates accept `name`, `token`, `group`,
+`enabled`, `isDefault`, and `source`; omitted values are preserved. A metadata-only
+edit leaves `token` out of the request, keeping the stored secret unchanged.
+Quota, expiry, and IP restrictions are upstream-creation options, not token-update
+fields; manage an existing token's restrictions at the upstream site.
 
 ### GET /api/account-tokens/{id}/value
 

--- a/docs/api/accounts.md
+++ b/docs/api/accounts.md
@@ -37,6 +37,15 @@ Recent background model-probe history per account — the data behind the row-le
 
 `status` shares the probe vocabulary: `success` | `failure` | `inconclusive` | `skipped`. Results are ordered newest-first within each account.
 
+Account creation (single Session/API-key import and batch API-key import) now
+initializes the persisted model inventory immediately. Session relay-token sync
+runs before discovery, so a successful token paste does not leave routing empty
+until the periodic scheduler. `modelCount` reports the initialized inventory;
+`modelRefresh` carries the same detailed result as password login. A discovery
+failure is partial initialization: the verified account remains saved and the
+failure is explicit. `skipModelFetch: true` performs no model probe and returns
+`modelRefresh.skipped: true` rather than claiming model readiness.
+
 ### POST /api/accounts/login
 
 Log in against the site with username/password and create the account — or update the existing one for `(siteId, username)` — with the session token and an encrypted `autoRelogin` credential (`extraConfig.credentialMode = session`).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -247,3 +247,14 @@ reward, an explicit unsupported/skipped result is reported as SKIP. Fresh
 accounts also create their upstream relay token through the account detail form
 before route binding and the downstream relay are accepted. Never point the
 cleanup-enabled browser runner at an existing user or production database.
+
+The token-import smoke chain is strict by default too: an empty model inventory,
+a missing selected model, or a structured 503 is failure, not successful relay.
+`E2E_SKIP_RELAY=1` is the explicit management-only mode for a fixture with no
+provider; it skips relay key/route setup and model calls and counts those steps
+as SKIP. `SKIP_MODEL_FETCH=true` by itself does not relax relay acceptance.
+Repeated full login journeys can hit the upstream's real sensitive-operation
+rate limit. Honor its cooldown or reuse a valid management credential; do not
+disable the guard or automatically retry PAT creation to make a test green.
+Run live model acceptance when the test host is idle: the upstream may correctly
+reject requests with `system_cpu_overloaded` while full local CI saturates it.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -209,3 +209,39 @@ Both scripts print PASS/FAIL/WARN/SKIP summaries, preserve truncated failure evi
 - Hostnames, host filesystem layouts, SSH commands, real credentials, and private upstream addresses stay in the operator-controlled environment.
 - Attach sanitized request/response shapes and commit/PR references to public issues; never attach raw environment files or full tokens.
 - A healthy run is evidence for the exercised platform and version only. Do not generalize it into a cluster-wide or all-adapter claim.
+
+## Opt-in live model acceptance
+
+`scripts/e2e/verify-real-relay.py` exercises Chat Completions, Responses, and
+Anthropic Messages through the service under test. It requires Python 3, curl
+8.4 or newer, and operator-provided `RELAY_BASE_URL`, `RELAY_API_KEY`, and
+`RELAY_MODEL` environment variables. Inject the key from a secret store rather
+than putting it in a command line, shell history, or committed file.
+
+```bash
+python3 scripts/e2e/verify-real-relay.py --protocol all --timeout 120 --max-tokens 256
+```
+
+Each protocol checks JSON, SSE completion, and a complete echo-tool/result
+roundtrip. The tool result contains a fresh receipt that must appear in the final
+answer; merely announcing a tool call is not sufficient. The command makes at
+most 12 model POSTs, performs no automatic retries, and can incur upstream usage.
+It prints metadata only and exits nonzero for any failed scenario. Tool streaming
+is not covered by this runner; exercise a real downstream CLI separately when
+that client contract is part of the release scope.
+
+A passing client report does not identify the physical upstream provider. Pair it
+with verified test configuration, model request IDs, and gateway/Metapi logs for
+cross-service provenance. Model aliases may legitimately differ from the
+requested model. Deterministic validator tests in CI are instrument checks, not
+substitutes for these live calls.
+
+For the browser journey, use `bun run acceptance:e2e` (which executes Node, not
+Bun's JavaScript runtime) against a dedicated disposable Metapi instance. Set
+`ACCEPT_LOGIN=1` and `ACCEPT_EXPECT_CHECKIN=1` when the real upstream is configured
+to grant a check-in reward. The journey verifies a fresh account-specific log
+and its UI result; a pre-existing or failed log cannot pass. Without a required
+reward, an explicit unsupported/skipped result is reported as SKIP. Fresh
+accounts also create their upstream relay token through the account detail form
+before route binding and the downstream relay are accepted. Never point the
+cleanup-enabled browser runner at an existing user or production database.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -263,3 +263,8 @@ A route `displayName` is its downstream model alias, not just an internal label.
 The smoke chains leave it unset on fresh routes and honor an existing alias
 when relaying; the account model and the public model ID need not be identical.
 The instrument fixtures cover both route creation and alias reuse.
+
+The protocol report records the configured token cap and allowlisted terminal
+signals on failure. `length` remains FAIL; use an explicit, bounded larger cap
+when a reasoning model needs it, rather than relaxing completion validation.
+Repeated terminal signals and `end_turn` with tool calls remain visible failures.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -239,7 +239,9 @@ substitutes for these live calls.
 For the browser journey, use `bun run acceptance:e2e` (which executes Node, not
 Bun's JavaScript runtime) against a dedicated disposable Metapi instance. Set
 `ACCEPT_LOGIN=1` and `ACCEPT_EXPECT_CHECKIN=1` when the real upstream is configured
-to grant a check-in reward. The journey verifies a fresh account-specific log
+to support successful check-in. When a test upstream grants a fixed known amount,
+set `ACCEPT_EXPECT_REWARD` as well to check that exact value in the API log and UI;
+an already-complete check-in is success but does not mean a new reward. The journey verifies a fresh account-specific log
 and its UI result; a pre-existing or failed log cannot pass. Without a required
 reward, an explicit unsupported/skipped result is reported as SKIP. Fresh
 accounts also create their upstream relay token through the account detail form

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -258,3 +258,8 @@ rate limit. Honor its cooldown or reuse a valid management credential; do not
 disable the guard or automatically retry PAT creation to make a test green.
 Run live model acceptance when the test host is idle: the upstream may correctly
 reject requests with `system_cpu_overloaded` while full local CI saturates it.
+
+A route `displayName` is its downstream model alias, not just an internal label.
+The smoke chains leave it unset on fresh routes and honor an existing alias
+when relaying; the account model and the public model ID need not be identical.
+The instrument fixtures cover both route creation and alias reuse.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -201,7 +201,7 @@ PLATFORM=sub2api \
   bash scripts/e2e/verify-token-import.sh
 ```
 
-Both scripts print PASS/FAIL/WARN summaries, preserve truncated failure evidence, and exit non-zero on a failed required step.
+Both scripts print PASS/FAIL/WARN/SKIP summaries, preserve truncated failure evidence, and exit non-zero on a failed required step. Check-in verdicts follow the API's normalized `status` and `skipped` fields: a failed or malformed HTTP 200 response fails the chain, while an explicit skipped outcome is counted as SKIP, not successful check-in coverage. A run with a skipped check-in does not prove that a supported platform can complete a check-in.
 
 ## Privacy and evidence boundary
 

--- a/handler/admin/accounts_create.go
+++ b/handler/admin/accounts_create.go
@@ -109,15 +109,17 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 				}
 				items = append(items, item)
 			} else {
+				modelCount, modelRefresh := h.refreshModelsAfterAccountCreate(r.Context(), body, created.ID)
 				createdCount++
 				items = append(items, map[string]any{
-					"index":      i,
-					"status":     "created",
-					"id":         created.ID,
-					"username":   coalescePtr(created.Username, ""),
-					"queued":     false,
-					"message":    nil,
-					"modelCount": created.ModelCount,
+					"index":        i,
+					"status":       "created",
+					"id":           created.ID,
+					"username":     coalescePtr(created.Username, ""),
+					"queued":       false,
+					"message":      nil,
+					"modelCount":   modelCount,
+					"modelRefresh": modelRefresh,
 				})
 			}
 		}
@@ -173,14 +175,18 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Fetch created account
-	var account store.Account
-	h.db.Get(&account, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), created.ID)
-
-	// Auto-sync upstream tokens via the existing sync path (#1002). The report
-	// is truth-only: a sync failure never rolls back the persisted account.
+	// Discover models only after the session's relay keys have been synced.
+	// Verification alone did not persist availability, so fresh imports stayed
+	// empty and their first route could not relay until a scheduled refresh.
 	syncReport := syncTokensAfterAccountCreate(r.Context(), h.db, h.cfg, created.ID)
+	modelCount, modelRefresh := h.refreshModelsAfterAccountCreate(r.Context(), body, created.ID)
 
+	// Return the initialized credential state, not the pre-sync snapshot.
+	var account store.Account
+	if err := h.db.Get(&account, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), created.ID); err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Account saved, but its initialized state could not be loaded.")
+		return
+	}
 	caps := service.BuildCapabilitiesForAccount(&account)
 	routing.InvalidateCache()
 	globalAccountsCache.clear()
@@ -193,14 +199,32 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 		"tokenType":        created.TokenType,
 		"credentialMode":   string(service.ResolveStoredCredentialMode(&account)),
 		"capabilities":     caps,
-		"modelCount":       created.ModelCount,
-		"apiTokenFound":    created.APITokenFound,
+		"modelCount":       modelCount,
+		"modelRefresh":     modelRefresh,
+		"apiTokenFound":    account.APIToken != nil && strings.TrimSpace(*account.APIToken) != "",
 		"usernameDetected": created.UsernameDetected,
 		"queued":           false,
 		"tokenCount":       syncReport.TokenCount,
 		"tokenSyncStatus":  syncReport.Status,
 		"tokenSyncMessage": syncReport.Message,
 	})
+}
+
+// refreshModelsAfterAccountCreate uses the same discovery/persistence owner as
+// password login. A discovery failure is partial initialization, never grounds
+// to erase an already verified account. Explicit no-probe imports remain so.
+func (h *accountsHandler) refreshModelsAfterAccountCreate(ctx context.Context, body payloads.AccountCreatePayload, accountID int64) (int, map[string]any) {
+	if body.SkipModelFetch != nil && *body.SkipModelFetch {
+		return 0, map[string]any{"success": true, "skipped": true, "reason": "skipModelFetch"}
+	}
+	result := accountModelRefresher(ctx, h.db, accountID, false)
+	count := 0
+	if success, _ := result["success"].(bool); success {
+		if refresh, ok := result["refresh"].(map[string]any); ok {
+			count, _ = refresh["modelCount"].(int)
+		}
+	}
+	return count, result
 }
 
 // accountCreateError is returned when create fails closed on token verification.
@@ -233,8 +257,6 @@ type createAccountOutcome struct {
 	ID               int64
 	Username         *string
 	TokenType        string
-	ModelCount       int
-	APITokenFound    bool
 	UsernameDetected bool
 }
 
@@ -432,8 +454,6 @@ func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads
 		ID:               id,
 		Username:         usernameVal,
 		TokenType:        tokenType,
-		ModelCount:       len(verifiedModels),
-		APITokenFound:    apiTokenPtr != nil,
 		UsernameDetected: !usernameProvided && usernameVal != nil,
 	}, nil
 }

--- a/handler/admin/accounts_import_models_test.go
+++ b/handler/admin/accounts_import_models_test.go
@@ -1,0 +1,111 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAccounts_SessionImportPersistsModelsAfterRelayTokenSync(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch req.URL.Path {
+		case "/api/user/self":
+			fmt.Fprint(w, `{"success":true,"data":{"id":2,"username":"import-user","quota":10000000}}`)
+		case "/api/token/":
+			fmt.Fprint(w, `{"success":true,"data":[{"id":1,"name":"relay","key":"fixture-relay-key","status":1}]}`)
+		case "/v1/models":
+			if req.Header.Get("Authorization") != "Bearer fixture-relay-key" {
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprint(w, `{"error":"management credential is not a relay key"}`)
+				return
+			}
+			fmt.Fprint(w, `{"data":[{"id":"first-import-model"}]}`)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer upstream.Close()
+	siteID := createTokenSyncSite(t, r, "fresh import", upstream.URL)
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{"siteId": siteID, "accessToken": "fixture-management-pat", "credentialMode": "session", "username": "import-user"})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create HTTP %d: %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["modelCount"] != float64(1) || result["apiTokenFound"] != true {
+		t.Fatalf("initialized state=%s", resp.Body.String())
+	}
+	refresh, _ := result["modelRefresh"].(map[string]any)
+	if refresh["success"] != true {
+		t.Fatalf("refresh=%#v", refresh)
+	}
+	aid := int64(result["id"].(float64))
+	var count int
+	if err := db.Get(&count, db.Rebind("SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = TRUE"), aid); err != nil || count != 1 {
+		t.Fatalf("persisted=%d, err=%v", count, err)
+	}
+	models := doGet(t, r, "/api/accounts/"+itoa(aid)+"/models")
+	if !strings.Contains(models.Body.String(), "first-import-model") {
+		t.Fatalf("immediate models=%s", models.Body.String())
+	}
+}
+
+func TestAccounts_BatchAPIKeyImportsPersistEachModelInventory(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":[{"id":"batch-import-model"}]}`)
+	}))
+	defer upstream.Close()
+	site := doPostJSON(t, r, "/api/sites", map[string]any{"name": "batch model imports", "url": upstream.URL, "platform": "openai"})
+	var siteData map[string]any
+	json.Unmarshal(site.Body.Bytes(), &siteData)
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{"siteId": siteData["id"], "credentialMode": "apikey", "accessTokens": []string{"fixture-api-a", "fixture-api-b"}})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create: %s", resp.Body.String())
+	}
+	var result map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &result)
+	items := result["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("items=%#v", items)
+	}
+	for _, raw := range items {
+		item := raw.(map[string]any)
+		if item["modelCount"] != float64(1) {
+			t.Fatalf("item=%#v", item)
+		}
+	}
+	var count int
+	if err := db.Get(&count, "SELECT COUNT(*) FROM model_availability WHERE available = TRUE"); err != nil || count != 2 {
+		t.Fatalf("persisted=%d, err=%v", count, err)
+	}
+}
+
+func TestAccounts_ExplicitSkipImportDoesNotProbeModels(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) { hits.Add(1); http.Error(w, "must not probe", 500) }))
+	defer upstream.Close()
+	site := doPostJSON(t, r, "/api/sites", map[string]any{"name": "explicit no probe", "url": upstream.URL, "platform": "openai"})
+	var siteData map[string]any
+	json.Unmarshal(site.Body.Bytes(), &siteData)
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{"siteId": siteData["id"], "credentialMode": "apikey", "accessToken": "fixture-api-key", "skipModelFetch": true})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create: %s", resp.Body.String())
+	}
+	var result map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &result)
+	refresh, _ := result["modelRefresh"].(map[string]any)
+	if refresh["skipped"] != true || hits.Load() != 0 {
+		t.Fatalf("refresh=%#v, probes=%d", refresh, hits.Load())
+	}
+}

--- a/handler/proxy/headers.go
+++ b/handler/proxy/headers.go
@@ -1,6 +1,8 @@
 package proxyhandler
 
 import (
+	"encoding/json"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -128,5 +130,25 @@ func relayUpstreamResponseHeaders(w http.ResponseWriter, upstream http.Header) {
 		if values := upstream.Values(name); len(values) > 0 {
 			dst[name] = append([]string(nil), values...)
 		}
+	}
+}
+
+// normalizeUpstreamJSONContentType repairs the missing/default text media type
+// seen on real chat-family JSON answers. Only a readable, valid JSON body on a
+// known JSON API is eligible: downloads, opaque encodings, explicit non-text
+// media types, and malformed bodies retain their upstream semantics.
+func normalizeUpstreamJSONContentType(header http.Header, body []byte, path string) {
+	if _, known := proxy.EndpointFromPath(path); !known || header.Get("Content-Disposition") != "" || header.Get("Content-Encoding") != "" {
+		return
+	}
+	contentType := header.Get("Content-Type")
+	if contentType != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil || mediaType != "text/plain" {
+			return
+		}
+	}
+	if json.Valid(body) {
+		header.Set("Content-Type", "application/json")
 	}
 }

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -713,6 +713,9 @@ func dispatchEndpointAttemptWithContinue(
 		requestID: requestID,
 	})
 	respBody = body.bytes
+	if body.readable {
+		normalizeUpstreamJSONContentType(resp.Header, respBody, r.URL.Path)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		rawErrText := string(respBody)
 		if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback, endpointFailureResponse) {

--- a/handler/proxy/upstream_json_media_type_test.go
+++ b/handler/proxy/upstream_json_media_type_test.go
@@ -1,0 +1,71 @@
+package proxyhandler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+func TestChatFamilyJSONRepairsUpstreamTextMediaType(t *testing.T) {
+	cases := []struct {
+		name, path, request, response string
+		handle                        http.HandlerFunc
+	}{
+		{"chat tool call", "/v1/chat/completions", `{"model":"test-model","messages":[{"role":"user","content":"echo"}]}`, `{"id":"chat-1","object":"chat.completion","model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call-1","type":"function","function":{"name":"echo","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`, HandleChatCompletions},
+		{"messages", "/v1/messages", `{"model":"test-model","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}`, `{"id":"msg-1","type":"message","role":"assistant","model":"test-model","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn"}`, HandleClaudeMessages},
+		{"responses", "/v1/responses", `{"model":"test-model","input":"hello"}`, `{"id":"resp-1","object":"response","model":"test-model","status":"completed","output":[{"id":"msg-1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello"}]}]}`, func(w http.ResponseWriter, r *http.Request) { HandleResponses(w, r, "/v1/responses") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				_, _ = w.Write([]byte(tc.response))
+			}))
+			defer upstream.Close()
+			SetUpstreamConfig(&UpstreamConfig{Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+				Channel: store.RouteChannel{ID: 42, Enabled: true}, Account: store.Account{ID: 7, Status: "active"},
+				Site: store.Site{ID: 3, URL: upstream.URL, Platform: "new-api", Status: "active"}, TokenValue: "fixture-upstream-token", ActualModel: "test-model",
+			}}})
+			defer SetUpstreamConfig(nil)
+			rec := httptest.NewRecorder()
+			tc.handle(rec, makeProxyReq("POST", tc.path, tc.request))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("HTTP %d: %s", rec.Code, rec.Body.String())
+			}
+			if got := rec.Header().Get("Content-Type"); got != "application/json" {
+				t.Fatalf("Content-Type=%q, want application/json", got)
+			}
+			if rec.Body.String() != tc.response {
+				t.Fatalf("relay changed body bytes: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestJSONMediaTypeNormalizationPreservesOtherRepresentations(t *testing.T) {
+	cases := []struct{ name, path, contentType, encoding, disposition, body, want string }{
+		{"missing", "/v1/messages", "", "", "", `{"ok":true}`, "application/json"},
+		{"already JSON", "/v1/chat/completions", "application/json; charset=utf-8", "", "", `{"ok":true}`, "application/json; charset=utf-8"},
+		{"vendor JSON", "/v1/responses", "application/problem+json", "", "", `{"error":true}`, "application/problem+json"},
+		{"non JSON", "/v1/chat/completions", "text/plain", "", "", "not json", "text/plain"},
+		{"download path", "/v1/files/file-1/content", "text/plain", "", "", `{"data":1}`, "text/plain"},
+		{"attachment", "/v1/responses", "text/plain", "", `attachment; filename="data.json"`, `{"data":1}`, "text/plain"},
+		{"opaque encoding", "/v1/chat/completions", "text/plain", "br", "", `{"data":1}`, "text/plain"},
+		{"binary type", "/v1/messages", "application/octet-stream", "", "", `{"data":1}`, "application/octet-stream"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			h.Set("Content-Type", tc.contentType)
+			h.Set("Content-Encoding", tc.encoding)
+			h.Set("Content-Disposition", tc.disposition)
+			normalizeUpstreamJSONContentType(h, []byte(tc.body), tc.path)
+			if got := h.Get("Content-Type"); got != tc.want {
+				t.Fatalf("Content-Type=%q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -5,9 +5,12 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 )
 
 // NewApiAdapter handles NewAPI platforms with full cookie fallback, shield challenge,
@@ -57,6 +60,9 @@ func (n *NewApiAdapter) Detect(ctx context.Context, url string) (bool, error) {
 
 // --- Login ---
 
+const newAPIPATVerificationScope = "access_token.generate"
+const newAPIManualPATImport = "complete verification in New API and import a durable dashboard PAT manually"
+
 func (n *NewApiAdapter) Login(ctx context.Context, baseURL, username, password string, platformUserId *int, proxy *ProxyConfig) (*LoginResult, error) {
 	body := map[string]string{"username": username, "password": password}
 	headers := map[string]string{
@@ -75,6 +81,9 @@ func (n *NewApiAdapter) Login(ctx context.Context, baseURL, username, password s
 	}
 
 	data, _ := getMap(parsed, "data")
+	if required, _ := getBool(data, "require_verification"); required {
+		return &LoginResult{Success: false, Message: "New API login requires MFA/interactive verification; " + newAPIManualPATImport}, nil
+	}
 	accessToken := extractLoginToken(parsed, data)
 	success, hasSuccess := getBool(parsed, "success")
 
@@ -89,7 +98,7 @@ func (n *NewApiAdapter) Login(ctx context.Context, baseURL, username, password s
 	if accessToken != "" && (!hasSuccess || success) {
 		if isSession, sessionID := newAPIV1LoginSession(data); isSession {
 			durableToken, promoteErr := n.promoteV1LoginCredential(
-				ctx, baseURL, accessToken, cookieHeader, sessionID, platformUserId, proxy)
+				ctx, baseURL, accessToken, password, cookieHeader, sessionID, platformUserId, proxy)
 			if promoteErr != nil {
 				return &LoginResult{Success: false, Message: promoteErr.Error()}, nil
 			}
@@ -137,62 +146,140 @@ func newAPIV1LoginSession(data map[string]interface{}) (bool, string) {
 // an explicit re-login or recovery after a revoked PAT intentionally rotates it.
 func (n *NewApiAdapter) promoteV1LoginCredential(
 	ctx context.Context,
-	baseURL, sessionJWT, cookieHeader, sessionID string,
+	baseURL, sessionJWT, password, cookieHeader, sessionID string,
 	platformUserID *int,
 	proxy *ProxyConfig,
 ) (string, error) {
-	resp, err := fetchJSON(
-		ctx,
-		strings.TrimRight(baseURL, "/")+"/api/user/token",
-		http.MethodGet,
-		nil,
-		n.authHeaders(sessionJWT, platformUserID),
-		proxy,
-	)
-	if err != nil {
-		return "", fmt.Errorf("login succeeded, but New API could not issue a durable dashboard token: %w", err)
-	}
-	durableToken, _ := getString(resp, "data")
-	durableToken = strings.TrimSpace(durableToken)
-	if durableToken == "" {
-		return "", fmt.Errorf("login succeeded, but New API returned no durable dashboard token")
-	}
-
-	// Minting the PAT required a browser login session. Revoke that transient
-	// session immediately so automated relogin cannot consume New API's active
-	// session quota. PAT issuance already succeeded, so logout is best-effort:
-	// failing the whole bind here would discard a usable durable credential while
-	// still leaving the upstream session behind.
-	if strings.TrimSpace(sessionID) != "" {
-		headers := map[string]string{
-			"Authorization":  "Bearer " + sessionJWT,
-			"X-Auth-Session": sessionID,
-		}
+	baseURL = strings.TrimRight(baseURL, "/")
+	sessionID = strings.TrimSpace(sessionID)
+	headers := n.authHeaders(sessionJWT, platformUserID)
+	if sessionID != "" {
+		headers["X-Auth-Session"] = sessionID
+		// Refresh cookies are scoped to /api/user/auth, not /api/verify or
+		// /api/user/token. Keep them for logout; the JWT authenticates the
+		// proof ceremony. Revoke failed promotions as well, so rejected
+		// step-up attempts do not exhaust the upstream login-session quota.
+		logoutHeaders := n.authHeaders(sessionJWT, platformUserID)
+		logoutHeaders["X-Auth-Session"] = sessionID
 		if strings.TrimSpace(cookieHeader) != "" {
-			headers["Cookie"] = cookieHeader
+			logoutHeaders["Cookie"] = cookieHeader
 		}
-		logoutResp, logoutErr := fetchJSON(
-			ctx,
-			strings.TrimRight(baseURL, "/")+"/api/user/auth/logout",
-			http.MethodPost,
-			nil,
-			headers,
-			proxy,
-		)
-		logoutOK := false
-		if logoutErr == nil {
-			logoutOK, _ = getBool(logoutResp, "success")
+		if origin, err := url.Parse(baseURL); err == nil {
+			logoutHeaders["Origin"] = origin.Scheme + "://" + origin.Host
 		}
-		if logoutErr != nil || !logoutOK {
-			slog.Warn("new-api login: durable token issued but transient session logout failed",
-				"session_id", sessionID,
-				"error", logoutErr)
-		}
+		defer func() {
+			_, err := fetchNewAPIV1SessionJSON(ctx, baseURL+"/api/user/auth/logout", http.MethodPost, nil, logoutHeaders, proxy)
+			if err != nil {
+				// Only the fixed diagnostic/status is safe to log. An
+				// upstream error body can echo passwords, proofs or tokens.
+				slog.Warn("new-api login: transient session logout failed", "error", err)
+			}
+		}()
 	} else {
-		slog.Warn("new-api login: durable token issued but upstream returned no session id; transient session could not be revoked")
+		slog.Warn("new-api login: upstream returned no session id; transient session could not be revoked")
 	}
 
+	answer, err := fetchNewAPIV1SessionJSON(ctx, baseURL+"/api/user/token", http.MethodGet, nil, headers, proxy)
+	var proof string
+	if err != nil {
+		code, _ := getString(answer.Parsed, "code")
+		success, hasSuccess := getBool(answer.Parsed, "success")
+		// A translated message or an arbitrary 403 is not a step-up demand.
+		// Only the upstream's explicit machine contract permits re-auth.
+		if answer.Status != http.StatusForbidden || code != "SECURITY_PROOF_REQUIRED" || !hasSuccess || success {
+			return "", fmt.Errorf("login succeeded, but New API could not issue a durable dashboard token: %w; %s", err, newAPIManualPATImport)
+		}
+		proof, err = newAPIV1PasswordProof(ctx, baseURL, password, headers, proxy)
+		if err != nil {
+			return "", fmt.Errorf("login succeeded, but New API security verification failed: %w; %s", err, newAPIManualPATImport)
+		}
+		// The proof is single-use and bound to this session and operation.
+		// Retry PAT issuance exactly once, never verify/replay in a loop.
+		headers["X-Security-Proof"] = proof
+		answer, err = fetchNewAPIV1SessionJSON(ctx, baseURL+"/api/user/token", http.MethodGet, nil, headers, proxy)
+		delete(headers, "X-Security-Proof")
+		if err != nil {
+			return "", fmt.Errorf("login succeeded, but New API could not issue a durable dashboard token after security verification: %w; %s", err, newAPIManualPATImport)
+		}
+	}
+	durableToken, _ := getString(answer.Parsed, "data")
+	durableToken = strings.TrimSpace(durableToken)
+	if durableToken == "" || durableToken == sessionJWT || durableToken == proof {
+		return "", fmt.Errorf("login succeeded, but New API returned no durable dashboard PAT; %s", newAPIManualPATImport)
+	}
+	// Logout remains best-effort: never discard a PAT already issued because
+	// session revocation failed. The deferred cleanup uses the session JWT,
+	// never the PAT or the consumed security proof.
 	return durableToken, nil
+}
+
+// newAPIV1PasswordProof implements New API's advertised password ceremony for
+// access_token.generate. MFA and encrypted-password flows are not implemented
+// here; require manual PAT import rather than downgrading to plaintext.
+func newAPIV1PasswordProof(ctx context.Context, baseURL, password string, headers map[string]string, proxy *ProxyConfig) (string, error) {
+	answer, err := fetchNewAPIV1SessionJSON(ctx, baseURL+"/api/verify/methods?scope="+newAPIPATVerificationScope, http.MethodGet, nil, headers, proxy)
+	if err != nil {
+		return "", fmt.Errorf("could not obtain password verification methods: %w", err)
+	}
+	data, _ := getMap(answer.Parsed, "data")
+	scope, _ := getString(data, "scope")
+	if scope != newAPIPATVerificationScope {
+		return "", fmt.Errorf("upstream returned unsupported verification requirements")
+	}
+	methods, _ := data["methods"].([]interface{})
+	passwordAllowed := false
+	for _, raw := range methods {
+		option, _ := raw.(map[string]interface{})
+		method, _ := getString(option, "method")
+		available, _ := getBool(option, "available")
+		if method == "password" && available {
+			passwordAllowed = true
+		}
+	}
+	if !passwordAllowed {
+		return "", fmt.Errorf("upstream requires MFA/interactive verification or password verification is unavailable")
+	}
+	encrypted, hasEncryptionPolicy := getBool(data, "password_encryption_enabled")
+	if !hasEncryptionPolicy || encrypted {
+		return "", fmt.Errorf("upstream password encryption requirements are not supported by this login flow")
+	}
+	if password == "" {
+		return "", fmt.Errorf("no password was supplied for verification")
+	}
+	body := map[string]string{"method": "password", "scope": newAPIPATVerificationScope, "password": password}
+	answer, err = fetchNewAPIV1SessionJSON(ctx, baseURL+"/api/verify", http.MethodPost, body, headers, proxy)
+	if err != nil {
+		return "", fmt.Errorf("password verification was rejected: %w", err)
+	}
+	data, _ = getMap(answer.Parsed, "data")
+	proof, _ := getString(data, "proof_token")
+	method, _ := getString(data, "method")
+	scope, _ = getString(data, "scope")
+	expires, _ := getFloat(data, "expires_at")
+	if strings.TrimSpace(proof) == "" || method != "password" || scope != newAPIPATVerificationScope || expires <= float64(time.Now().Unix()) {
+		return "", fmt.Errorf("upstream returned no valid password verification proof")
+	}
+	return proof, nil
+}
+
+// fetchNewAPIV1SessionJSON retains the status and structured error code for
+// step-up detection, but never exposes upstream bodies or transport errors
+// (which may contain credentials/URLs) to a login result or a log entry.
+func fetchNewAPIV1SessionJSON(ctx context.Context, url, method string, body map[string]string, headers map[string]string, proxy *ProxyConfig) (loginResponse, error) {
+	answer, err := fetchLoginSessionResponse(ctx, url, method, body, headers, proxy)
+	if err != nil {
+		return answer, fmt.Errorf("request failed")
+	}
+	if answer.Status < 200 || answer.Status >= 300 {
+		return answer, fmt.Errorf("HTTP %d", answer.Status)
+	}
+	if answer.Parsed == nil {
+		return answer, fmt.Errorf("invalid JSON response (HTTP %d)", answer.Status)
+	}
+	if success, _ := getBool(answer.Parsed, "success"); !success {
+		return answer, fmt.Errorf("unsuccessful response (HTTP %d)", answer.Status)
+	}
+	return answer, nil
 }
 
 // --- GetUserInfo ---
@@ -897,21 +984,38 @@ type loginResponse struct {
 // caller reports the observed status instead of retrying (the acw_sc__v2
 // challenge requires JS execution, which Go cannot provide).
 func fetchLoginResponse(ctx context.Context, url string, body map[string]string, headers map[string]string, proxy *ProxyConfig) (loginResponse, error) {
-	reqBody, err := json.Marshal(body)
-	if err != nil {
-		return loginResponse{}, fmt.Errorf("marshal body: %w", err)
+	return fetchLoginSessionResponse(ctx, url, http.MethodPost, body, headers, proxy)
+}
+
+// fetchLoginSessionResponse shares the login transport with its authenticated
+// verification/PAT/logout requests without discarding non-2xx JSON envelopes.
+func fetchLoginSessionResponse(ctx context.Context, url, method string, body map[string]string, headers map[string]string, proxy *ProxyConfig) (loginResponse, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		reqBody, err := json.Marshal(body)
+		if err != nil {
+			return loginResponse{}, fmt.Errorf("marshal body: %w", err)
+		}
+		bodyReader = strings.NewReader(string(reqBody))
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(reqBody)))
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
 	if err != nil {
 		return loginResponse{}, fmt.Errorf("create request: %w", err)
+	}
+	if headers == nil {
+		headers = make(map[string]string)
 	}
 	if _, ok := headers["Content-Type"]; !ok {
 		headers["Content-Type"] = "application/json"
 	}
+	if _, ok := headers["User-Agent"]; !ok {
+		headers["User-Agent"] = DefaultBrowserUserAgent
+	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
+	ApplySiteIdentity(req, proxy)
 
 	resp, err := DoWithProxy(ctx, req, proxy)
 	if err != nil {

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -538,7 +540,7 @@ func (n *NewApiAdapter) Checkin(ctx context.Context, baseURL, accessToken string
 	resp, err := fetchJSON(ctx, baseURL+"/api/user/checkin", "POST", nil, headers, proxy)
 	if err == nil {
 		if success, _ := getBool(resp, "success"); success {
-			return checkinResultFromResponse(resp, "checkin success", "checkin failed"), nil
+			return newAPICheckinResultFromResponse(resp, "checkin success", "checkin failed"), nil
 		}
 		firstFailureMessage = extractResponseMessage(resp)
 	} else {
@@ -560,7 +562,7 @@ func (n *NewApiAdapter) Checkin(ctx context.Context, baseURL, accessToken string
 			signInResp, _ := fetchJSON(ctx, baseURL+"/api/user/sign_in", "POST", map[string]interface{}{}, signInHeaders, proxy)
 			if signInResp != nil {
 				if success, _ := getBool(signInResp, "success"); success {
-					return checkinResultFromResponse(signInResp, "checked in", "checked in failed")
+					return newAPICheckinResultFromResponse(signInResp, "checked in", "checked in failed")
 				}
 			}
 
@@ -572,7 +574,7 @@ func (n *NewApiAdapter) Checkin(ctx context.Context, baseURL, accessToken string
 			checkinResp, err := fetchJSON(ctx, baseURL+"/api/user/checkin", "POST", nil, checkinHeaders, proxy)
 			if err == nil {
 				if success, _ := getBool(checkinResp, "success"); success {
-					return checkinResultFromResponse(checkinResp, "checkin success", "checkin failed")
+					return newAPICheckinResultFromResponse(checkinResp, "checkin success", "checkin failed")
 				}
 				fm := extractResponseMessage(checkinResp)
 				if fm != "" && firstFailureMessage == "" {
@@ -605,6 +607,24 @@ func (n *NewApiAdapter) Checkin(ctx context.Context, baseURL, accessToken string
 		firstFailureMessage = "checkin failed"
 	}
 	return &CheckinResult{Success: false, Message: firstFailureMessage}, nil
+}
+
+// newAPICheckinResultFromResponse normalizes the native New API award into
+// the same monetary units as GetBalance. quota_awarded is the integer quota
+// actually credited by this check-in, not the account's remaining quota.
+func newAPICheckinResultFromResponse(resp map[string]interface{}, successMsg, failureMsg string) *CheckinResult {
+	result := checkinResultFromResponse(resp, successMsg, failureMsg)
+	if result.Success {
+		if data, ok := getMap(resp, "data"); ok {
+			if quota, ok := getFloat(data, "quota_awarded"); ok && quota >= 0 && !math.IsInf(quota, 0) && math.Trunc(quota) == quota {
+				// Keep explicit zero distinct from an absent reward. Decimal
+				// formatting also prevents 1 quota from becoming "2e-06",
+				// which a decorated-reward text parser could read as 2.
+				result.Reward = strconv.FormatFloat(quota/500000, 'f', -1, 64)
+			}
+		}
+	}
+	return result
 }
 
 func (n *NewApiAdapter) detectCookieSessionFailure(ctx context.Context, baseURL, accessToken string, candidateUserIDs []*int, proxy *ProxyConfig) string {

--- a/platform/newapi_checkin_reward_test.go
+++ b/platform/newapi_checkin_reward_test.go
@@ -1,0 +1,74 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// QuantumNous/new-api v1.0.0-rc.34 (0c76e4dae77a279e015329b7478e6f02d6b62edd)
+// controller/checkin.go returns quota_awarded, not reward or the total quota.
+func TestNewApiAdapter_CheckinQuotaAwarded(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"rc34_award", `{"success":true,"message":"签到成功","data":{"quota_awarded":1000,"checkin_date":"2026-09-07"}}`, "0.002"},
+		{"one_quota_is_not_two_dollars", `{"success":true,"message":"签到成功","data":{"quota_awarded":1}}`, "0.000002"},
+		{"explicit_zero", `{"success":true,"message":"签到成功","data":{"quota_awarded":0}}`, "0"},
+		{"native_award_precedes_legacy_reward", `{"success":true,"message":"签到成功","data":{"quota_awarded":1000,"reward":20.002}}`, "0.002"},
+		{"legacy_reward_keeps_its_units", `{"success":true,"data":{"reward":"0.003"}}`, "0.003"},
+		{"total_balance_is_not_an_award", `{"success":true,"message":"签到成功","data":{"balance":20.002,"quota":10001000,"checkin_date":"2026-09-07"}}`, ""},
+		{"null_award_is_unknown", `{"success":true,"data":{"quota_awarded":null}}`, ""},
+		{"string_award_is_not_official_contract", `{"success":true,"data":{"quota_awarded":"1000"}}`, ""},
+		{"negative_award_is_unknown", `{"success":true,"data":{"quota_awarded":-1000}}`, ""},
+		{"fractional_quota_is_not_official_contract", `{"success":true,"data":{"quota_awarded":0.5}}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/api/user/checkin" {
+					t.Error("unexpected upstream operation")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tc.body)
+			}))
+			t.Cleanup(srv.Close)
+			userID := 17
+			result, err := newApiAdapterUnderTest().Checkin(context.Background(), srv.URL, "test-dashboard-pat", &userID, nil)
+			if err != nil || result == nil || !result.Success {
+				t.Fatalf("Checkin = %+v, err=%v", result, err)
+			}
+			if result.Reward != tc.want {
+				t.Fatalf("Reward = %q, want %q", result.Reward, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewApiAdapter_CheckinQuotaAwardedCookieFallback(t *testing.T) {
+	for _, path := range []string{"/api/user/sign_in", "/api/user/checkin"} {
+		t.Run(path, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Header.Get("Authorization") != "" {
+					w.WriteHeader(http.StatusUnauthorized)
+					fmt.Fprint(w, `{"success":false,"message":"Unauthorized"}`)
+				} else if r.Method == http.MethodPost && r.URL.Path == path && r.Header.Get("Cookie") != "" {
+					fmt.Fprint(w, `{"success":true,"message":"签到成功","data":{"quota_awarded":1000,"checkin_date":"2026-09-07"}}`)
+				} else {
+					fmt.Fprint(w, `{"success":false}`)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			userID := 17
+			result, err := newApiAdapterUnderTest().Checkin(context.Background(), srv.URL, "session=test-cookie", &userID, nil)
+			if err != nil || result == nil || !result.Success || result.Reward != "0.002" {
+				t.Fatalf("cookie Checkin = %+v, err=%v; want reward 0.002", result, err)
+			}
+		})
+	}
+}

--- a/platform/newapi_step_up_login_test.go
+++ b/platform/newapi_step_up_login_test.go
@@ -1,0 +1,297 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const (
+	stepUpUsername = "test-user"
+	stepUpPassword = "  test-password-with-spaces!  "
+	stepUpJWT      = "test-short-lived-dashboard-jwt"
+	stepUpSID      = "test-session-id"
+	stepUpCookie   = "new_api_refresh=test-session-id.test-refresh-secret"
+	stepUpProof    = "test-single-use-security-proof"
+	stepUpPAT      = "test-durable-dashboard-pat"
+)
+
+type stepUpResponse struct {
+	status int
+	body   string
+}
+
+// The fixture follows QuantumNous/new-api at 0c76e4dae77a279e015329b7478e6f02d6b62edd:
+// router/api-router.go, controller/{access_token,secure_verification,auth_session}.go
+// and service/security_verification.go. A proof is session- and scope-bound,
+// consumed once, and is NOT a cookie or a durable dashboard credential.
+func newAPIStepUpServer(t *testing.T, overrides map[string]stepUpResponse) (*httptest.Server, func() []string) {
+	t.Helper()
+	responses := map[string]stepUpResponse{
+		"login":     {200, `{"success":true,"data":{"access_token":"` + stepUpJWT + `","access_expires_at":1893456000,"session":{"sid":"` + stepUpSID + `"}}}`},
+		"pat":       {403, `{"success":false,"code":"SECURITY_PROOF_REQUIRED","message":"需要安全验证"}`},
+		"methods":   {200, `{"success":true,"data":{"scope":"access_token.generate","methods":[{"method":"password","available":true}],"oauth_providers":[],"password_encryption_enabled":false}}`},
+		"verify":    {200, stepUpProofBody(stepUpProof, "password", "access_token.generate", 1893456000)},
+		"pat-retry": {200, `{"success":true,"message":"","data":"` + stepUpPAT + `"}`},
+		"logout":    {200, `{"success":true,"message":"","data":{"revoked_sid":"` + stepUpSID + `","cookie_cleared":true}}`},
+	}
+	for step, response := range overrides {
+		responses[step] = response
+	}
+	var mu sync.Mutex
+	var calls []string
+	patCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var step string
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/user/login":
+			step = "login"
+		case "GET /api/user/token":
+			mu.Lock()
+			patCalls++
+			count := patCalls
+			mu.Unlock()
+			step = "pat"
+			if count == 2 {
+				step = "pat-retry"
+			} else if count > 2 {
+				t.Error("PAT was retried more than once")
+				step = "unexpected-pat-retry"
+			}
+		case "GET /api/verify/methods":
+			step = "methods"
+		case "POST /api/verify":
+			step = "verify"
+		case "POST /api/user/auth/logout":
+			step = "logout"
+		default:
+			step = "unexpected: " + r.Method + " " + r.URL.Path
+			t.Error("unexpected upstream request")
+		}
+		mu.Lock()
+		calls = append(calls, step)
+		mu.Unlock()
+
+		if step == "login" || step == "verify" {
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error("invalid authentication request JSON")
+			}
+			want := map[string]string{"username": stepUpUsername, "password": stepUpPassword}
+			if step == "verify" {
+				want = map[string]string{"method": "password", "scope": "access_token.generate", "password": stepUpPassword}
+			}
+			if !reflect.DeepEqual(body, want) {
+				t.Error("authentication request did not use exactly the original password and official fields")
+			}
+		} else if r.ContentLength > 0 {
+			t.Error("password or other body unexpectedly sent outside login/verification")
+		}
+		if step == "methods" {
+			if r.URL.RawQuery != "scope=access_token.generate" {
+				t.Error("verification methods requested for the wrong scope")
+			}
+		} else if r.URL.RawQuery != "" {
+			t.Error("unexpected authentication query parameters")
+		}
+		if step != "login" {
+			if r.Header.Get("Authorization") != "Bearer "+stepUpJWT || r.Header.Get("X-Auth-Session") != stepUpSID {
+				t.Error("authentication did not retain the original login session")
+			}
+			if r.Header.Get("New-Api-User") != "17" {
+				t.Error("authentication changed the requested upstream user")
+			}
+		}
+		if step == "pat-retry" {
+			if r.Header.Get("X-Security-Proof") != stepUpProof {
+				t.Error("PAT retry did not carry the issued security proof")
+			}
+		} else if r.Header.Get("X-Security-Proof") != "" {
+			t.Error("security proof sent outside the single PAT retry")
+		}
+		if step == "logout" {
+			if r.Header.Get("Cookie") != stepUpCookie {
+				t.Error("logout lost the login refresh cookie")
+			}
+			if r.Header.Get("Origin") != "http://"+r.Host {
+				t.Error("logout must satisfy the upstream same-origin cookie guard")
+			}
+		} else if r.Header.Get("Cookie") != "" {
+			t.Error("refresh cookie escaped its /api/user/auth path")
+		}
+		if step == "login" {
+			w.Header().Set("Set-Cookie", stepUpCookie+"; Path=/api/user/auth; HttpOnly; SameSite=Strict")
+		}
+		response, ok := responses[step]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(response.status)
+		fmt.Fprint(w, response.body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), calls...)
+	}
+}
+
+func stepUpProofBody(token, method, scope string, expires int64) string {
+	body, _ := json.Marshal(map[string]interface{}{
+		"success": true,
+		"data":    map[string]interface{}{"proof_token": token, "method": method, "scope": scope, "expires_at": expires},
+	})
+	return string(body)
+}
+
+func stepUpSecretError(code string) string {
+	body, _ := json.Marshal(map[string]interface{}{
+		"success": false, "code": code,
+		"message": strings.Join([]string{stepUpUsername, stepUpPassword, stepUpJWT, stepUpSID, stepUpCookie, stepUpProof, stepUpPAT}, " | "),
+	})
+	return string(body)
+}
+
+func captureStepUpLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return &logs
+}
+
+func assertStepUpNoSecrets(t *testing.T, text string) {
+	t.Helper()
+	for _, secret := range []string{stepUpUsername, stepUpPassword, stepUpJWT, stepUpSID, stepUpCookie, stepUpProof, stepUpPAT} {
+		if strings.Contains(text, secret) {
+			t.Error("authentication response or logs leaked a credential/session value")
+		}
+	}
+}
+
+func TestNewApiAdapter_Login_V1PasswordStepUp(t *testing.T) {
+	for _, logoutFails := range []bool{false, true} {
+		t.Run(fmt.Sprintf("logoutFailure=%t", logoutFails), func(t *testing.T) {
+			logs := captureStepUpLogs(t)
+			overrides := map[string]stepUpResponse{}
+			if logoutFails {
+				overrides["logout"] = stepUpResponse{403, stepUpSecretError("AUTH_ORIGIN_FORBIDDEN")}
+			}
+			srv, calls := newAPIStepUpServer(t, overrides)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			userID := 17
+			result, err := newApiAdapterUnderTest().Login(ctx, srv.URL, stepUpUsername, stepUpPassword, &userID, nil)
+			if err != nil || result == nil || !result.Success || result.AccessToken != stepUpPAT {
+				t.Fatalf("password step-up did not return the durable PAT: result=%+v err=%v", result, err)
+			}
+			want := []string{"login", "pat", "methods", "verify", "pat-retry", "logout"}
+			if !reflect.DeepEqual(calls(), want) {
+				t.Fatalf("requests = %v, want %v", calls(), want)
+			}
+			if logoutFails && logs.Len() == 0 {
+				t.Error("best-effort logout failure must be observable")
+			}
+			assertStepUpNoSecrets(t, result.Message+logs.String())
+		})
+	}
+}
+
+func TestNewApiAdapter_Login_V1StepUpFailsClosed(t *testing.T) {
+	beforeMethods := []string{"login", "pat", "logout"}
+	beforeVerify := []string{"login", "pat", "methods", "logout"}
+	beforeRetry := []string{"login", "pat", "methods", "verify", "logout"}
+	afterRetry := []string{"login", "pat", "methods", "verify", "pat-retry", "logout"}
+	cases := []struct {
+		name     string
+		step     string
+		response stepUpResponse
+		calls    []string
+	}{
+		{"wrong_password", "verify", stepUpResponse{200, stepUpSecretError("SECURITY_VERIFICATION_FAILED")}, beforeRetry},
+		{"policy_changed_to_mfa", "verify", stepUpResponse{200, stepUpSecretError("SECURITY_PROOF_METHOD_MISMATCH")}, beforeRetry},
+		{"two_factor_required", "methods", stepUpResponse{200, `{"success":true,"data":{"scope":"access_token.generate","methods":[{"method":"2fa","available":true}],"password_encryption_enabled":false}}`}, beforeVerify},
+		{"passkey_required", "methods", stepUpResponse{200, `{"success":true,"data":{"scope":"access_token.generate","methods":[{"method":"passkey","available":true}],"password_encryption_enabled":false}}`}, beforeVerify},
+		{"oauth_required", "methods", stepUpResponse{200, `{"success":true,"data":{"scope":"access_token.generate","methods":[{"method":"oauth","available":true}],"password_encryption_enabled":false}}`}, beforeVerify},
+		{"password_unavailable", "methods", stepUpResponse{200, `{"success":true,"data":{"scope":"access_token.generate","methods":[{"method":"password","available":false}],"password_encryption_enabled":false}}`}, beforeVerify},
+		{"encrypted_password_required", "methods", stepUpResponse{200, `{"success":true,"data":{"scope":"access_token.generate","methods":[{"method":"password","available":true}],"password_encryption_enabled":true}}`}, beforeVerify},
+		{"unknown_encryption_policy", "methods", stepUpResponse{200, `{"success":true,"data":{"scope":"access_token.generate","methods":[{"method":"password","available":true}]}}`}, beforeVerify},
+		{"different_operation", "methods", stepUpResponse{200, `{"success":true,"data":{"scope":"access_token.revoke","methods":[{"method":"password","available":true}],"password_encryption_enabled":false}}`}, beforeVerify},
+		{"methods_not_supported", "methods", stepUpResponse{404, stepUpSecretError("NOT_FOUND")}, beforeVerify},
+		{"non_step_up_403", "pat", stepUpResponse{403, stepUpSecretError("SECURITY_ACTION_FORBIDDEN")}, beforeMethods},
+		{"message_alone_is_not_a_challenge", "pat", stepUpResponse{403, `{"success":false,"message":"需要安全验证 SECURITY_PROOF_REQUIRED"}`}, beforeMethods},
+		{"challenge_code_without_403", "pat", stepUpResponse{401, stepUpSecretError("SECURITY_PROOF_REQUIRED")}, beforeMethods},
+		{"challenge_code_with_200", "pat", stepUpResponse{200, stepUpSecretError("SECURITY_PROOF_REQUIRED")}, beforeMethods},
+		{"invalid_json_403", "pat", stepUpResponse{403, "not JSON: " + stepUpPassword + " " + stepUpJWT}, beforeMethods},
+		{"failed_pat_envelope_with_data", "pat", stepUpResponse{200, `{"success":false,"data":"` + stepUpPAT + `"}`}, beforeMethods},
+		{"proof_still_required_after_retry", "pat-retry", stepUpResponse{403, stepUpSecretError("SECURITY_PROOF_REQUIRED")}, afterRetry},
+		{"pat_retry_server_error", "pat-retry", stepUpResponse{500, stepUpSecretError("AUTH_INTERNAL_ERROR")}, afterRetry},
+		{"pat_must_not_be_session_jwt", "pat-retry", stepUpResponse{200, `{"success":true,"data":"` + stepUpJWT + `"}`}, afterRetry},
+		{"pat_must_not_be_security_proof", "pat-retry", stepUpResponse{200, `{"success":true,"data":"` + stepUpProof + `"}`}, afterRetry},
+		{"wrong_proof_scope", "verify", stepUpResponse{200, stepUpProofBody(stepUpProof, "password", "access_token.revoke", 1893456000)}, beforeRetry},
+		{"wrong_proof_method", "verify", stepUpResponse{200, stepUpProofBody(stepUpProof, "2fa", "access_token.generate", 1893456000)}, beforeRetry},
+		{"expired_proof", "verify", stepUpResponse{200, stepUpProofBody(stepUpProof, "password", "access_token.generate", 1)}, beforeRetry},
+		{"missing_proof", "verify", stepUpResponse{200, stepUpProofBody("", "password", "access_token.generate", 1893456000)}, beforeRetry},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureStepUpLogs(t)
+			srv, calls := newAPIStepUpServer(t, map[string]stepUpResponse{tc.step: tc.response})
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			userID := 17
+			result, err := newApiAdapterUnderTest().Login(ctx, srv.URL, stepUpUsername, stepUpPassword, &userID, nil)
+			if err != nil || result == nil {
+				t.Fatalf("Login should return an explicit rejected result, err=%v", err)
+			}
+			if result.Success || result.AccessToken != "" {
+				t.Fatal("failed verification returned a credential")
+			}
+			if !strings.Contains(result.Message, "manually") || !strings.Contains(result.Message, "PAT") {
+				t.Errorf("missing manual PAT recovery instruction: %q", result.Message)
+			}
+			if !reflect.DeepEqual(calls(), tc.calls) {
+				t.Fatalf("requests = %v, want %v", calls(), tc.calls)
+			}
+			assertStepUpNoSecrets(t, result.Message+logs.String())
+		})
+	}
+}
+
+func TestNewApiAdapter_Login_MFAChallengeRequiresManualPAT(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Method != http.MethodPost || r.URL.Path != "/api/user/login" {
+			t.Error("MFA login must not attempt a bypass or PAT request")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"require_verification":true,"flow_token":"test-mfa-flow-token","expires_at":1893456000,"methods":[{"method":"2fa","available":true}]}}`)
+	}))
+	t.Cleanup(srv.Close)
+	result, err := newApiAdapterUnderTest().Login(context.Background(), srv.URL, stepUpUsername, stepUpPassword, nil, nil)
+	if err != nil || result == nil || result.Success || result.AccessToken != "" || !strings.Contains(result.Message, "MFA") || !strings.Contains(result.Message, "manually") {
+		t.Fatalf("expected explicit manual PAT recovery for MFA: result=%+v err=%v", result, err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("requests = %d, want only the login", calls.Load())
+	}
+	assertStepUpNoSecrets(t, result.Message)
+	if strings.Contains(result.Message, "test-mfa-flow-token") {
+		t.Error("MFA flow token leaked")
+	}
+}

--- a/scripts/e2e/smoke-strict-relay-test.sh
+++ b/scripts/e2e/smoke-strict-relay-test.sh
@@ -17,6 +17,8 @@ method=GET
 out=
 auth=
 url=
+request_body=
+exit_code=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -X) method="$2"; shift 2 ;;
@@ -26,14 +28,16 @@ while [ "$#" -gt 0 ]; do
       case "$2" in Authorization:*) auth="${2#Authorization: }" ;; esac
       shift 2
       ;;
-    -d) shift 2 ;;
+    -d) request_body="$2"; shift 2 ;;
+    --noproxy) shift 2 ;;
     -m) shift 2 ;;
-    -s|-S|-f|-sS|-fsS) shift ;;
+    -q|-s|-S|-f|-sS|-fsS) shift ;;
     http://*|https://*) url="$1"; shift ;;
     *) echo "fake curl: unsupported argument $1" >&2; exit 2 ;;
   esac
 done
 path="/${url#*://*/}"
+printf "%s %s\n" "$method" "$path" >> "$RELAY_CALL_LOG"
 status=200
 body='{}'
 case "$method $path" in
@@ -52,11 +56,14 @@ case "$method $path" in
   "GET /api/accounts") body='{"accounts":[{"id":1,"siteId":1,"username":"root"}]}' ;;
   "PUT /api/accounts/1") body='{"id":1}' ;;
   "GET /api/accounts/1/models")
-    if [ "${STRICT_CASE:-good}" = "models_empty" ]; then
-      body='{"models":[],"totalCount":0}'
-    else
-      body='{"models":[{"name":"gpt-4o-mini"}],"totalCount":1}'
-    fi
+    case "${STRICT_CASE:-good}" in
+      models_empty|account_models_empty) body='{"models":[],"totalCount":0}' ;;
+      models_http_error) status=503; body='{"error":"discovery unavailable"}' ;;
+      models_malformed) body='{not-json' ;;
+      models_bad_shape) body='{"models":[{"name":null}],"totalCount":1}' ;;
+      models_zero_count) body='{"models":[{"name":"gpt-4o-mini"}],"totalCount":0}' ;;
+      *) body='{"models":[{"name":"gpt-4o-mini"}],"totalCount":1}' ;;
+    esac
     ;;
   "POST /api/accounts/1/balance") body='{"balance":10}' ;;
   "POST /api/checkin/trigger/1")
@@ -73,30 +80,51 @@ case "$method $path" in
   "PUT /api/downstream-keys/9") body='{"success":true}' ;;
   "GET /api/routes/lite") body='[{"id":1,"modelPattern":"gpt-4o-mini"},{"id":2,"modelPattern":"gpt-3.5-turbo"}]' ;;
   "GET /v1/models")
-    if [ "${STRICT_CASE:-good}" = "models_empty" ]; then
-      body='{"object":"list","data":[]}'
-    else
-      body='{"object":"list","data":[{"id":"gpt-4o-mini","object":"model"}]}'
-    fi
+    case "${STRICT_CASE:-good}" in
+      models_empty|proxy_models_empty) body='{"object":"list","data":[]}' ;;
+      proxy_models_missing_selected) body='{"data":[{"id":"some-other-model"}]}' ;;
+      proxy_models_200_error) body='{"error":{},"data":[{"id":"gpt-4o-mini"}]}' ;;
+      proxy_models_malformed) body='{not-json' ;;
+      proxy_models_http_error) status=503; body='{"error":"no models available"}' ;;
+      *) body='{"object":"list","data":[{"id":"gpt-4o-mini","object":"model"}]}' ;;
+    esac
+    if [ "${STRICT_CASE:-good}" = "proxy_models_transport_error" ]; then exit_code=28; fi
     ;;
   "POST /v1/chat/completions")
+    requested_model="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("model", ""))' "$request_body")"
+    if [ "$requested_model" != "gpt-4o-mini" ]; then
+      echo "fake curl: completion did not use the discovered model" >&2
+      exit 2
+    fi
     case "${STRICT_CASE:-good}" in
       completion_error) status=502; body='{"error":{"message":"no available channels"}}' ;;
+      completion_503_error) status=503; body='{"error":{"message":"no available channels"}}' ;;
+      completion_200_error) body='{"error":{"message":"model failed"}}' ;;
+      completion_error_with_content) body='{"error":{},"choices":[{"message":{"content":"metapi-e2e-marker"}}]}' ;;
+      completion_empty_choices) body='{"choices":[]}' ;;
       completion_missing) body='{"id":"chatcmpl-empty","choices":[{"message":{"role":"assistant"}}]}' ;;
+      completion_empty_content) body='{"choices":[{"message":{"content":"   "}}]}' ;;
+      completion_malformed) body='{not-json' ;;
+      completion_wrong_marker) body='{"choices":[{"message":{"content":"wrong-marker"}}]}' ;;
+      completion_parts) body='{"choices":[{"message":{"content":[{"type":"text","text":"part content"}]}}]}' ;;
       *) body='{"id":"chatcmpl-ok","choices":[{"message":{"role":"assistant","content":"metapi-e2e-marker"}}]}' ;;
     esac
+    if [ "${STRICT_CASE:-good}" = "completion_transport_error" ]; then exit_code=28; fi
     ;;
   *) status=404; body='{"error":"fake route not found"}' ;;
 esac
 printf '%s' "$body" > "$out"
 printf '%s' "$status"
+exit "$exit_code"
 FAKE_CURL
 chmod +x "$TEST_DIR/curl"
 
 run_chain() {
   local script="$1" case_name="$2" output="$3"
   shift 3
-  env PATH="$TEST_DIR:$PATH" STRICT_CASE="$case_name" \
+  : > "$output.requests"
+  env PATH="$TEST_DIR:$PATH" STRICT_CASE="$case_name" RELAY_CALL_LOG="$output.requests" \
+    EXPECT_RELAY=1 E2E_SKIP_RELAY=0 \
     METAPI_URL=http://127.0.0.1:4000 \
     METAPI_AUTH_TOKEN=test-admin \
     UPSTREAM_URL=http://127.0.0.1:3001 \
@@ -215,4 +243,137 @@ for script in "$SMOKE_SCRIPT" "$TOKEN_IMPORT_SCRIPT"; do
   echo "$chain: explicit check-in skip counted, not PASS"
 done
 
-echo "smoke relay and check-in verdict contracts: PASS"
+# A failed discovery must not be papered over by a fallback/another route.
+# Keep these before the token happy-path output assertions: the old verifier
+# must be rejected because it ACCEPTS bad input, not because its prose differs.
+assert_no_relay_requests() {
+  local output="$1"
+  test -f "$output.requests"
+  if grep -Eq '^[A-Z]+ /(v1/|api/downstream-keys|api/routes)' "$output.requests"; then
+    echo "unexpected relay/setup request: $output" >&2
+    cat "$output.requests" >&2
+    exit 1
+  else
+    test "$?" -eq 1 # grep read errors are not evidence of zero requests.
+  fi
+}
+
+for case_name in models_empty account_models_empty models_http_error models_malformed models_bad_shape models_zero_count; do
+  output="$TEST_DIR/token-$case_name.log"
+  if run_chain "$TOKEN_IMPORT_SCRIPT" "$case_name" "$output"; then
+    echo "token-import verifier accepted failed model discovery: $case_name" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  status=200
+  if [ "$case_name" = "models_http_error" ]; then status=503; fi
+  assert_contains "$output" "[FAIL] models (HTTP $status, expected non-empty discovery containing PROXY_MODEL when set)"
+  assert_no_relay_requests "$output"
+  echo "token-import $case_name: rejected before relay setup"
+done
+
+for case_name in proxy_models_empty proxy_models_missing_selected proxy_models_200_error proxy_models_malformed proxy_models_http_error proxy_models_transport_error; do
+  output="$TEST_DIR/token-$case_name.log"
+  if run_chain "$TOKEN_IMPORT_SCRIPT" "$case_name" "$output"; then
+    echo "token-import verifier accepted an unavailable proxy model: $case_name" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  status=200
+  if [ "$case_name" = "proxy_models_http_error" ]; then status=503; fi
+  assert_contains "$output" "[FAIL] proxy /v1/models (HTTP $status, expected non-empty data containing selected model without error)"
+  assert_contains "$output" '[FAIL] proxy /v1/chat/completions not attempted (selected model unavailable)'
+  if grep -Fqx 'POST /v1/chat/completions' "$output.requests"; then
+    echo "token-import verifier issued a model POST after failed model discovery" >&2
+    exit 1
+  else
+    test "$?" -eq 1
+  fi
+  echo "token-import $case_name: rejected without model POST"
+done
+
+for case_name in completion_error completion_503_error completion_200_error completion_error_with_content completion_empty_choices completion_missing completion_empty_content completion_malformed completion_wrong_marker completion_transport_error; do
+  output="$TEST_DIR/token-$case_name.log"
+  if run_chain "$TOKEN_IMPORT_SCRIPT" "$case_name" "$output"; then
+    echo "token-import verifier accepted an invalid completion: $case_name" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  status=200
+  if [ "$case_name" = "completion_error" ]; then status=502; fi
+  if [ "$case_name" = "completion_503_error" ]; then status=503; fi
+  assert_contains "$output" "[FAIL] proxy /v1/chat/completions (HTTP $status, expected completion content without error)"
+  test "$(grep -Fxc 'POST /v1/chat/completions' "$output.requests")" = "1"
+  echo "token-import $case_name: rejected, no retry"
+done
+
+output="$TEST_DIR/token-good.log"
+run_chain "$TOKEN_IMPORT_SCRIPT" good "$output" PROXY_MODEL=
+assert_contains "$output" '[PASS] models (HTTP 200, selected=gpt-4o-mini)'
+assert_contains "$output" '[PASS] proxy /v1/models (HTTP 200, selected model present: gpt-4o-mini)'
+assert_contains "$output" '[PASS] proxy /v1/chat/completions (HTTP 200, completion content present)'
+assert_contains "$output" '== summary: 13 passed, 0 warned, 0 skipped, 0 failed =='
+test "$(grep -Fxc 'GET /v1/models' "$output.requests")" = "1"
+test "$(grep -Fxc 'POST /v1/chat/completions' "$output.requests")" = "1"
+echo "token-import default model selection: 13 PASS, exact relay calls"
+
+output="$TEST_DIR/token-requested-model-missing.log"
+if run_chain "$TOKEN_IMPORT_SCRIPT" good "$output" PROXY_MODEL=not-discovered; then
+  echo "token-import verifier ignored the requested model" >&2
+  exit 1
+fi
+assert_contains "$output" '[FAIL] models (HTTP 200, expected non-empty discovery containing PROXY_MODEL when set)'
+assert_no_relay_requests "$output"
+
+# Match smoke.sh: no marker means nonempty text (including text parts) suffices;
+# a configured marker requires exact string equality, tested above.
+output="$TEST_DIR/token-parts.log"
+run_chain "$TOKEN_IMPORT_SCRIPT" completion_parts "$output" EXPECTED_COMPLETION_CONTENT=
+assert_contains "$output" '== summary: 13 passed, 0 warned, 0 skipped, 0 failed =='
+
+output="$TEST_DIR/token-explicit-skip.log"
+run_chain "$TOKEN_IMPORT_SCRIPT" models_empty "$output" E2E_SKIP_RELAY=1
+assert_contains "$output" '[SKIP] models relay assertion disabled explicitly'
+assert_contains "$output" '[SKIP] downstream token relay setup disabled explicitly'
+assert_contains "$output" '[SKIP] route relay setup disabled explicitly'
+assert_contains "$output" '[SKIP] proxy /v1/models relay assertion disabled explicitly'
+assert_contains "$output" '[SKIP] proxy /v1/chat/completions relay assertion disabled explicitly'
+assert_contains "$output" '== summary: 8 passed, 0 warned, 5 skipped, 0 failed =='
+assert_contains "$output" '[PASS] checkin (success)'
+grep -Fqx 'GET /health' "$output.requests"
+assert_no_relay_requests "$output"
+if grep -Eq '^\[PASS\] (models|token|route|proxy) ' "$output"; then
+  echo "explicit relay skip was mislabeled PASS" >&2
+  exit 1
+else
+  test "$?" -eq 1
+fi
+echo "token-import explicit skip: 8 management PASS, 5 SKIP, zero relay/setup calls"
+
+# Existing management checks still gate even when relay coverage is disabled.
+output="$TEST_DIR/token-skip-checkin-failed.log"
+if run_chain "$TOKEN_IMPORT_SCRIPT" checkin_failed "$output" E2E_SKIP_RELAY=1; then
+  echo "relay skip masked a failed check-in" >&2
+  exit 1
+fi
+assert_contains "$output" '[FAIL] checkin (HTTP 200, expected a consistent success or skipped outcome)'
+assert_no_relay_requests "$output"
+
+for flag in SKIP_MODEL_FETCH=true EXPECT_RELAY=0; do
+  output="$TEST_DIR/token-not-a-skip-${flag%%=*}.log"
+  if run_chain "$TOKEN_IMPORT_SCRIPT" models_empty "$output" "$flag"; then
+    echo "token-import verifier treated $flag as relay skip" >&2
+    exit 1
+  fi
+  assert_contains "$output" '[FAIL] models (HTTP 200, expected non-empty discovery containing PROXY_MODEL when set)'
+  assert_no_relay_requests "$output"
+done
+output="$TEST_DIR/token-invalid-skip.log"
+if run_chain "$TOKEN_IMPORT_SCRIPT" good "$output" E2E_SKIP_RELAY=true; then
+  echo "token-import verifier accepted an ambiguous skip value" >&2
+  exit 1
+fi
+assert_contains "$output" 'FATAL: E2E_SKIP_RELAY must be 0 or 1'
+test ! -s "$output.requests"
+
+echo "smoke/token-import strict relay and check-in verdict contracts: PASS"

--- a/scripts/e2e/smoke-strict-relay-test.sh
+++ b/scripts/e2e/smoke-strict-relay-test.sh
@@ -40,6 +40,12 @@ path="/${url#*://*/}"
 printf "%s %s\n" "$method" "$path" >> "$RELAY_CALL_LOG"
 status=200
 body='{}'
+exposed_model=gpt-4o-mini
+if [ "${STRICT_CASE:-good}" = "aliased_route" ]; then
+  exposed_model=customer-alias
+elif [ -f "$RELAY_CALL_LOG.public-model" ]; then
+  exposed_model="$(cat "$RELAY_CALL_LOG.public-model")"
+fi
 case "$method $path" in
   "GET /health") body='{"status":"ok"}' ;;
   "GET /api/sites")
@@ -78,7 +84,23 @@ case "$method $path" in
   "POST /api/downstream-keys") status=409; body='{"error":"duplicate"}' ;;
   "GET /api/downstream-keys") body='{"items":[{"id":9,"name":"e2e-smoke-token"}]}' ;;
   "PUT /api/downstream-keys/9") body='{"success":true}' ;;
-  "GET /api/routes/lite") body='[{"id":1,"modelPattern":"gpt-4o-mini"},{"id":2,"modelPattern":"gpt-3.5-turbo"}]' ;;
+  "GET /api/routes/lite")
+    case "${STRICT_CASE:-good}" in
+      fresh_route) body='[]' ;;
+      aliased_route) body='[{"id":1,"modelPattern":"gpt-4o-mini","displayName":"customer-alias"}]' ;;
+      *) body='[{"id":1,"modelPattern":"gpt-4o-mini"},{"id":2,"modelPattern":"gpt-3.5-turbo"}]' ;;
+    esac
+    ;;
+  "POST /api/routes")
+    body="$(python3 -c '
+import json,sys
+from pathlib import Path
+route=json.loads(sys.argv[1])
+public=(route.get("displayName") or route["modelPattern"]).strip()
+Path(sys.argv[2]).write_text(public)
+print(json.dumps(dict(route, id=1)))
+' "$request_body" "$RELAY_CALL_LOG.public-model")"
+    ;;
   "GET /v1/models")
     case "${STRICT_CASE:-good}" in
       models_empty|proxy_models_empty) body='{"object":"list","data":[]}' ;;
@@ -86,14 +108,14 @@ case "$method $path" in
       proxy_models_200_error) body='{"error":{},"data":[{"id":"gpt-4o-mini"}]}' ;;
       proxy_models_malformed) body='{not-json' ;;
       proxy_models_http_error) status=503; body='{"error":"no models available"}' ;;
-      *) body='{"object":"list","data":[{"id":"gpt-4o-mini","object":"model"}]}' ;;
+      *) body="$(printf '{"object":"list","data":[{"id":"%s","object":"model"}]}' "$exposed_model")" ;;
     esac
     if [ "${STRICT_CASE:-good}" = "proxy_models_transport_error" ]; then exit_code=28; fi
     ;;
   "POST /v1/chat/completions")
     requested_model="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("model", ""))' "$request_body")"
-    if [ "$requested_model" != "gpt-4o-mini" ]; then
-      echo "fake curl: completion did not use the discovered model" >&2
+    if [ "$requested_model" != "$exposed_model" ]; then
+      echo "fake curl: completion did not use the advertised route model" >&2
       exit 2
     fi
     case "${STRICT_CASE:-good}" in
@@ -375,5 +397,26 @@ if run_chain "$TOKEN_IMPORT_SCRIPT" good "$output" E2E_SKIP_RELAY=true; then
 fi
 assert_contains "$output" 'FATAL: E2E_SKIP_RELAY must be 0 or 1'
 test ! -s "$output.requests"
+
+# A fresh route exposes displayName as its model ID. The fixture must derive
+# that value from the actual create payload instead of assuming the raw model.
+for script in "$SMOKE_SCRIPT" "$TOKEN_IMPORT_SCRIPT"; do
+  for case_name in fresh_route aliased_route; do
+    output="$TEST_DIR/$(basename "$script")-$case_name.log"
+    if ! run_chain "$script" "$case_name" "$output"; then
+      echo "$(basename "$script"): $case_name did not relay the exposed model" >&2
+      cat "$output" >&2
+      exit 1
+    fi
+    if [ "$case_name" = fresh_route ]; then
+      test "$(grep -Fxc 'POST /api/routes' "$output.requests")" = "1"
+    elif grep -Fqx 'POST /api/routes' "$output.requests"; then
+      echo "existing alias was overwritten instead of reused" >&2
+      exit 1
+    fi
+    test "$(grep -Fxc 'POST /v1/chat/completions' "$output.requests")" = "1"
+    echo "$(basename "$script"): $case_name relays the advertised model"
+  done
+done
 
 echo "smoke/token-import strict relay and check-in verdict contracts: PASS"

--- a/scripts/e2e/smoke-strict-relay-test.sh
+++ b/scripts/e2e/smoke-strict-relay-test.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Deterministic contract test for smoke.sh strict/skip relay semantics.
+# Deterministic contract tests for relay strictness and check-in verdicts.
+# These fixtures test the instruments; real-platform chains remain separate.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SMOKE_SCRIPT="${SMOKE_UNDER_TEST:-$ROOT_DIR/scripts/e2e/smoke.sh}"
+TOKEN_IMPORT_SCRIPT="${TOKEN_IMPORT_UNDER_TEST:-$ROOT_DIR/scripts/e2e/verify-token-import.sh}"
 TEST_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_DIR"' EXIT
 
@@ -48,6 +50,7 @@ case "$method $path" in
   "POST /api/accounts/login") body='{"success":true,"account":{"accessToken":"session-token"}}' ;;
   "POST /api/accounts/verify-token") body='{"tokenType":"session"}' ;;
   "GET /api/accounts") body='{"accounts":[{"id":1,"siteId":1,"username":"root"}]}' ;;
+  "PUT /api/accounts/1") body='{"id":1}' ;;
   "GET /api/accounts/1/models")
     if [ "${STRICT_CASE:-good}" = "models_empty" ]; then
       body='{"models":[],"totalCount":0}'
@@ -56,7 +59,15 @@ case "$method $path" in
     fi
     ;;
   "POST /api/accounts/1/balance") body='{"balance":10}' ;;
-  "POST /api/checkin/trigger/1") body='{"success":true}' ;;
+  "POST /api/checkin/trigger/1")
+    case "${STRICT_CASE:-good}" in
+      checkin_failed) body='{"success":false,"status":"failed","skipped":false,"message":"test upstream authentication failed"}' ;;
+      checkin_malformed) body='{"message":"missing outcome fields"}' ;;
+      checkin_contradictory) body='{"success":true,"status":"success","skipped":true}' ;;
+      checkin_skipped) body='{"success":true,"status":"skipped","skipped":true}' ;;
+      *) body='{"success":true,"status":"success","skipped":false}' ;;
+    esac
+    ;;
   "POST /api/downstream-keys") status=409; body='{"error":"duplicate"}' ;;
   "GET /api/downstream-keys") body='{"items":[{"id":9,"name":"e2e-smoke-token"}]}' ;;
   "PUT /api/downstream-keys/9") body='{"success":true}' ;;
@@ -82,19 +93,23 @@ printf '%s' "$status"
 FAKE_CURL
 chmod +x "$TEST_DIR/curl"
 
-run_smoke() {
-  local case_name="$1" output="$2"
-  shift 2
+run_chain() {
+  local script="$1" case_name="$2" output="$3"
+  shift 3
   env PATH="$TEST_DIR:$PATH" STRICT_CASE="$case_name" \
     METAPI_URL=http://127.0.0.1:4000 \
     METAPI_AUTH_TOKEN=test-admin \
     UPSTREAM_URL=http://127.0.0.1:3001 \
     UPSTREAM_USERNAME=root \
     UPSTREAM_PASSWORD=test-password \
-    PLATFORM=new-api \
+    UPSTREAM_TOKEN=test-upstream-token \
+    ACCOUNT_USERNAME=root SITE_NAME=e2e-smoke TOKEN_NAME=e2e-smoke-token \
+    PROXY_MODEL=gpt-4o-mini PLATFORM=new-api \
     EXPECTED_COMPLETION_CONTENT=metapi-e2e-marker \
-    "$@" bash "$SMOKE_SCRIPT" >"$output" 2>&1
+    "$@" bash "$script" >"$output" 2>&1
 }
+
+run_smoke() { run_chain "$SMOKE_SCRIPT" "$@"; }
 
 assert_contains() {
   local file="$1" exact="$2"
@@ -162,4 +177,42 @@ assert_contains "$good" '[PASS] token reuse (e2e-smoke-token, relay policy reass
 assert_contains "$good" '[PASS] proxy /v1/models (HTTP 200, non-empty data)'
 assert_contains "$good" '[PASS] proxy /v1/chat/completions (HTTP 200, completion content present)'
 assert_contains "$good" '== summary: 14 passed, 0 warned, 0 skipped, 0 failed =='
-echo "smoke strict relay contract: PASS"
+# Both entrypoints consume the same normalized API outcome, including the
+# token-import path that used to have no SKIP counter at all.
+for script in "$SMOKE_SCRIPT" "$TOKEN_IMPORT_SCRIPT"; do
+  chain="$(basename "$script")"
+  output="$TEST_DIR/$chain-checkin-good.log"
+  if ! run_chain "$script" good "$output"; then
+    echo "$chain: happy path failed" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  assert_contains "$output" '[PASS] checkin (success)'
+
+  for case_name in checkin_failed checkin_malformed checkin_contradictory; do
+    output="$TEST_DIR/$chain-$case_name.log"
+    if run_chain "$script" "$case_name" "$output"; then
+      echo "$chain: accepted $case_name" >&2
+      cat "$output" >&2
+      exit 1
+    fi
+    assert_contains "$output" '[FAIL] checkin (HTTP 200, expected a consistent success or skipped outcome)'
+    echo "$chain: $case_name rejected"
+  done
+
+  output="$TEST_DIR/$chain-checkin-skipped.log"
+  if ! run_chain "$script" checkin_skipped "$output"; then
+    echo "$chain: an explicit skipped outcome incorrectly failed the chain" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  assert_contains "$output" '[SKIP] checkin (status=skipped; no successful check-in verified)'
+  if grep -Fq '[PASS] checkin (' "$output" || ! grep -Eq '^== summary: .* 1 skipped, 0 failed ==$' "$output"; then
+    echo "$chain: skipped check-in was mislabeled or not counted" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  echo "$chain: explicit check-in skip counted, not PASS"
+done
+
+echo "smoke relay and check-in verdict contracts: PASS"

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -547,6 +547,8 @@ else
 fi
 
 # 12. route create (idempotent by modelPattern lookup)
+# displayName is the public model alias, not an internal fixture label.
+RELAY_MODEL="$ROUTE_MODEL"
 if [ "$EXPECT_RELAY" = "0" ]; then
   skip_step "route relay setup disabled explicitly"
 else
@@ -556,10 +558,13 @@ else
     if [ "$status" = "200" ]; then
       if idx="$(json_find_index modelPattern "$ROUTE_MODEL" 2>/dev/null)"; then
         ROUTE_ID="$(json_value "[$idx].id" 2>/dev/null || true)"
+        route_alias="$(json_value "[$idx].displayName" 2>/dev/null || true)"
+        route_alias="$(printf '%s' "$route_alias" | python3 -c 'import sys; print(sys.stdin.read().strip())')"
+        if [ -n "$route_alias" ]; then RELAY_MODEL="$route_alias"; fi
       fi
     fi
     if [ -z "$ROUTE_ID" ]; then
-      status="$(request POST "$METAPI_URL/api/routes" "{\"modelPattern\":\"$ROUTE_MODEL\",\"displayName\":\"e2e-smoke-route\",\"routeMode\":\"pattern\",\"enabled\":true}" "$METAPI_AUTH_TOKEN")"
+      status="$(request POST "$METAPI_URL/api/routes" "{\"modelPattern\":\"$ROUTE_MODEL\",\"routeMode\":\"pattern\",\"enabled\":true}" "$METAPI_AUTH_TOKEN")"
       if [ "$status" = "200" ] || [ "$status" = "201" ]; then
         ROUTE_ID="$(json_value id 2>/dev/null || true)"
       fi
@@ -594,7 +599,7 @@ elif [ -n "$PROXY_TOKEN" ]; then
     evidence
   fi
 
-  status="$(request POST "$METAPI_URL/v1/chat/completions" "{\"model\":\"$ROUTE_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}" "$PROXY_TOKEN")"
+  status="$(request POST "$METAPI_URL/v1/chat/completions" "{\"model\":\"$RELAY_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}" "$PROXY_TOKEN")"
   if [[ "$status" =~ ^2[0-9][0-9]$ ]] && json_completion_has_content "$EXPECTED_COMPLETION_CONTENT"; then
     pass_step "proxy /v1/chat/completions (HTTP $status, completion content present)"
   else

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -78,7 +78,8 @@ RESP_BODY="$WORKDIR/resp_body.txt"
 # response body is saved to $RESP_BODY.
 request() {
   local method="$1" url="$2" body="${3:-}" token="${4:-}"
-  local args=(-sS -m 120 -X "$method" "$url" -o "$RESP_BODY" -w "%{http_code}" -H "Content-Type: application/json")
+  : > "$RESP_BODY" || return 1
+  local args=(-q --noproxy "*" -sS -m 120 -X "$method" "$url" -o "$RESP_BODY" -w "%{http_code}" -H "Content-Type: application/json")
   if [ -n "$token" ]; then
     args+=(-H "Authorization: Bearer $token")
   fi

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -482,18 +482,24 @@ else
   fail_step "balance skipped (no account id)"
 fi
 
-# 10. checkin (POST /api/checkin/trigger/{id}); v1 may not support checkin —
-#     a 2xx with success=false is a documented unsupported result (PASS),
-#     5xx/crash is a FAIL.
+# 10. checkin: success is PASS, an explicit skipped outcome is SKIP, and
+#     failed/malformed outcomes are FAIL even when the endpoint answers 200.
 if [ -n "$ACCOUNT_ID" ]; then
   status="$(request POST "$METAPI_URL/api/checkin/trigger/$ACCOUNT_ID" "" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ]; then
     checkin_ok="$(json_value success 2>/dev/null || true)"
-    if [ "$checkin_ok" = "True" ]; then
-      pass_step "checkin (success)"
-    else
-      pass_step "checkin (documented unsupported/negative result: success=$checkin_ok)"
-    fi
+    checkin_status="$(json_value status 2>/dev/null || true)"
+    checkin_skipped="$(json_value skipped 2>/dev/null || true)"
+    # The API owns outcome normalization. Do not infer unsupported from HTTP
+    # 200 or success=false, and do not grow another message-text classifier.
+    case "$checkin_ok:$checkin_status:$checkin_skipped" in
+      True:success:False) pass_step "checkin (success)" ;;
+      True:skipped:True|False:skipped:True) skip_step "checkin (status=skipped; no successful check-in verified)" ;;
+      *)
+        fail_step "checkin (HTTP 200, expected a consistent success or skipped outcome)"
+        evidence
+        ;;
+    esac
   elif [ "$status" = "404" ]; then
     fail_step "checkin (HTTP 404 account not found)"
     evidence

--- a/scripts/e2e/test_verify_real_relay.py
+++ b/scripts/e2e/test_verify_real_relay.py
@@ -531,6 +531,34 @@ class TransportAndCliValidatorTests(unittest.TestCase):
         for private in (KEY, TEXT, VALUE, RECEIPT, "Preserve this reasoning"):
             self.assertNotIn(private, raw)
 
+    def test_failed_responses_report_bounded_terminal_signals_not_payloads(self):
+        def limited(client, protocol, body):
+            client.request_count += 1
+            doc = document(protocol, tool="tools" in body)
+            doc["choices"][0]["finish_reason"] = "length"
+            return 200, "application/json", encode(doc)
+        code, report, raw = self.run_cli(["--protocol", "chat"], limited)
+        self.assertEqual(code, 1)
+        self.assertEqual(report["maxTokensPerRequest"], 256)
+        self.assertEqual(report["results"][0]["observed"]["finishReasons"], ["length"])
+        self.assertTrue(report["results"][2]["observed"]["toolCallsPresent"])
+        for private in (KEY, TEXT, VALUE, "Preserve this reasoning"):
+            self.assertNotIn(private, raw)
+
+    def test_terminal_diagnostics_preserve_duplicates_and_redact_unknown_reasons(self):
+        frame = encode({"choices": [{"finish_reason": "stop"}]}).decode()
+        raw = ("data: " + frame + "\n\n") * 25 + "data: [DONE]\n\n"
+        signals = relay.observed_response_signals((200, "text/event-stream", raw.encode()))
+        self.assertEqual(signals["finishReasonCount"], 25)
+        self.assertEqual(signals["finishReasons"], ["stop"] * 20)
+        signals = relay.observed_response_signals((200, "application/json", encode({"stop_reason": KEY, "content": [{"type": "tool_use", "input": {"value": TEXT}}]})))
+        self.assertEqual(signals["finishReasons"], ["other"])
+        self.assertTrue(signals["toolCallsPresent"])
+        self.assertNotIn(KEY, json.dumps(signals))
+        self.assertNotIn(TEXT, json.dumps(signals))
+        empty = relay.observed_response_signals((200, "application/json", encode({"choices": [{"finish_reason": ""}]})))
+        self.assertEqual(empty["finishReasons"], ["empty_string"])
+
     def test_protocol_selection_uses_exactly_four_posts(self):
         for protocol in relay.PROTOCOLS:
             with self.subTest(protocol=protocol):

--- a/scripts/e2e/test_verify_real_relay.py
+++ b/scripts/e2e/test_verify_real_relay.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Offline validator tests. Fixtures/mocked curl are NOT live relay proof.
+
+Run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/e2e \
+     -p test_verify_real_relay.py -v
+No credentials, sockets, providers, services, or installed dependencies are used.
+"""
+
+import contextlib
+import copy
+import importlib.util
+import io
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SPEC = importlib.util.spec_from_file_location("verify_real_relay", Path(__file__).with_name("verify-real-relay.py"))
+relay = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(relay)
+
+MODEL = "fixture-response-model"
+VALUE = "echo-fixture"
+RECEIPT = "receipt-fixture"
+TEXT = "Private fixture text, not report output."
+KEY = "fixture-key-never-log"
+ENV = {"RELAY_BASE_URL": "http://127.0.0.1:12345", "RELAY_API_KEY": KEY,
+       "RELAY_MODEL": "fixture-request-model", "PATH": "/usr/bin:/bin"}
+
+
+def encode(value):
+    return json.dumps(value).encode("utf-8")
+
+
+def document(protocol, text=TEXT, tool=False):
+    if protocol == "chat":
+        message = {"role": "assistant", "content": None if tool else text}
+        if tool:
+            message.update(reasoning_content="Preserve this reasoning on replay.", tool_calls=[{
+                "id": "call_fixture", "type": "function", "function": {
+                    "name": "metapi_echo", "arguments": json.dumps({"value": VALUE})}}])
+        return {"id": "chat_fixture", "model": MODEL, "object": "chat.completion",
+                "choices": [{"index": 0, "message": message, "finish_reason": "tool_calls" if tool else "stop"}],
+                "usage": {"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17}}
+    if protocol == "responses":
+        output = [{"id": "msg_fixture", "type": "message", "role": "assistant", "status": "completed",
+                   "content": [{"type": "output_text", "text": text, "annotations": []}]}]
+        if tool:
+            output = [{"id": "rs_fixture", "type": "reasoning", "summary": []},
+                      {"id": "fc_fixture", "call_id": "call_fixture", "type": "function_call",
+                       "status": "completed", "name": "metapi_echo", "arguments": json.dumps({"value": VALUE})}]
+        return {"id": "resp_fixture", "model": MODEL, "object": "response", "status": "completed",
+                "error": None, "incomplete_details": None, "output": output,
+                "usage": {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17}}
+    content = [{"type": "text", "text": text}]
+    if tool:
+        content = [{"type": "tool_use", "name": "metapi_echo", "id": "toolu_fixture", "input": {"value": VALUE}}]
+    return {"id": "msg_fixture", "model": MODEL, "type": "message", "role": "assistant",
+            "content": content, "stop_reason": "tool_use" if tool else "end_turn", "stop_sequence": None,
+            "usage": {"input_tokens": 12, "output_tokens": 5}}
+
+
+def call_item(protocol, doc):
+    if protocol == "chat":
+        return doc["choices"][0]["message"]["tool_calls"][0]
+    return doc["output"][-1] if protocol == "responses" else doc["content"][0]
+
+
+def stream_events(protocol):
+    doc = document(protocol)
+    if protocol == "chat":
+        def chunk(delta, finish=None):
+            return {"id": doc["id"], "model": MODEL, "object": "chat.completion.chunk",
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": finish}]}
+        return [("", chunk({"role": "assistant", "content": ""})),
+                ("", chunk({"content": TEXT})), ("", chunk({}, "stop")),
+                ("", {"id": doc["id"], "model": MODEL, "object": "chat.completion.chunk",
+                      "choices": [], "usage": doc["usage"]}), ("", "[DONE]")]
+    if protocol == "responses":
+        return [("response.created", {"type": "response.created", "response": {
+                    "id": doc["id"], "model": MODEL, "status": "in_progress"}}),
+                ("response.output_text.delta", {"type": "response.output_text.delta", "item_id": "msg_fixture",
+                    "output_index": 0, "content_index": 0, "delta": TEXT}),
+                ("response.output_text.done", {"type": "response.output_text.done", "item_id": "msg_fixture",
+                    "output_index": 0, "content_index": 0, "text": TEXT}),
+                ("response.completed", {"type": "response.completed", "response": doc})]
+    start = dict(doc, content=[], stop_reason=None, usage={"input_tokens": 12})
+    return [("message_start", {"type": "message_start", "message": start}),
+            ("content_block_start", {"type": "content_block_start", "index": 0,
+                                     "content_block": {"type": "text", "text": ""}}),
+            ("content_block_delta", {"type": "content_block_delta", "index": 0,
+                                     "delta": {"type": "text_delta", "text": TEXT}}),
+            ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            ("message_delta", {"type": "message_delta", "delta": {"stop_reason": "end_turn"},
+                               "usage": {"output_tokens": 5}}),
+            ("message_stop", {"type": "message_stop"})]
+
+
+def pack(events):
+    return "".join(("event: " + event + "\n" if event else "") + "data: "
+                   + (data if isinstance(data, str) else json.dumps(data)) + "\n\n"
+                   for event, data in events).encode("utf-8")
+
+
+class ValidatorTests(unittest.TestCase):
+    def test_all_normal_json_fixtures(self):
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                value = relay.validate_http(protocol, (200, "application/json; charset=utf-8", encode(document(protocol))))
+                self.assertEqual(value["_text"], TEXT)
+                self.assertEqual(value["model"], MODEL)
+                self.assertEqual(value["contentLength"], len(TEXT))
+                self.assertGreater(value["usage"].get("output_tokens", value["usage"].get("completion_tokens", 0)), 0)
+
+    def test_all_normal_sse_fixtures(self):
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                events = stream_events(protocol)
+                value = relay.validate_http(protocol, (200, "text/event-stream; charset=utf-8", pack(events)), stream=True)
+                self.assertEqual(value["_text"], TEXT)
+                self.assertEqual(value["eventCount"], len(events))
+                self.assertEqual(value["responseId"], document(protocol)["id"])
+                self.assertTrue(value["usage"])
+
+    def test_all_normal_tool_fixtures(self):
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                value = relay.validate_json(protocol, encode(document(protocol, tool=True)), tool=True, expected_value=VALUE)
+                self.assertEqual(value["_call"]["name"], "metapi_echo")
+                self.assertEqual(value["_call"]["arguments"], {"value": VALUE})
+
+    def test_damaged_json_and_non_objects(self):
+        for protocol in relay.PROTOCOLS:
+            for raw in (b'{"broken":', b'{} trailing', b'[]', b'null', b'"text"', b'\xff',
+                        b'{"x":NaN}', b'{"x":Infinity}', b'{"x":1,"x":2}'):
+                with self.subTest(protocol=protocol, raw=raw):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_json(protocol, raw)
+
+    def test_http_200_errors_never_pass_even_with_valid_content(self):
+        for protocol in relay.PROTOCOLS:
+            for error in ({"message": "not success"}, {}, "upstream failed"):
+                doc = document(protocol)
+                doc["error"] = error
+                with self.subTest(protocol=protocol, error=error):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_http(protocol, (200, "application/json", encode(doc)))
+
+    def test_non_200_and_wrong_mime_fail(self):
+        for protocol in relay.PROTOCOLS:
+            for status, mime in ((401, "application/json"), (500, "application/json"), (302, "application/json"),
+                                 (200, "text/html"), (200, "")):
+                with self.subTest(protocol=protocol, status=status, mime=mime):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_http(protocol, (status, mime, encode(document(protocol))))
+            with self.assertRaises(relay.CheckFailed):
+                relay.validate_http(protocol, (200, "application/json", pack(stream_events(protocol))), stream=True)
+
+    def test_truncated_or_abnormal_json_finish(self):
+        for protocol in relay.PROTOCOLS:
+            for reason in (None, "length", "max_tokens", "content_filter", "incomplete", "failed"):
+                doc = document(protocol)
+                if protocol == "chat":
+                    doc["choices"][0]["finish_reason"] = reason
+                else:
+                    doc["status" if protocol == "responses" else "stop_reason"] = reason
+                with self.subTest(protocol=protocol, reason=reason):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_json(protocol, encode(doc))
+        doc = document("responses")
+        doc["incomplete_details"] = {"reason": "max_output_tokens"}
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_json("responses", encode(doc))
+
+    def test_empty_or_reasoning_only_is_not_content(self):
+        for protocol in relay.PROTOCOLS:
+            for text in ("", "  \n", "\x00", "\ud800"):
+                with self.subTest(protocol=protocol, text=text):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_json(protocol, encode(document(protocol, text=text)))
+            events = stream_events(protocol)
+            raw = pack(events).replace(TEXT.encode(), b"")
+            with self.assertRaises(relay.CheckFailed):
+                relay.validate_sse(protocol, raw)
+        doc = document("responses")
+        doc["output"] = [{"type": "reasoning", "summary": [{"type": "summary_text", "text": TEXT}]}]
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_json("responses", encode(doc))
+
+    def test_bad_usage_fails_instead_of_hiding_read_error(self):
+        for protocol in relay.PROTOCOLS:
+            for usage in ([], "unknown", {"output_tokens": -1}, {"input_tokens": True},
+                          {"output_tokens_details": "not an object"}):
+                doc = document(protocol)
+                doc["usage"] = usage
+                with self.subTest(protocol=protocol, usage=usage):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_json(protocol, encode(doc))
+        self.assertEqual(relay.usage_summary(None), {})
+        self.assertNotIn("payload", relay.usage_summary({"input_tokens": 1, "payload": TEXT}))
+
+    def test_missing_terminal_or_terminal_frame_is_failure(self):
+        for protocol in relay.PROTOCOLS:
+            raw = pack(stream_events(protocol))
+            for broken in (pack(stream_events(protocol)[:-1]), raw.rstrip(b"\n"), raw[:-1]):
+                with self.subTest(protocol=protocol, tail=broken[-35:]):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_sse(protocol, broken)
+
+    def test_malformed_sse_never_accepts_a_valid_prefix(self):
+        for protocol in relay.PROTOCOLS:
+            for tail in (b'data: {oops}\n\n', b'data: {"broken":', b'not-sse\n\n', b'\xff\n\n'):
+                with self.subTest(protocol=protocol, tail=tail):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_sse(protocol, pack(stream_events(protocol)) + tail)
+            with self.assertRaises(relay.CheckFailed):
+                relay.validate_sse(protocol, b': heartbeat\n\n')
+
+    def test_http_200_sse_error_before_or_after_terminal_fails(self):
+        for protocol in relay.PROTOCOLS:
+            events = stream_events(protocol)
+            error = ("error", {"type": "error", "error": {"message": "private failure detail"}})
+            for damaged in ([error] + events, events + [error], events[:-1] + [error]):
+                with self.subTest(protocol=protocol, length=len(damaged)):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_http(protocol, (200, "text/event-stream", pack(damaged)), stream=True)
+
+    def test_each_stream_abnormal_finish_fails(self):
+        for protocol in relay.PROTOCOLS:
+            events = stream_events(protocol)
+            if protocol == "chat":
+                events[2][1]["choices"][0]["finish_reason"] = "length"
+            elif protocol == "responses":
+                events[-1][1]["response"]["status"] = "incomplete"
+            else:
+                events[-2][1]["delta"]["stop_reason"] = "max_tokens"
+            with self.subTest(protocol=protocol):
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse(protocol, pack(events))
+
+    def test_chat_needs_finish_reason_and_done(self):
+        events = stream_events("chat")
+        del events[2]
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("chat", pack(events))
+        events = stream_events("chat")
+        events[1][1]["id"] = "wrong_response_id"
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("chat", pack(events))
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("chat", pack(stream_events("chat") + [("", "[DONE]")]))
+
+    def test_responses_completion_snapshot_must_match_stream(self):
+        for field, value in (("id", "wrong_response"), ("model", "wrong_stream_model")):
+            events = stream_events("responses")
+            events[-1][1]["response"][field] = value
+            with self.assertRaises(relay.CheckFailed):
+                relay.validate_sse("responses", pack(events))
+        for field, value in (("item_id", "wrong_item"), ("output_index", 3), ("content_index", 2)):
+            events = stream_events("responses")
+            events[1][1][field] = value
+            with self.assertRaises(relay.CheckFailed):
+                relay.validate_sse("responses", pack(events))
+        events = stream_events("responses")
+        events[-1][1]["response"]["output"][0]["content"][0]["text"] = "different text"
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("responses", pack(events))
+        self.assertTrue(relay.validate_sse("responses", pack(stream_events("responses") + [("", "[DONE]")])))
+
+    def test_responses_failed_or_incomplete_event_and_type_mismatch(self):
+        for kind in ("response.failed", "response.incomplete"):
+            events = stream_events("responses")[:-1] + [(kind, {"type": kind, "response": document("responses")})]
+            with self.assertRaises(relay.CheckFailed):
+                relay.validate_sse("responses", pack(events))
+        events = stream_events("responses")
+        events[1] = ("response.completed", events[1][1])
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("responses", pack(events))
+
+    def test_anthropic_requires_full_block_and_message_lifecycle(self):
+        for missing_index in (0, 1, 3, 4, 5):
+            events = stream_events("messages")
+            del events[missing_index]
+            with self.subTest(missing_index=missing_index):
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse("messages", pack(events))
+        events = stream_events("messages")
+        events[2][1]["index"] = 99
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("messages", pack(events))
+
+    def test_sse_crlf_comments_and_multiline_json(self):
+        for protocol in relay.PROTOCOLS:
+            raw = b': heartbeat\n\n' + pack(stream_events(protocol))
+            raw = raw.replace(b'"model": ', b'"model":\ndata: ', 1).replace(b'\n', b'\r\n')
+            with self.subTest(protocol=protocol):
+                self.assertTrue(relay.validate_sse(protocol, raw))
+
+    def test_missing_toolcall_is_failure(self):
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_json(protocol, encode(document(protocol)), tool=True, expected_value=VALUE)
+
+    def test_wrong_tool_name_and_builtin_tools_fail(self):
+        for protocol in relay.PROTOCOLS:
+            for name in ("shell", "web_search", "not_metapi_echo", None):
+                doc = document(protocol, tool=True)
+                item = call_item(protocol, doc)
+                (item["function"] if protocol == "chat" else item)["name"] = name
+                with self.subTest(protocol=protocol, name=name):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_json(protocol, encode(doc), tool=True, expected_value=VALUE)
+
+    def test_missing_or_invalid_tool_ids_fail(self):
+        for protocol in relay.PROTOCOLS:
+            fields = ("id", "call_id") if protocol == "responses" else ("id",)
+            for field in fields:
+                for bad_id in (None, "", "has spaces", "line\nbreak", [], 42):
+                    doc = document(protocol, tool=True)
+                    call_item(protocol, doc)[field] = bad_id
+                    with self.subTest(protocol=protocol, field=field, bad_id=bad_id):
+                        with self.assertRaises(relay.CheckFailed):
+                            relay.validate_json(protocol, encode(doc), tool=True, expected_value=VALUE)
+
+    def test_unparseable_wrong_and_ambiguous_tool_args_fail(self):
+        for protocol in relay.PROTOCOLS:
+            invalid = [None, [], {}, {"value": 42}, {"value": "wrong"}, {"value": VALUE, "extra": "no"}]
+            for args in invalid:
+                doc = document(protocol, tool=True)
+                item = call_item(protocol, doc)
+                if protocol == "chat":
+                    item["function"]["arguments"] = json.dumps(args)
+                elif protocol == "responses":
+                    item["arguments"] = json.dumps(args)
+                else:
+                    item["input"] = args
+                with self.subTest(protocol=protocol, args=args):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_json(protocol, encode(doc), tool=True, expected_value=VALUE)
+            if protocol != "messages":
+                for raw in ('{"value":', '{"value":"wrong","value":"echo-fixture"}', 'NaN'):
+                    doc = document(protocol, tool=True)
+                    item = call_item(protocol, doc)
+                    (item["function"] if protocol == "chat" else item)["arguments"] = raw
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_json(protocol, encode(doc), tool=True, expected_value=VALUE)
+
+    def test_multiple_calls_and_tool_in_text_scenario_fail(self):
+        for protocol in relay.PROTOCOLS:
+            doc = document(protocol, tool=True)
+            with self.assertRaises(relay.CheckFailed):
+                relay.validate_json(protocol, encode(doc))
+            if protocol == "chat":
+                doc["choices"][0]["message"]["tool_calls"] *= 2
+            elif protocol == "responses":
+                doc["output"].append(copy.deepcopy(doc["output"][-1]))
+            else:
+                doc["content"] *= 2
+            with self.assertRaises(relay.CheckFailed):
+                relay.validate_json(protocol, encode(doc), tool=True, expected_value=VALUE)
+
+    def test_followup_preserves_call_ids_reasoning_and_exact_echo_result(self):
+        for protocol in relay.PROTOCOLS:
+            original = relay.request_body(protocol, "requested", 256, tool_value=VALUE)
+            before = copy.deepcopy(original)
+            doc = document(protocol, tool=True)
+            validated = relay.validate_json(protocol, encode(doc), tool=True, expected_value=VALUE)
+            followup = relay.followup_body(protocol, original, validated, RECEIPT)
+            with self.subTest(protocol=protocol):
+                self.assertEqual(original, before)
+                if protocol == "chat":
+                    result = followup["messages"][-1]
+                    self.assertEqual(result["tool_call_id"], "call_fixture")
+                    self.assertEqual(followup["messages"][-2], doc["choices"][0]["message"])
+                    raw = result["content"]
+                elif protocol == "responses":
+                    self.assertNotIn("previous_response_id", followup)
+                    self.assertFalse(followup["store"])
+                    self.assertEqual(followup["input"][-1]["call_id"], "call_fixture")
+                    self.assertNotEqual(followup["input"][-1]["call_id"], "fc_fixture")
+                    self.assertEqual(followup["input"][1:-1], doc["output"])
+                    raw = followup["input"][-1]["output"]
+                else:
+                    self.assertEqual(followup["messages"][-2]["content"], doc["content"])
+                    result = followup["messages"][-1]["content"][0]
+                    self.assertEqual(result["tool_use_id"], "toolu_fixture")
+                    raw = result["content"]
+                self.assertEqual(json.loads(raw), {"value": VALUE, "receipt": RECEIPT})
+                self.assertEqual(followup["tool_choice"], {"type": "none"} if protocol == "messages" else "none")
+                self.assertEqual(len(followup["tools"]), 1)
+
+
+    def test_responses_multiple_text_parts(self):
+        doc = document("responses", text="First ")
+        doc["output"][0]["content"].append({"type": "output_text", "text": "second."})
+        events = stream_events("responses")[:1]
+        for index, text in enumerate(("First ", "second.")):
+            base = {"item_id": "msg_fixture", "output_index": 0, "content_index": index}
+            events += [("response.output_text.delta", dict(base, type="response.output_text.delta", delta=text)),
+                       ("response.output_text.done", dict(base, type="response.output_text.done", text=text))]
+        events.append(("response.completed", {"type": "response.completed", "response": doc}))
+        self.assertEqual(relay.validate_sse("responses", pack(events))["_text"], "First second.")
+
+    def test_reasoning_streams_can_precede_text_but_do_not_count_as_content(self):
+        events = stream_events("chat")
+        reasoning = copy.deepcopy(events[1][1])
+        reasoning["choices"][0]["delta"] = {"reasoning_content": "not visible text"}
+        events.insert(1, ("", reasoning))
+        self.assertEqual(relay.validate_sse("chat", pack(events))["contentLength"], len(TEXT))
+        events = stream_events("responses")
+        events.insert(1, ("response.reasoning_summary_text.delta", {
+            "type": "response.reasoning_summary_text.delta", "delta": "not visible text"}))
+        for _, obj in events:
+            if "output_index" in obj:
+                obj["output_index"] = 1
+        events[-1][1]["response"]["output"].insert(0, {"type": "reasoning", "id": "rs_fixture", "summary": []})
+        self.assertEqual(relay.validate_sse("responses", pack(events))["contentLength"], len(TEXT))
+        events = stream_events("messages")
+        for _, obj in events:
+            if "index" in obj:
+                obj["index"] = 1
+        reasoning = [("content_block_start", {"type": "content_block_start", "index": 0,
+                                              "content_block": {"type": "thinking", "thinking": ""}}),
+                     ("content_block_delta", {"type": "content_block_delta", "index": 0,
+                                              "delta": {"type": "thinking_delta", "thinking": "not visible text"}}),
+                     ("content_block_delta", {"type": "content_block_delta", "index": 0,
+                                              "delta": {"type": "signature_delta", "signature": "fixture-signature"}}),
+                     ("content_block_stop", {"type": "content_block_stop", "index": 0})]
+        events[1:1] = reasoning
+        self.assertEqual(relay.validate_sse("messages", pack(events))["contentLength"], len(TEXT))
+
+    def test_body_and_sse_event_caps_fail_closed(self):
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                with mock.patch.object(relay, "MAX_BODY", 16):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_http(protocol, (200, "application/json", encode(document(protocol))))
+                with mock.patch.object(relay, "MAX_EVENTS", 1):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_sse(protocol, pack(stream_events(protocol)))
+
+
+class TransportAndCliValidatorTests(unittest.TestCase):
+    def client(self):
+        return relay.CurlClient("http://127.0.0.1:12345/v1", KEY, 10, dict(ENV))
+
+    def test_curl_auth_only_in_stdin_config_and_no_hidden_config_proxy_or_retry(self):
+        raw = encode(document("chat")) + relay.HTTP_MARKER + b'200\napplication/json'
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                with mock.patch.object(relay.subprocess, "run", return_value=subprocess.CompletedProcess([], 0, raw)) as run:
+                    self.client().post(protocol, relay.request_body(protocol, "requested", 256))
+                args, kwargs = run.call_args
+                argv = args[0]
+                self.assertEqual(argv[:4], ["curl", "-q", "--noproxy", "*"])
+                self.assertEqual(argv[-2:], ["--config", "-"])
+                self.assertEqual(argv[argv.index("--retry") + 1], "0")
+                self.assertNotIn(KEY, repr(argv))
+                self.assertNotIn("RELAY_API_KEY", kwargs["env"])
+                self.assertIn(KEY, kwargs["input"].decode())
+                self.assertNotIn("--user-agent", argv)
+                self.assertNotIn("--location", argv)
+                self.assertIs(kwargs["stderr"], subprocess.DEVNULL)
+                self.assertLessEqual(kwargs["timeout"], 15)
+                if protocol == "messages":
+                    self.assertIn(b'anthropic-version: 2023-06-01', kwargs["input"])
+                    self.assertIn(b'x-api-key: ', kwargs["input"])
+                else:
+                    self.assertIn(b'Authorization: Bearer ', kwargs["input"])
+
+    def test_curl_quote_cannot_inject_a_config_line(self):
+        value = 'header "value"\\backslash\nnext\rline'
+        quoted = relay.curl_quote(value)
+        self.assertNotIn('\n', quoted)
+        self.assertNotIn('\r', quoted)
+        self.assertIn('\\"value\\"', quoted)
+        self.assertIn('\\\\backslash', quoted)
+
+    def test_transport_failure_timeout_and_bad_metadata_never_accept_valid_prefix(self):
+        body = encode(document("chat"))
+        cases = [subprocess.CompletedProcess([], 28, body + relay.HTTP_MARKER + b'200\napplication/json'),
+                 subprocess.CompletedProcess([], 0, body),
+                 subprocess.CompletedProcess([], 0, body + relay.HTTP_MARKER + b'bad\napplication/json'),
+                 subprocess.CompletedProcess([], 0, body + relay.HTTP_MARKER + b'200\n\xff'),
+                 subprocess.CompletedProcess([], 0, b'x' * (relay.MAX_BODY + 4097)),
+                 subprocess.TimeoutExpired(["curl"], 10, output=KEY.encode()), OSError(KEY)]
+        for outcome in cases:
+            with self.subTest(outcome=type(outcome).__name__):
+                kwargs = {"side_effect": outcome} if isinstance(outcome, Exception) else {"return_value": outcome}
+                with mock.patch.object(relay.subprocess, "run", **kwargs) as run:
+                    with self.assertRaises(relay.CheckFailed):
+                        self.client().post("chat", relay.request_body("chat", "requested", 256))
+                    self.assertEqual(run.call_count, 1)
+
+    def run_cli(self, argv, post, env=None):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with mock.patch.object(relay.CurlClient, "post", post), mock.patch.object(relay.secrets, "token_hex", return_value="fixture"):
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                code = relay.main(argv, dict(ENV if env is None else env))
+        self.assertEqual(stderr.getvalue(), "")
+        return code, json.loads(stdout.getvalue()), stdout.getvalue()
+
+    @staticmethod
+    def good_post(client, protocol, body):
+        client.request_count += 1
+        if body["stream"]:
+            return 200, "text/event-stream", pack(stream_events(protocol))
+        if body.get("tool_choice") in ("none", {"type": "none"}):
+            doc = document(protocol, text=RECEIPT)
+        else:
+            doc = document(protocol, tool="tools" in body)
+        return 200, "application/json", encode(doc)
+
+    def test_all_protocols_use_twelve_posts_and_do_not_require_model_name_equality(self):
+        code, report, raw = self.run_cli([], self.good_post)
+        self.assertEqual(code, 0)
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["requestCount"], 12)
+        self.assertEqual(report["requestLimit"], 12)
+        self.assertEqual(len(report["results"]), 9)
+        self.assertEqual(report["upstreamProvenance"], "not_verified")
+        for row in report["results"]:
+            self.assertEqual(row["requestedModel"], ENV["RELAY_MODEL"])
+            self.assertEqual(row["responseModel"], MODEL)
+            self.assertNotEqual(row["requestedModel"], row["responseModel"])
+            self.assertEqual(row["status"], "pass")
+            if row["scenario"] == "tool_roundtrip":
+                self.assertEqual(row["followup"]["status"], "pass")
+        for private in (KEY, TEXT, VALUE, RECEIPT, "Preserve this reasoning"):
+            self.assertNotIn(private, raw)
+
+    def test_protocol_selection_uses_exactly_four_posts(self):
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                code, report, _ = self.run_cli(["--protocol", protocol], self.good_post)
+                self.assertEqual(code, 0)
+                self.assertEqual(report["requestCount"], 4)
+                self.assertEqual({r["protocol"] for r in report["results"]}, {protocol})
+
+    def test_missing_tool_skips_followup_and_is_nonzero(self):
+        def post(client, protocol, body):
+            if "tools" in body:
+                client.request_count += 1
+                return 200, "application/json", encode(document(protocol))
+            return self.good_post(client, protocol, body)
+        code, report, _ = self.run_cli([], post)
+        self.assertEqual(code, 1)
+        self.assertEqual(report["requestCount"], 9)
+        for row in report["results"]:
+            if row["scenario"] == "tool_roundtrip":
+                self.assertEqual(row["status"], "fail")
+                self.assertEqual(row["followup"]["status"], "not_run")
+
+    def test_followup_requires_receipt_not_just_any_text(self):
+        def post(client, protocol, body):
+            if body.get("tool_choice") in ("none", {"type": "none"}):
+                client.request_count += 1
+                return 200, "application/json", encode(document(protocol))
+            return self.good_post(client, protocol, body)
+        code, report, _ = self.run_cli([], post)
+        self.assertEqual(code, 1)
+        self.assertEqual(report["requestCount"], 12)
+        for row in report["results"]:
+            if row["scenario"] == "tool_roundtrip":
+                self.assertEqual(row["followup"]["error"], "followup_did_not_use_tool_result")
+
+    def test_arbitrary_read_exception_fails_without_dumping_exception_data(self):
+        def post(client, protocol, body):
+            client.request_count += 1
+            raise RuntimeError(KEY + TEXT)
+        code, report, raw = self.run_cli(["--protocol", "chat"], post)
+        self.assertEqual(code, 1)
+        self.assertEqual(report["requestCount"], 3)
+        self.assertTrue(all(row["status"] == "fail" for row in report["results"]))
+        self.assertNotIn(KEY, raw)
+        self.assertNotIn(TEXT, raw)
+
+    def test_reflected_key_is_redacted_in_metadata(self):
+        def post(client, protocol, body):
+            status, mime, raw = self.good_post(client, protocol, body)
+            return status, mime, raw.replace(MODEL.encode(), KEY.encode())
+        code, report, raw = self.run_cli(["--protocol", "chat"], post)
+        self.assertEqual(code, 0)
+        self.assertNotIn(KEY, raw)
+        self.assertEqual(report["results"][0]["responseModel"], "[REDACTED]")
+
+    def test_invalid_environment_or_limits_make_no_requests(self):
+        cases = [([], {}), (["--timeout", "0"], ENV), (["--max-tokens", "999999"], ENV),
+                 (["--protocol", "wrong"], ENV), ([], dict(ENV, RELAY_BASE_URL="http://user:password@example.invalid")),
+                 ([], dict(ENV, RELAY_API_KEY="bad\nheader")), ([], dict(ENV, RELAY_BASE_URL="http://host:bad"))]
+        for argv, env in cases:
+            with self.subTest(argv=argv, keys=list(env)):
+                post = mock.Mock(side_effect=AssertionError("must not issue requests"))
+                code, report, _ = self.run_cli(argv, post, env)
+                self.assertEqual(code, 2)
+                self.assertEqual(report["status"], "fail")
+                post.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/e2e/verify-real-relay.py
+++ b/scripts/e2e/verify-real-relay.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Exercise three relay wire APIs; this command makes model POSTs, not fixtures.
+
+Required environment: RELAY_BASE_URL (origin or /v1 base), RELAY_API_KEY,
+RELAY_MODEL. No service discovery, provisioning, retries, or built-in tools.
+Requires system curl >= 8.4 for unknown-length transfer-size enforcement.
+Each protocol uses at most four POSTs: JSON, SSE, echo call, echo followup.
+Only metadata is printed. Bodies, prompts, tool payloads and auth stay in memory.
+A pass proves client-visible relay semantics, NOT upstream/provider provenance.
+The companion unittest file contains validator tests, never live relay proof.
+"""
+
+import argparse
+import json
+import os
+import secrets
+import subprocess
+import sys
+from urllib.parse import urlsplit
+
+PROTOCOLS = ("chat", "responses", "messages")
+PATHS = {"chat": "/chat/completions", "responses": "/responses", "messages": "/messages"}
+TOOL_NAME = "metapi_echo"
+MAX_BODY = 1024 * 1024
+MAX_EVENTS = 10000
+HTTP_MARKER = b"\n__METAPI_HTTP__"
+SUMMARY_FIELDS = ("model", "responseId", "usage", "eventCount", "contentLength")
+USAGE_FIELDS = (
+    "input_tokens", "output_tokens", "total_tokens", "prompt_tokens",
+    "completion_tokens", "cache_read_input_tokens", "cache_creation_input_tokens",
+)
+
+
+class CheckFailed(Exception):
+    """Only constant, non-payload error codes may leave the validator."""
+
+
+def require(condition, code):
+    if not condition:
+        raise CheckFailed(code)
+
+
+def identifier(value):
+    require(isinstance(value, str) and 0 < len(value) <= 256
+            and all(c.isprintable() and not c.isspace() for c in value), "invalid_identifier")
+    return value
+
+
+def integer(value):
+    return type(value) is int and value >= 0
+
+
+def has_text(value):
+    return any(c.isprintable() and not c.isspace() for c in value)
+
+
+def no_error(obj):
+    require(isinstance(obj, dict), "expected_object")
+    require(obj.get("error") is None and obj.get("incomplete_details") is None
+            and obj.get("type") not in ("error", "response.failed", "response.incomplete")
+            and obj.get("status") not in ("failed", "incomplete", "cancelled", "error"),
+            "error_or_incomplete")
+
+
+def json_value(raw):
+    def pairs(items):
+        result = {}
+        for key, value in items:
+            require(key not in result, "duplicate_json_key")
+            result[key] = value
+        return result
+
+    def constant(_):
+        raise CheckFailed("invalid_json_constant")
+
+    try:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw, object_pairs_hook=pairs, parse_constant=constant)
+    except (ValueError, UnicodeError, RecursionError):
+        raise CheckFailed("invalid_json") from None
+
+
+def usage_summary(value):
+    if value is None:
+        return {}
+    require(isinstance(value, dict), "invalid_usage")
+    result = {}
+    for key in USAGE_FIELDS:
+        if key in value:
+            require(integer(value[key]), "invalid_usage")
+            result[key] = value[key]
+    # Never copy arbitrary upstream metadata into the report.
+    for key in ("input_tokens_details", "output_tokens_details",
+                "prompt_tokens_details", "completion_tokens_details"):
+        if value.get(key) is not None:
+            require(isinstance(value[key], dict), "invalid_usage")
+            details = {}
+            for field in ("cached_tokens", "reasoning_tokens"):
+                if field in value[key]:
+                    require(integer(value[key][field]), "invalid_usage")
+                    details[field] = value[key][field]
+            if details:
+                result[key] = details
+    return result
+
+
+def checked_call(name, call_id, arguments, expected_value):
+    require(name == TOOL_NAME, "unexpected_tool_name")
+    identifier(call_id)
+    require(isinstance(arguments, dict) and set(arguments) == {"value"}
+            and isinstance(arguments["value"], str)
+            and arguments["value"] == expected_value, "invalid_tool_arguments")
+    return {"name": name, "id": call_id, "arguments": arguments}
+
+
+def validate_json(protocol, raw, *, tool=False, expected_value=None):
+    doc = json_value(raw)
+    no_error(doc)
+    model, response_id = identifier(doc.get("model")), identifier(doc.get("id"))
+    text, calls = "", []
+    if protocol == "chat":
+        require(doc.get("object") == "chat.completion", "invalid_response_type")
+        choices = doc.get("choices")
+        require(isinstance(choices, list) and len(choices) == 1, "invalid_choices")
+        choice = choices[0]
+        no_error(choice)
+        require(type(choice.get("index")) is int and choice["index"] == 0, "invalid_choice_index")
+        require(choice.get("finish_reason") == ("tool_calls" if tool else "stop"), "abnormal_finish")
+        message = choice.get("message")
+        no_error(message)
+        require(message.get("role") == "assistant", "invalid_role")
+        require(not message.get("refusal") and not message.get("function_call"), "refusal_or_legacy_tool")
+        text = message.get("content")
+        require(text is None or isinstance(text, str), "invalid_content")
+        text = text or ""
+        raw_calls = message.get("tool_calls", [])
+        require(isinstance(raw_calls, list), "invalid_tool_calls")
+        for item in raw_calls:
+            no_error(item)
+            require(item.get("type") == "function", "unexpected_tool_type")
+            function = item.get("function")
+            no_error(function)
+            require(isinstance(function.get("arguments"), str), "invalid_tool_arguments")
+            calls.append(checked_call(function.get("name"), item.get("id"),
+                                      json_value(function["arguments"]), expected_value))
+    elif protocol == "responses":
+        require(doc.get("object") == "response" and doc.get("status") == "completed", "abnormal_finish")
+        output = doc.get("output")
+        require(isinstance(output, list) and output, "missing_output")
+        for item in output:
+            no_error(item)
+            require(item.get("status", "completed") == "completed", "incomplete_output_item")
+            kind = item.get("type")
+            if kind == "message":
+                require(item.get("role") == "assistant", "invalid_role")
+                content = item.get("content")
+                require(isinstance(content, list), "invalid_content")
+                for part in content:
+                    no_error(part)
+                    require(part.get("type") == "output_text" and isinstance(part.get("text"), str),
+                            "refusal_or_invalid_content")
+                    text += part["text"]
+            elif kind == "function_call":
+                identifier(item.get("id"))  # item id is not the tool-result call_id.
+                require(isinstance(item.get("arguments"), str), "invalid_tool_arguments")
+                calls.append(checked_call(item.get("name"), item.get("call_id"),
+                                          json_value(item["arguments"]), expected_value))
+            else:
+                require(kind == "reasoning", "unexpected_output_type")
+    elif protocol == "messages":
+        require(doc.get("type") == "message" and doc.get("role") == "assistant", "invalid_response_type")
+        require(doc.get("stop_reason") == ("tool_use" if tool else "end_turn"), "abnormal_finish")
+        content = doc.get("content")
+        require(isinstance(content, list), "invalid_content")
+        for part in content:
+            no_error(part)
+            kind = part.get("type")
+            if kind == "text":
+                require(isinstance(part.get("text"), str), "invalid_content")
+                text += part["text"]
+            elif kind == "tool_use":
+                calls.append(checked_call(part.get("name"), part.get("id"), part.get("input"), expected_value))
+            else:
+                require(kind in ("thinking", "redacted_thinking"), "unexpected_content_type")
+    else:
+        raise CheckFailed("invalid_protocol")
+    if tool:
+        require(len(calls) == 1, "expected_one_tool_call")
+    else:
+        require(not calls and has_text(text), "missing_text_or_unexpected_tool")
+    return {"model": model, "responseId": response_id, "usage": usage_summary(doc.get("usage")),
+            "eventCount": 0, "contentLength": len(text), "_text": text,
+            "_document": doc, "_call": calls[0] if calls else None}
+
+
+def sse_events(raw):
+    try:
+        text = raw.decode("utf-8-sig") if isinstance(raw, bytes) else raw
+    except UnicodeError:
+        raise CheckFailed("invalid_sse_encoding") from None
+    require(isinstance(text, str), "invalid_sse")
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    events, data, event = [], [], ""
+    # splitlines() hides an unterminated frame; only a blank line dispatches SSE.
+    lines = text.split("\n")
+    for line in lines[:-1]:
+        if not line:
+            if data:
+                events.append((event, "\n".join(data)))
+                require(len(events) <= MAX_EVENTS, "too_many_sse_events")
+            else:
+                require(not event, "empty_sse_event")
+            data, event = [], ""
+        elif line.startswith(":"):
+            continue
+        else:
+            field, separator, value = line.partition(":")
+            require(bool(separator) and field in ("data", "event", "id", "retry"), "invalid_sse_field")
+            value = value[1:] if value.startswith(" ") else value
+            if field == "data":
+                data.append(value)
+            elif field == "event":
+                require(not event, "duplicate_sse_event_type")
+                event = value
+            elif field == "retry":
+                require(value.isascii() and value.isdigit(), "invalid_sse_retry")
+    require(not lines[-1] and not data and not event, "truncated_sse_frame")
+    require(bool(events), "empty_sse")
+    return events
+
+
+def validate_sse(protocol, raw):
+    events = sse_events(raw)
+    text, model, response_id, usage = "", None, None, {}
+    finished, done, started, stop_reason = False, False, False, None
+    blocks, closed = {}, set()
+    response_parts, part_ids, ended_parts = {}, {}, set()
+
+    def metadata(doc):
+        nonlocal model, response_id, usage
+        no_error(doc)
+        for key, old in (("model", model), ("id", response_id)):
+            if key in doc:
+                value = identifier(doc[key])
+                require(old is None or old == value, "stream_identity_changed")
+                if key == "model":
+                    model = value
+                else:
+                    response_id = value
+        usage.update(usage_summary(doc.get("usage")))
+
+    for event, data in events:
+        if data == "[DONE]":
+            require(protocol in ("chat", "responses") and finished and not done, "premature_or_duplicate_done")
+            done = True
+            continue
+        require(not done, "event_after_done")
+        obj = json_value(data)
+        no_error(obj)
+        require(event != "error", "stream_error")
+        if protocol == "chat":
+            require(event in ("", "message"), "invalid_sse_event_type")
+            require(obj.get("object") == "chat.completion.chunk", "invalid_chunk_type")
+            metadata(obj)
+            choices = obj.get("choices")
+            require(isinstance(choices, list), "invalid_choices")
+            if not choices:
+                require(obj.get("usage") is not None, "empty_chunk")
+                continue
+            require(len(choices) == 1 and not finished, "chunk_after_finish_or_multiple_choices")
+            choice = choices[0]
+            no_error(choice)
+            require(type(choice.get("index")) is int and choice["index"] == 0, "invalid_choice_index")
+            delta = choice.get("delta")
+            no_error(delta)
+            require(delta.get("role", "assistant") == "assistant", "invalid_role")
+            require(not delta.get("tool_calls") and not delta.get("function_call") and not delta.get("refusal"),
+                    "unexpected_tool_or_refusal")
+            content = delta.get("content")
+            require(content is None or isinstance(content, str), "invalid_content")
+            text += content or ""
+            reason = choice.get("finish_reason")
+            require(reason in (None, "stop"), "abnormal_finish")
+            finished = reason == "stop"
+        elif protocol == "responses":
+            require(not finished, "event_after_completion")
+            kind = obj.get("type")
+            require(isinstance(kind, str) and event in ("", kind), "sse_event_type_mismatch")
+            if kind in ("response.created", "response.in_progress"):
+                metadata(obj.get("response"))
+            elif kind in ("response.output_text.delta", "response.output_text.done"):
+                index = (obj.get("output_index"), obj.get("content_index"))
+                require(all(integer(i) for i in index), "invalid_output_index")
+                item_id = identifier(obj.get("item_id"))
+                require(part_ids.setdefault(index, item_id) == item_id, "stream_item_identity_changed")
+                require(index not in ended_parts, "text_after_part_done")
+                if kind.endswith(".delta"):
+                    require(isinstance(obj.get("delta"), str), "invalid_text_delta")
+                    response_parts[index] = response_parts.get(index, "") + obj["delta"]
+                else:
+                    require(index in response_parts and isinstance(obj.get("text"), str)
+                            and obj["text"] == response_parts[index], "stream_text_mismatch")
+                    ended_parts.add(index)
+                text = "".join(response_parts[i] for i in sorted(response_parts))
+            elif kind == "response.completed":
+                final = validate_json("responses", json.dumps(obj.get("response")))
+                metadata(final["_document"])
+                require(has_text(text) and text == final["_text"], "stream_text_mismatch")
+                output = final["_document"]["output"]
+                for (item_index, content_index), item_id in part_ids.items():
+                    require(item_index < len(output), "invalid_output_index")
+                    item = output[item_index]
+                    require(item.get("type") == "message" and item.get("id") == item_id
+                            and content_index < len(item["content"])
+                            and item["content"][content_index].get("text") == response_parts[(item_index, content_index)],
+                            "stream_item_identity_or_text_mismatch")
+                finished = True
+            elif kind in ("response.output_item.added", "response.output_item.done"):
+                item = obj.get("item")
+                no_error(item)
+                require(item.get("type") in ("message", "reasoning"), "unexpected_output_type")
+                if kind.endswith(".done"):
+                    require(item.get("status", "completed") == "completed", "incomplete_output_item")
+            elif kind in ("response.content_part.added", "response.content_part.done"):
+                part = obj.get("part")
+                no_error(part)
+                require(part.get("type") == "output_text", "unexpected_content_type")
+            else:
+                require(kind in ("response.reasoning_summary_part.added", "response.reasoning_summary_part.done",
+                                 "response.reasoning_summary_text.delta", "response.reasoning_summary_text.done",
+                                 "response.reasoning_text.delta", "response.reasoning_text.done"),
+                        "unexpected_sse_event")
+        elif protocol == "messages":
+            require(not finished, "event_after_completion")
+            kind = obj.get("type")
+            require(isinstance(kind, str) and event in ("", kind), "sse_event_type_mismatch")
+            if kind == "ping":
+                continue
+            if kind == "message_start":
+                require(not started, "duplicate_message_start")
+                message = obj.get("message")
+                metadata(message)
+                require(message.get("type") == "message" and message.get("role") == "assistant"
+                        and message.get("content") == [] and message.get("stop_reason") is None,
+                        "invalid_message_start")
+                started = True
+            else:
+                require(started, "missing_message_start")
+                if kind in ("content_block_start", "content_block_delta", "content_block_stop"):
+                    index = obj.get("index")
+                    require(integer(index) and stop_reason is None, "invalid_block_index_or_order")
+                    if kind == "content_block_start":
+                        require(index not in blocks, "duplicate_content_block")
+                        block = obj.get("content_block")
+                        no_error(block)
+                        require(block.get("type") in ("text", "thinking", "redacted_thinking"),
+                                "unexpected_content_type")
+                        initial = block.get("text", "")
+                        require(isinstance(initial, str), "invalid_content")
+                        blocks[index] = {"type": block["type"], "text": initial if block["type"] == "text" else ""}
+                    else:
+                        require(index in blocks and index not in closed, "unopened_or_closed_block")
+                        if kind == "content_block_stop":
+                            closed.add(index)
+                        else:
+                            delta = obj.get("delta")
+                            no_error(delta)
+                            if blocks[index]["type"] == "text":
+                                require(delta.get("type") == "text_delta" and isinstance(delta.get("text"), str),
+                                        "invalid_text_delta")
+                                blocks[index]["text"] += delta["text"]
+                            else:
+                                field = {"thinking_delta": "thinking", "signature_delta": "signature"}.get(delta.get("type"))
+                                require(field is not None and isinstance(delta.get(field), str), "invalid_thinking_delta")
+                elif kind == "message_delta":
+                    delta = obj.get("delta")
+                    no_error(delta)
+                    require(stop_reason is None and set(blocks) == closed and delta.get("stop_reason") == "end_turn",
+                            "abnormal_finish_or_unclosed_block")
+                    stop_reason = "end_turn"
+                    usage.update(usage_summary(obj.get("usage")))
+                elif kind == "message_stop":
+                    require(stop_reason == "end_turn" and set(blocks) == closed, "missing_stop_reason_or_unclosed_block")
+                    text = "".join(blocks[i]["text"] for i in sorted(blocks))
+                    finished = True
+                else:
+                    raise CheckFailed("unexpected_sse_event")
+        else:
+            raise CheckFailed("invalid_protocol")
+    require(finished and (protocol != "chat" or done), "missing_stream_termination")
+    require(has_text(text), "missing_stream_text")
+    return {"model": identifier(model), "responseId": identifier(response_id), "usage": usage,
+            "eventCount": len(events), "contentLength": len(text), "_text": text}
+
+
+def validate_http(protocol, reply, *, stream=False, tool=False, expected_value=None):
+    status, content_type, body = reply
+    require(status == 200, "http_error")
+    require(isinstance(body, bytes) and len(body) <= MAX_BODY, "invalid_or_oversized_body")
+    require(isinstance(content_type, str), "invalid_content_type")
+    mime = content_type.split(";", 1)[0].strip().lower()
+    if stream:
+        require(mime == "text/event-stream", "expected_sse_content_type")
+        return validate_sse(protocol, body)
+    require(mime == "application/json" or (mime.startswith("application/") and mime.endswith("+json")),
+            "expected_json_content_type")
+    return validate_json(protocol, body, tool=tool, expected_value=expected_value)
+
+
+def request_body(protocol, model, max_tokens, *, stream=False, tool_value=None):
+    prompt = "Reply with one short sentence confirming the relay works."
+    schema = {"type": "object", "properties": {"value": {"type": "string"}},
+              "required": ["value"], "additionalProperties": False}
+    function = {"name": TOOL_NAME, "description": "Echo a value and return a receipt; no external actions.",
+                "parameters": schema}
+    if tool_value is not None:
+        prompt = ("Call metapi_echo exactly once with value " + json.dumps(tool_value)
+                  + ". After its result, reply with the receipt from that result. Do not call any other tool.")
+    message = {"role": "user", "content": prompt}
+    body = {"model": model, "stream": stream}
+    if protocol == "responses":
+        body.update(input=[message], max_output_tokens=max_tokens, store=False)
+        if tool_value is not None:
+            body.update(tools=[dict(type="function", **function)],
+                        tool_choice={"type": "function", "name": TOOL_NAME}, parallel_tool_calls=False)
+    else:
+        body.update(messages=[message], max_tokens=max_tokens)
+        if protocol == "chat":
+            body["n"] = 1
+            if stream:
+                body["stream_options"] = {"include_usage": True}
+            if tool_value is not None:
+                body.update(tools=[{"type": "function", "function": function}],
+                            tool_choice={"type": "function", "function": {"name": TOOL_NAME}},
+                            parallel_tool_calls=False)
+        elif protocol == "messages":
+            if tool_value is not None:
+                body.update(tools=[{"name": TOOL_NAME, "description": function["description"], "input_schema": schema}],
+                            tool_choice={"type": "tool", "name": TOOL_NAME, "disable_parallel_tool_use": True})
+        else:
+            raise CheckFailed("invalid_protocol")
+    return body
+
+
+def followup_body(protocol, original, validated, receipt):
+    call, doc = validated["_call"], validated["_document"]
+    output = json.dumps({"value": call["arguments"]["value"], "receipt": receipt})
+    body = dict(original)
+    if protocol == "chat":
+        # Keep reasoning_content when supplied; thinking-capable models need it on replay.
+        body["messages"] = original["messages"] + [doc["choices"][0]["message"],
+                                                    {"role": "tool", "tool_call_id": call["id"], "content": output}]
+        body["tool_choice"] = "none"
+    elif protocol == "responses":
+        # Stateless replay, including reasoning items, avoids previous_response_id storage dependencies.
+        body["input"] = original["input"] + doc["output"] + [
+            {"type": "function_call_output", "call_id": call["id"], "output": output}]
+        body["tool_choice"] = "none"
+    else:
+        body["messages"] = original["messages"] + [
+            {"role": "assistant", "content": doc["content"]},
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": call["id"], "content": output}]}]
+        body["tool_choice"] = {"type": "none"}
+    return body
+
+
+def curl_quote(value):
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r") + '"'
+
+
+class CurlClient:
+    def __init__(self, base_url, key, timeout, environment):
+        self.base_url, self.key, self.timeout = base_url, key, timeout
+        self.environment = {k: v for k, v in environment.items() if k != "RELAY_API_KEY"}
+        self.request_count = 0
+
+    def post(self, protocol, body):
+        headers = ["Content-Type: application/json", "Accept: " + ("text/event-stream" if body["stream"] else "application/json")]
+        if protocol == "messages":
+            headers += ["x-api-key: " + self.key, "anthropic-version: 2023-06-01"]
+        else:
+            headers += ["Authorization: Bearer " + self.key]
+        config = "url = " + curl_quote(self.base_url + PATHS[protocol]) + "\n"
+        config += "".join("header = " + curl_quote(h) + "\n" for h in headers)
+        config += "data-binary = " + curl_quote(json.dumps(body, ensure_ascii=True)) + "\n"
+        # -q MUST be curl's first argument: ignore ~/.curlrc before parsing anything.
+        # No redirects, retries, proxy, custom UA, shell, auth argv, or body/header files.
+        command = ["curl", "-q", "--noproxy", "*", "--silent", "--no-buffer",
+                   "--proto", "=http,https", "--globoff", "--retry", "0", "--max-redirs", "0",
+                   "--connect-timeout", str(min(10, self.timeout)), "--max-time", str(self.timeout),
+                   "--max-filesize", str(MAX_BODY), "--request", "POST",
+                   "--write-out", "\n__METAPI_HTTP__%{http_code}\n%{content_type}", "--config", "-"]
+        self.request_count += 1
+        try:
+            completed = subprocess.run(command, input=config.encode("utf-8"), stdout=subprocess.PIPE,
+                                       stderr=subprocess.DEVNULL, timeout=self.timeout + 5, env=self.environment,
+                                       check=False)
+        except subprocess.TimeoutExpired:
+            raise CheckFailed("transport_timeout") from None
+        except OSError:
+            raise CheckFailed("transport_io_error") from None
+        require(completed.returncode == 0, "curl_exit_" + str(completed.returncode))
+        require(isinstance(completed.stdout, bytes) and len(completed.stdout) <= MAX_BODY + 4096,
+                "invalid_or_oversized_body")
+        raw, marker, trailer = completed.stdout.rpartition(HTTP_MARKER)
+        require(bool(marker), "missing_http_metadata")
+        fields = trailer.split(b"\n")
+        require(len(fields) == 2 and len(fields[0]) == 3 and fields[0].isdigit(), "invalid_http_metadata")
+        try:
+            content_type = fields[1].decode("ascii")
+        except UnicodeError:
+            raise CheckFailed("invalid_http_metadata") from None
+        return int(fields[0]), content_type, raw
+
+
+def empty_result(protocol, scenario):
+    return {"protocol": protocol, "scenario": scenario, "status": "fail", "httpStatus": None,
+            "model": None, "requestedModel": None, "responseModel": None, "responseId": None,
+            "usage": {}, "eventCount": 0, "contentLength": 0,
+            "toolName": None, "followup": None}
+
+
+def error_code(error):
+    # Never format arbitrary exception text: curl/parser/upstream data may include secrets.
+    return str(error) if isinstance(error, CheckFailed) else "unexpected_read_or_validation_error"
+
+
+def run_protocol(client, protocol, model, max_tokens):
+    results = []
+    for scenario in ("nonstream", "stream", "tool_roundtrip"):
+        row = empty_result(protocol, scenario)
+        row["requestedModel"] = model
+        results.append(row)
+        tool_value = "echo-" + secrets.token_hex(8) if scenario == "tool_roundtrip" else None
+        if tool_value is not None:
+            row["followup"] = {"status": "not_run"}
+        try:
+            body = request_body(protocol, model, max_tokens, stream=scenario == "stream", tool_value=tool_value)
+            reply = client.post(protocol, body)
+            row["httpStatus"] = reply[0]
+            validated = validate_http(protocol, reply, stream=scenario == "stream", tool=tool_value is not None,
+                                      expected_value=tool_value)
+            row.update({key: validated[key] for key in SUMMARY_FIELDS})
+            row["responseModel"] = validated["model"]
+            if tool_value is not None:
+                row["toolName"] = validated["_call"]["name"]
+                followup = empty_result(protocol, "tool_followup")
+                followup["requestedModel"] = model
+                followup.pop("followup")
+                row["followup"] = followup
+                # This receipt exists only in the tool result, not in the first prompt.
+                receipt = "receipt-" + secrets.token_hex(12)
+                try:
+                    reply = client.post(protocol, followup_body(protocol, body, validated, receipt))
+                    followup["httpStatus"] = reply[0]
+                    final = validate_http(protocol, reply)
+                    followup.update({key: final[key] for key in SUMMARY_FIELDS})
+                    followup["responseModel"] = final["model"]
+                    require(receipt in final["_text"], "followup_did_not_use_tool_result")
+                    followup["status"] = "pass"
+                except Exception as error:
+                    followup["error"] = error_code(error)
+                    raise CheckFailed("tool_followup_failed") from None
+            row["status"] = "pass"
+        except Exception as error:
+            row["error"] = error_code(error)
+    return results
+
+
+class Parser(argparse.ArgumentParser):
+    def error(self, message):
+        raise CheckFailed("invalid_arguments")
+
+
+def main(argv=None, environment=None):
+    environment = os.environ if environment is None else environment
+    key = environment.get("RELAY_API_KEY", "")
+    report = {"kind": "relay_acceptance", "evidence": "http_observations",
+              "upstreamProvenance": "not_verified", "status": "fail", "requestCount": 0, "results": []}
+    exit_code = 2
+    try:
+        parser = Parser(description=__doc__)
+        parser.add_argument("--protocol", choices=("all",) + PROTOCOLS, default="all")
+        parser.add_argument("--timeout", type=int, default=120, metavar="SECONDS", help="per POST, 5..300 (default: 120)")
+        parser.add_argument("--max-tokens", type=int, default=256, metavar="TOKENS", help="per POST, 64..4096 (default: 256)")
+        args = parser.parse_args(argv)
+        require(5 <= args.timeout <= 300 and 64 <= args.max_tokens <= 4096, "invalid_limits")
+        base, model = environment.get("RELAY_BASE_URL", ""), environment.get("RELAY_MODEL", "")
+        require(bool(base and key and model), "missing_relay_environment")
+        require(len(key) <= 4096 and all(33 <= ord(c) <= 126 for c in key), "invalid_api_key_format")
+        identifier(model)
+        require(all(c.isprintable() and not c.isspace() for c in base), "invalid_base_url")
+        url = urlsplit(base)
+        require(url.scheme in ("http", "https") and bool(url.hostname) and not url.username
+                and not url.password and not url.query and not url.fragment, "invalid_base_url")
+        _ = url.port  # Invalid ports must fail before any model request.
+        base = base.rstrip("/")
+        if not base.endswith("/v1"):
+            base += "/v1"
+        selected = PROTOCOLS if args.protocol == "all" else (args.protocol,)
+        report["requestLimit"] = len(selected) * 4
+        client = CurlClient(base, key, args.timeout, environment)
+        for protocol in selected:
+            report["results"].extend(run_protocol(client, protocol, model, args.max_tokens))
+        report["requestCount"] = client.request_count
+        passed = bool(report["results"]) and all(row["status"] == "pass" for row in report["results"])
+        report["status"] = "pass" if passed else "fail"
+        exit_code = 0 if passed else 1
+    except Exception as error:
+        report["error"] = error_code(error)
+    # Upstream-controlled identifiers must not echo even a deliberately reflected key.
+    def redact(value):
+        if isinstance(value, dict):
+            return {k: redact(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [redact(v) for v in value]
+        return value.replace(key, "[REDACTED]") if key and isinstance(value, str) else value
+
+    print(json.dumps(redact(report), ensure_ascii=True, separators=(",", ":")))
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/e2e/verify-real-relay.py
+++ b/scripts/e2e/verify-real-relay.py
@@ -526,6 +526,54 @@ def error_code(error):
     return str(error) if isinstance(error, CheckFailed) else "unexpected_read_or_validation_error"
 
 
+def observed_response_signals(reply):
+    """Bounded, allowlisted diagnostics, never response text or tool arguments."""
+    if not isinstance(reply, (tuple, list)) or len(reply) != 3:
+        return {}
+    try:
+        documents = [json_value(reply[2])]
+    except CheckFailed:
+        try:
+            documents = [json_value(data) for _, data in sse_events(reply[2]) if data != "[DONE]"]
+        except CheckFailed:
+            return {}
+    allowed = {"stop", "length", "tool_calls", "function_call", "content_filter",
+               "end_turn", "tool_use", "max_tokens", "max_output_tokens", "stop_sequence",
+               "pause_turn", "refusal", "model_context_window_exceeded"}
+    reasons, tools = [], False
+
+    def note(value):
+        if value is not None:
+            reasons.append("empty_string" if value == "" else value if isinstance(value, str) and value in allowed else "other")
+
+    for doc in documents:
+        if not isinstance(doc, dict):
+            continue
+        note(doc.get("stop_reason"))
+        delta = doc.get("delta")
+        if isinstance(delta, dict):
+            note(delta.get("stop_reason"))
+        choices = doc.get("choices")
+        for choice in choices if isinstance(choices, list) else []:
+            if not isinstance(choice, dict):
+                continue
+            note(choice.get("finish_reason"))
+            for message in (choice.get("message"), choice.get("delta")):
+                if isinstance(message, dict) and isinstance(message.get("tool_calls"), list):
+                    tools = tools or bool(message["tool_calls"])
+        response = doc.get("response", doc)
+        if not isinstance(response, dict):
+            continue
+        details = response.get("incomplete_details")
+        if isinstance(details, dict):
+            note(details.get("reason"))
+        for name in ("content", "output"):
+            parts = response.get(name)
+            if isinstance(parts, list):
+                tools = tools or any(isinstance(part, dict) and part.get("type") in ("tool_use", "function_call") for part in parts)
+    return {"finishReasons": reasons[:20], "finishReasonCount": len(reasons), "toolCallsPresent": tools}
+
+
 def run_protocol(client, protocol, model, max_tokens):
     results = []
     for scenario in ("nonstream", "stream", "tool_roundtrip"):
@@ -535,6 +583,7 @@ def run_protocol(client, protocol, model, max_tokens):
         tool_value = "echo-" + secrets.token_hex(8) if scenario == "tool_roundtrip" else None
         if tool_value is not None:
             row["followup"] = {"status": "not_run"}
+        reply = None
         try:
             body = request_body(protocol, model, max_tokens, stream=scenario == "stream", tool_value=tool_value)
             reply = client.post(protocol, body)
@@ -551,20 +600,23 @@ def run_protocol(client, protocol, model, max_tokens):
                 row["followup"] = followup
                 # This receipt exists only in the tool result, not in the first prompt.
                 receipt = "receipt-" + secrets.token_hex(12)
+                followup_reply = None
                 try:
-                    reply = client.post(protocol, followup_body(protocol, body, validated, receipt))
-                    followup["httpStatus"] = reply[0]
-                    final = validate_http(protocol, reply)
+                    followup_reply = client.post(protocol, followup_body(protocol, body, validated, receipt))
+                    followup["httpStatus"] = followup_reply[0]
+                    final = validate_http(protocol, followup_reply)
                     followup.update({key: final[key] for key in SUMMARY_FIELDS})
                     followup["responseModel"] = final["model"]
                     require(receipt in final["_text"], "followup_did_not_use_tool_result")
                     followup["status"] = "pass"
                 except Exception as error:
                     followup["error"] = error_code(error)
+                    followup["observed"] = observed_response_signals(followup_reply)
                     raise CheckFailed("tool_followup_failed") from None
             row["status"] = "pass"
         except Exception as error:
             row["error"] = error_code(error)
+            row["observed"] = observed_response_signals(reply)
     return results
 
 
@@ -586,6 +638,8 @@ def main(argv=None, environment=None):
         parser.add_argument("--max-tokens", type=int, default=256, metavar="TOKENS", help="per POST, 64..4096 (default: 256)")
         args = parser.parse_args(argv)
         require(5 <= args.timeout <= 300 and 64 <= args.max_tokens <= 4096, "invalid_limits")
+        report["maxTokensPerRequest"] = args.max_tokens
+        report["perRequestTimeoutSeconds"] = args.timeout
         base, model = environment.get("RELAY_BASE_URL", ""), environment.get("RELAY_MODEL", "")
         require(bool(base and key and model), "missing_relay_environment")
         require(len(key) <= 4096 and all(33 <= ord(c) <= 126 for c in key), "invalid_api_key_format")

--- a/scripts/e2e/verify-token-import.sh
+++ b/scripts/e2e/verify-token-import.sh
@@ -40,7 +40,9 @@
 #   SKIP_MODEL_FETCH   "true" skips the upstream model verify on account
 #                      create (needed when the upstream exposes no models,
 #                      e.g. a fresh CLIProxyAPI instance with no auth files)
-#   PROXY_MODEL        fallback route model   (default gpt-3.5-turbo)
+#   PROXY_MODEL        model to require       (optional; otherwise first discovered)
+#   E2E_SKIP_RELAY     1 skips relay coverage  (default 0; management steps still run)
+#   EXPECTED_COMPLETION_CONTENT  exact content marker to require (optional)
 #   SITE_NAME          site name to reuse     (default e2e-token-import)
 #   TOKEN_NAME         downstream key name    (default e2e-token-import-token)
 #
@@ -57,7 +59,9 @@ PLATFORM="${PLATFORM:-sub2api}"
 CREDENTIAL_MODE="${CREDENTIAL_MODE:-session}"
 ACCOUNT_USERNAME="${ACCOUNT_USERNAME:-e2e-token-import}"
 SKIP_MODEL_FETCH="${SKIP_MODEL_FETCH:-false}"
-PROXY_MODEL="${PROXY_MODEL:-gpt-3.5-turbo}"
+PROXY_MODEL="${PROXY_MODEL:-}"
+E2E_SKIP_RELAY="${E2E_SKIP_RELAY:-0}"
+EXPECTED_COMPLETION_CONTENT="${EXPECTED_COMPLETION_CONTENT:-}"
 SITE_NAME="${SITE_NAME:-e2e-token-import}"
 TOKEN_NAME="${TOKEN_NAME:-e2e-token-import-token}"
 TOKEN_IMPORT_KEY="${TOKEN_IMPORT_KEY:-sk-e2e-token}"
@@ -69,6 +73,11 @@ SKIP_COUNT=0
 FAILED_NAMES=""
 
 # --- fatal setup checks ---
+
+if [ "$E2E_SKIP_RELAY" != "0" ] && [ "$E2E_SKIP_RELAY" != "1" ]; then
+  echo "FATAL: E2E_SKIP_RELAY must be 0 or 1" >&2
+  exit 2
+fi
 
 command -v curl >/dev/null 2>&1 || { echo "FATAL: curl is required but not found on PATH" >&2; exit 2; }
 command -v python3 >/dev/null 2>&1 || { echo "FATAL: python3 is required for JSON parsing but not found on PATH" >&2; exit 2; }
@@ -100,7 +109,8 @@ RESP_BODY="$WORKDIR/resp_body.txt"
 # response body is saved to $RESP_BODY.
 request() {
   local method="$1" url="$2" body="${3:-}" token="${4:-}"
-  local args=(-sS -m 120 -X "$method" "$url" -o "$RESP_BODY" -w "%{http_code}" -H "Content-Type: application/json")
+  : > "$RESP_BODY" || return 1
+  local args=(-q --noproxy "*" -sS -m 120 -X "$method" "$url" -o "$RESP_BODY" -w "%{http_code}" -H "Content-Type: application/json")
   if [ -n "$token" ]; then
     args+=(-H "Authorization: Bearer $token")
   fi
@@ -183,18 +193,84 @@ sys.exit(4)
 ' "$1" "$2" "$3" "$4" < "$RESP_BODY"
 }
 
-# json_has_error_key — 0 when $RESP_BODY is valid JSON containing an "error" key.
-json_has_error_key() {
+# json_select_model — require real account discovery; never invent a fallback.
+json_select_model() {
   python3 -c '
 import json, sys
 try:
-    data = json.load(sys.stdin)
+    payload = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-if isinstance(data, dict) and "error" in data:
-    sys.exit(0)
+if not isinstance(payload, dict) or "error" in payload:
+    sys.exit(1)
+models, count = payload.get("models"), payload.get("totalCount")
+if not isinstance(models, list) or not models or type(count) is not int or count <= 0:
+    sys.exit(1)
+names = []
+for item in models:
+    name = item.get("name") if isinstance(item, dict) else None
+    if not isinstance(name, str) or not name.strip():
+        sys.exit(1)
+    names.append(name)
+selected = sys.argv[1] or names[0]
+if selected not in names:
+    sys.exit(1)
+print(selected)
+' "$PROXY_MODEL" < "$RESP_BODY"
+}
+
+# The proxy must expose the same selected model, not merely some other model.
+json_models_data_contains() {
+  python3 -c '
+import json, sys
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+if not isinstance(payload, dict) or "error" in payload:
+    sys.exit(1)
+data = payload.get("data")
+if not isinstance(data, list) or not data:
+    sys.exit(1)
+for item in data:
+    name = item.get("id") if isinstance(item, dict) else item
+    if isinstance(name, str) and name.strip() and name == sys.argv[1]:
+        sys.exit(0)
 sys.exit(1)
-' < "$RESP_BODY"
+' "$1" < "$RESP_BODY"
+}
+
+# json_completion_has_content EXPECTED — rejects structured errors and requires
+# choices[0].message.content. When EXPECTED is non-empty, it must match exactly.
+json_completion_has_content() {
+  python3 -c '
+import json, sys
+expected = sys.argv[1]
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+if not isinstance(payload, dict) or "error" in payload:
+    sys.exit(1)
+choices = payload.get("choices")
+if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+    sys.exit(1)
+message = choices[0].get("message")
+if not isinstance(message, dict):
+    sys.exit(1)
+content = message.get("content")
+if isinstance(content, str):
+    if not content.strip() or (expected and content != expected):
+        sys.exit(1)
+    sys.exit(0)
+if isinstance(content, list) and not expected:
+    for part in content:
+        if isinstance(part, str) and part.strip():
+            sys.exit(0)
+        if isinstance(part, dict) and isinstance(part.get("text"), str) and part["text"].strip():
+            sys.exit(0)
+sys.exit(1)
+' "$1" < "$RESP_BODY"
 }
 
 pass_step() { PASS_COUNT=$((PASS_COUNT + 1)); echo "[PASS] $1"; }
@@ -221,7 +297,7 @@ evidence() {
 # --- main chain ---
 
 echo "== metapi token-import e2e =="
-echo "   metapi=$METAPI_URL upstream=$UPSTREAM_URL platform=$PLATFORM mode=$CREDENTIAL_MODE skipModelFetch=$SKIP_MODEL_FETCH"
+echo "   metapi=$METAPI_URL upstream=$UPSTREAM_URL platform=$PLATFORM mode=$CREDENTIAL_MODE skipModelFetch=$SKIP_MODEL_FETCH skipRelay=$E2E_SKIP_RELAY"
 
 # 1. health
 status="$(request GET "$METAPI_URL/health")"
@@ -366,28 +442,22 @@ else
   fail_step "account idempotent-create skipped (no site id / token not verified)"
 fi
 
-# 7. models (frontend uses GET /api/accounts/{id}/models)
-ROUTE_MODEL="$PROXY_MODEL"
-first_model=""
-if [ -n "$ACCOUNT_ID" ]; then
-  status="$(request GET "$METAPI_URL/api/accounts/$ACCOUNT_ID/models" "" "$METAPI_AUTH_TOKEN")"
-  if [ "$status" = "200" ]; then
-    model_count="$(json_value totalCount 2>/dev/null || true)"
-    first_model="$(json_value "models[0].name" 2>/dev/null || true)"
-    if [ -n "$first_model" ]; then
-      ROUTE_MODEL="$first_model"
-    fi
-    if [ "$model_count" = "0" ] || [ -z "$model_count" ]; then
-      warn_step "models (HTTP 200, totalCount=$model_count — upstream model list empty, route falls back to PROXY_MODEL)"
-    else
-      pass_step "models (HTTP 200, totalCount=$model_count)"
-    fi
+# 7. Account model discovery is required before configuring or exercising relay.
+# SKIP_MODEL_FETCH affects account creation only; it does not waive this gate.
+ROUTE_MODEL=""
+if [ "$E2E_SKIP_RELAY" = "1" ]; then
+  skip_step "models relay assertion disabled explicitly"
+elif [ -n "$ACCOUNT_ID" ]; then
+  if status="$(request GET "$METAPI_URL/api/accounts/$ACCOUNT_ID/models" "" "$METAPI_AUTH_TOKEN")" &&
+     [[ "$status" =~ ^2[0-9][0-9]$ ]] && ROUTE_MODEL="$(json_select_model 2>/dev/null)"; then
+    pass_step "models (HTTP $status, selected=$ROUTE_MODEL)"
   else
-    fail_step "models (HTTP $status)"
+    ROUTE_MODEL=""
+    fail_step "models (HTTP $status, expected non-empty discovery containing PROXY_MODEL when set)"
     evidence
   fi
 else
-  fail_step "models skipped (no account id)"
+  fail_step "models unavailable (no account id)"
 fi
 
 # 8. balance (POST /api/accounts/{id}/balance)
@@ -436,46 +506,54 @@ fi
 #     Managed keys default to deny-all-when-empty, so supportedModels:["*"]
 #     explicitly lets the test model through to the router/upstream.
 PROXY_TOKEN=""
-status="$(request POST "$METAPI_URL/api/downstream-keys" "{\"name\":\"$TOKEN_NAME\",\"key\":\"$TOKEN_IMPORT_KEY\",\"supportedModels\":[\"*\"]}" "$METAPI_AUTH_TOKEN")"
-if [ "$status" = "200" ] || [ "$status" = "201" ]; then
-  PROXY_TOKEN="$TOKEN_IMPORT_KEY"
-  pass_step "token create ($TOKEN_NAME)"
-elif [ "$status" = "409" ]; then
-  # The key exists from a previous run. Reassert the relay policy instead of
-  # merely reusing it: an empty supportedModels list is intentionally deny-all,
-  # so a leftover key would silently block every model this run is about to
-  # relay. smoke.sh step 11 already converges this way (#1209).
-  status="$(request GET "$METAPI_URL/api/downstream-keys" "" "$METAPI_AUTH_TOKEN")"
-  key_id="$(python3 -c 'import json,sys; p=json.load(sys.stdin); name=sys.argv[1]; print(next(str(item.get("id", "")) for item in p.get("items", []) if isinstance(item, dict) and item.get("name") == name))' "$TOKEN_NAME" < "$RESP_BODY" 2>/dev/null || true)"
-  if [ "$status" = "200" ] && [ -n "$key_id" ]; then
-    status="$(request PUT "$METAPI_URL/api/downstream-keys/$key_id" '{"supportedModels":["*"],"enabled":true}' "$METAPI_AUTH_TOKEN")"
-    if [ "$status" = "200" ]; then
-      PROXY_TOKEN="$TOKEN_IMPORT_KEY"
-      pass_step "token reuse ($TOKEN_NAME, relay policy reasserted)"
+if [ "$E2E_SKIP_RELAY" = "1" ]; then
+  skip_step "downstream token relay setup disabled explicitly"
+elif [ -z "$ROUTE_MODEL" ]; then
+  fail_step "downstream token relay setup blocked (model discovery failed)"
+else
+  status="$(request POST "$METAPI_URL/api/downstream-keys" "{\"name\":\"$TOKEN_NAME\",\"key\":\"$TOKEN_IMPORT_KEY\",\"supportedModels\":[\"*\"]}" "$METAPI_AUTH_TOKEN")"
+  if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+    PROXY_TOKEN="$TOKEN_IMPORT_KEY"
+    pass_step "token create ($TOKEN_NAME)"
+  elif [ "$status" = "409" ]; then
+    # The key exists from a previous run. Reassert the relay policy instead of
+    # merely reusing it: an empty supportedModels list is intentionally deny-all,
+    # so a leftover key would silently block every model this run is about to
+    # relay. smoke.sh step 11 already converges this way (#1209).
+    status="$(request GET "$METAPI_URL/api/downstream-keys" "" "$METAPI_AUTH_TOKEN")"
+    key_id="$(python3 -c 'import json,sys; p=json.load(sys.stdin); name=sys.argv[1]; print(next(str(item.get("id", "")) for item in p.get("items", []) if isinstance(item, dict) and item.get("name") == name))' "$TOKEN_NAME" < "$RESP_BODY" 2>/dev/null || true)"
+    if [ "$status" = "200" ] && [ -n "$key_id" ]; then
+      status="$(request PUT "$METAPI_URL/api/downstream-keys/$key_id" '{"supportedModels":["*"],"enabled":true}' "$METAPI_AUTH_TOKEN")"
+      if [ "$status" = "200" ]; then
+        PROXY_TOKEN="$TOKEN_IMPORT_KEY"
+        pass_step "token reuse ($TOKEN_NAME, relay policy reasserted)"
+      else
+        fail_step "token reuse/update (HTTP $status, keyId=$key_id)"
+        evidence
+      fi
     else
-      fail_step "token reuse/update (HTTP $status, keyId=$key_id)"
-      evidence
+      # A 409 with no record under this name means the fixed key VALUE belongs to a
+      # differently named record, so this script does not own it and cannot
+      # reassert its policy. That is a real topology here: two chains share
+      # TOKEN_IMPORT_KEY under different TOKEN_NAMEs, so whichever runs second
+      # always lands in this branch. Reusing the value is still correct -- the
+      # relay steps below prove it works -- but claiming the policy was checked
+      # would be a green that means nothing, and failing would red a run whose
+      # relay is fine. So: reuse, and say out loud what was not verified.
+      PROXY_TOKEN="$TOKEN_IMPORT_KEY"
+      warn_step "token reuse (HTTP 409: the fixed key is owned by a differently named record, relay policy NOT reasserted)"
     fi
   else
-    # A 409 with no record under this name means the fixed key VALUE belongs to a
-    # differently named record, so this script does not own it and cannot
-    # reassert its policy. That is a real topology here: two chains share
-    # TOKEN_IMPORT_KEY under different TOKEN_NAMEs, so whichever runs second
-    # always lands in this branch. Reusing the value is still correct -- the
-    # relay steps below prove it works -- but claiming the policy was checked
-    # would be a green that means nothing, and failing would red a run whose
-    # relay is fine. So: reuse, and say out loud what was not verified.
-    PROXY_TOKEN="$TOKEN_IMPORT_KEY"
-    warn_step "token reuse (HTTP 409: the fixed key is owned by a differently named record, relay policy NOT reasserted)"
+    fail_step "token create (HTTP $status)"
+    evidence
   fi
-else
-  fail_step "token create (HTTP $status)"
-  evidence
 fi
 
 # 11. route create (idempotent by modelPattern lookup)
-if [ -n "$PROXY_TOKEN" ]; then
-  ROUTE_ID=""
+ROUTE_ID=""
+if [ "$E2E_SKIP_RELAY" = "1" ]; then
+  skip_step "route relay setup disabled explicitly"
+elif [ -n "$PROXY_TOKEN" ] && [ -n "$ROUTE_MODEL" ]; then
   ROUTE_STATE="created"
   status="$(request GET "$METAPI_URL/api/routes/lite" "" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ]; then
@@ -491,43 +569,39 @@ if [ -n "$PROXY_TOKEN" ]; then
     fi
   fi
   if [ -n "$ROUTE_ID" ]; then
-    if [ "$ROUTE_MODEL" = "$PROXY_MODEL" ] && [ -z "$first_model" ]; then
-      warn_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL, $ROUTE_STATE) — upstream model list empty, used PROXY_MODEL"
-    else
-      pass_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL, $ROUTE_STATE)"
-    fi
+    pass_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL, $ROUTE_STATE)"
   else
     fail_step "route create (no route id obtained)"
     evidence
   fi
 else
-  fail_step "route create skipped (no downstream token)"
+  fail_step "route create blocked (no downstream token or discovered model)"
 fi
 
-# 12. proxy relay
-if [ -n "$PROXY_TOKEN" ]; then
-  status="$(request GET "$METAPI_URL/v1/models" "" "$PROXY_TOKEN")"
-  if [ "$status" = "200" ]; then
-    pass_step "proxy /v1/models (HTTP 200)"
+# 12. A structured error is not successful relay. Gate the model POST on the
+# selected model being exposed; do not issue it after discovery/setup failure.
+if [ "$E2E_SKIP_RELAY" = "1" ]; then
+  skip_step "proxy /v1/models relay assertion disabled explicitly"
+  skip_step "proxy /v1/chat/completions relay assertion disabled explicitly"
+elif [ -n "$PROXY_TOKEN" ] && [ -n "$ROUTE_ID" ]; then
+  if status="$(request GET "$METAPI_URL/v1/models" "" "$PROXY_TOKEN")" &&
+     [[ "$status" =~ ^2[0-9][0-9]$ ]] && json_models_data_contains "$ROUTE_MODEL"; then
+    pass_step "proxy /v1/models (HTTP $status, selected model present: $ROUTE_MODEL)"
+    if status="$(request POST "$METAPI_URL/v1/chat/completions" "{\"model\":\"$ROUTE_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}" "$PROXY_TOKEN")" &&
+       [[ "$status" =~ ^2[0-9][0-9]$ ]] && json_completion_has_content "$EXPECTED_COMPLETION_CONTENT"; then
+      pass_step "proxy /v1/chat/completions (HTTP $status, completion content present)"
+    else
+      fail_step "proxy /v1/chat/completions (HTTP $status, expected completion content without error)"
+      evidence
+    fi
   else
-    fail_step "proxy /v1/models (HTTP $status)"
+    fail_step "proxy /v1/models (HTTP $status, expected non-empty data containing selected model without error)"
     evidence
-  fi
-
-  status="$(request POST "$METAPI_URL/v1/chat/completions" "{\"model\":\"$ROUTE_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}" "$PROXY_TOKEN")"
-  if [ "$status" = "200" ]; then
-    pass_step "proxy /v1/chat/completions (HTTP 200, relayed)"
-  elif json_has_error_key; then
-    # Structured JSON error: metapi relayed and answered with a documented
-    # error (e.g. upstream has no models/channels). Internal 5xx + non-JSON
-    # would fail.
-    pass_step "proxy /v1/chat/completions (HTTP $status, structured error relayed)"
-  else
-    fail_step "proxy /v1/chat/completions (HTTP $status, unstructured response)"
-    evidence
+    fail_step "proxy /v1/chat/completions not attempted (selected model unavailable)"
   fi
 else
-  fail_step "proxy skipped (no downstream token)"
+  fail_step "proxy /v1/models blocked (relay setup failed)"
+  fail_step "proxy /v1/chat/completions not attempted (relay setup failed)"
 fi
 
 # --- summary ---

--- a/scripts/e2e/verify-token-import.sh
+++ b/scripts/e2e/verify-token-import.sh
@@ -9,7 +9,7 @@
 #   -> account -> models -> balance -> checkin -> downstream token -> route
 #   -> /v1 proxy relay.
 #
-# Every step prints [PASS]/[FAIL]/[WARN] and accumulates a summary; the script
+# Every step prints [PASS]/[FAIL]/[WARN]/[SKIP] and accumulates a summary; the script
 # exits 1 when any step FAILs. FAILs print the truncated response body as
 # evidence.
 #
@@ -65,6 +65,7 @@ TOKEN_IMPORT_KEY="${TOKEN_IMPORT_KEY:-sk-e2e-token}"
 PASS_COUNT=0
 FAIL_COUNT=0
 WARN_COUNT=0
+SKIP_COUNT=0
 FAILED_NAMES=""
 
 # --- fatal setup checks ---
@@ -199,6 +200,7 @@ sys.exit(1)
 pass_step() { PASS_COUNT=$((PASS_COUNT + 1)); echo "[PASS] $1"; }
 fail_step() { FAIL_COUNT=$((FAIL_COUNT + 1)); FAILED_NAMES="$FAILED_NAMES $1"; echo "[FAIL] $1"; }
 warn_step() { WARN_COUNT=$((WARN_COUNT + 1)); echo "[WARN] $1"; }
+skip_step() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo "[SKIP] $1"; }
 
 evidence() {
   local b curl_err
@@ -401,18 +403,24 @@ else
   fail_step "balance skipped (no account id)"
 fi
 
-# 9. checkin (POST /api/checkin/trigger/{id}); token-import platforms may not
-#    support checkin — a 2xx with success=false is a documented unsupported
-#    result (PASS), 5xx/crash is a FAIL.
+# 9. checkin: a token-import platform may explicitly skip this operation.
+#    A skip is not successful coverage; failed/malformed outcomes must fail.
 if [ -n "$ACCOUNT_ID" ]; then
   status="$(request POST "$METAPI_URL/api/checkin/trigger/$ACCOUNT_ID" "" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ]; then
     checkin_ok="$(json_value success 2>/dev/null || true)"
-    if [ "$checkin_ok" = "True" ]; then
-      pass_step "checkin (success)"
-    else
-      pass_step "checkin (documented unsupported/negative result: success=$checkin_ok)"
-    fi
+    checkin_status="$(json_value status 2>/dev/null || true)"
+    checkin_skipped="$(json_value skipped 2>/dev/null || true)"
+    # The API owns outcome normalization. Do not infer unsupported from HTTP
+    # 200 or success=false, and do not grow another message-text classifier.
+    case "$checkin_ok:$checkin_status:$checkin_skipped" in
+      True:success:False) pass_step "checkin (success)" ;;
+      True:skipped:True|False:skipped:True) skip_step "checkin (status=skipped; no successful check-in verified)" ;;
+      *)
+        fail_step "checkin (HTTP 200, expected a consistent success or skipped outcome)"
+        evidence
+        ;;
+    esac
   elif [ "$status" = "404" ]; then
     fail_step "checkin (HTTP 404 account not found)"
     evidence
@@ -523,7 +531,7 @@ else
 fi
 
 # --- summary ---
-echo "== summary: $PASS_COUNT passed, $WARN_COUNT warned, $FAIL_COUNT failed =="
+echo "== summary: $PASS_COUNT passed, $WARN_COUNT warned, $SKIP_COUNT skipped, $FAIL_COUNT failed =="
 if [ "$FAIL_COUNT" -gt 0 ]; then
   echo "   failed steps:$FAILED_NAMES"
   exit 1

--- a/scripts/e2e/verify-token-import.sh
+++ b/scripts/e2e/verify-token-import.sh
@@ -550,6 +550,8 @@ else
 fi
 
 # 11. route create (idempotent by modelPattern lookup)
+# displayName is the public model alias, not an internal fixture label.
+RELAY_MODEL="$ROUTE_MODEL"
 ROUTE_ID=""
 if [ "$E2E_SKIP_RELAY" = "1" ]; then
   skip_step "route relay setup disabled explicitly"
@@ -559,11 +561,14 @@ elif [ -n "$PROXY_TOKEN" ] && [ -n "$ROUTE_MODEL" ]; then
   if [ "$status" = "200" ]; then
     if idx="$(json_find_index modelPattern "$ROUTE_MODEL" 2>/dev/null)"; then
       ROUTE_ID="$(json_value "[$idx].id" 2>/dev/null || true)"
+      route_alias="$(json_value "[$idx].displayName" 2>/dev/null || true)"
+      route_alias="$(printf '%s' "$route_alias" | python3 -c 'import sys; print(sys.stdin.read().strip())')"
+      if [ -n "$route_alias" ]; then RELAY_MODEL="$route_alias"; fi
       ROUTE_STATE="reused"
     fi
   fi
   if [ -z "$ROUTE_ID" ]; then
-    status="$(request POST "$METAPI_URL/api/routes" "{\"modelPattern\":\"$ROUTE_MODEL\",\"displayName\":\"e2e-token-import-route\",\"routeMode\":\"pattern\",\"enabled\":true}" "$METAPI_AUTH_TOKEN")"
+    status="$(request POST "$METAPI_URL/api/routes" "{\"modelPattern\":\"$ROUTE_MODEL\",\"routeMode\":\"pattern\",\"enabled\":true}" "$METAPI_AUTH_TOKEN")"
     if [ "$status" = "200" ] || [ "$status" = "201" ]; then
       ROUTE_ID="$(json_value id 2>/dev/null || true)"
     fi
@@ -585,9 +590,9 @@ if [ "$E2E_SKIP_RELAY" = "1" ]; then
   skip_step "proxy /v1/chat/completions relay assertion disabled explicitly"
 elif [ -n "$PROXY_TOKEN" ] && [ -n "$ROUTE_ID" ]; then
   if status="$(request GET "$METAPI_URL/v1/models" "" "$PROXY_TOKEN")" &&
-     [[ "$status" =~ ^2[0-9][0-9]$ ]] && json_models_data_contains "$ROUTE_MODEL"; then
-    pass_step "proxy /v1/models (HTTP $status, selected model present: $ROUTE_MODEL)"
-    if status="$(request POST "$METAPI_URL/v1/chat/completions" "{\"model\":\"$ROUTE_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}" "$PROXY_TOKEN")" &&
+     [[ "$status" =~ ^2[0-9][0-9]$ ]] && json_models_data_contains "$RELAY_MODEL"; then
+    pass_step "proxy /v1/models (HTTP $status, selected model present: $RELAY_MODEL)"
+    if status="$(request POST "$METAPI_URL/v1/chat/completions" "{\"model\":\"$RELAY_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}" "$PROXY_TOKEN")" &&
        [[ "$status" =~ ^2[0-9][0-9]$ ]] && json_completion_has_content "$EXPECTED_COMPLETION_CONTENT"; then
       pass_step "proxy /v1/chat/completions (HTTP $status, completion content present)"
     else

--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -134,8 +135,6 @@ func IsSiteDisabled(status string) bool {
 func isAccountDisabled(status string) bool {
 	return strings.EqualFold(strings.TrimSpace(status), "disabled")
 }
-
-
 
 // classifyAndMarshalFailureReason runs the structured failure classifier
 // (ClassifyFailureReason) and serializes the result to JSON for the
@@ -499,23 +498,17 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 			}
 		}
 
-		// Parse reward
-		parsedReward := ParseCheckinRewardAmount(logReward)
-		if parsedReward <= 0 {
-			parsedReward = ParseCheckinRewardAmount(result.Message)
-			if parsedReward > 0 {
-				logReward = fmt.Sprintf("%v", parsedReward)
-			}
-		}
-		if directCheckinSuccess && parsedReward <= 0 {
-			// Only infer a reward delta when the pre-checkin balance is known;
-			// a NULL (never-refreshed) balance gives no baseline to diff against.
-			if refreshedBalanceInfo != nil && account.Balance != nil {
-				inferredReward := InferRewardFromBalanceDelta(*account.Balance, refreshedBalanceInfo.Balance)
-				if inferredReward > 0 {
-					parsedReward = inferredReward
-					logReward = fmt.Sprintf("%v", parsedReward)
-				}
+		// The adapter owns native award fields and their units. A non-empty
+		// reward (including explicit "0") is authoritative; free-form message
+		// numbers may be dates or total balances, not money awarded here.
+		// The account snapshot predates the refresh above. DEFAULT 0 is not a
+		// known baseline: require evidence of a prior successful balance read.
+		if directCheckinSuccess && strings.TrimSpace(logReward) == "" &&
+			refreshedBalanceInfo != nil && account.Balance != nil &&
+			account.LastBalanceRefresh != nil && strings.TrimSpace(*account.LastBalanceRefresh) != "" {
+			inferredReward := InferRewardFromBalanceDelta(*account.Balance, refreshedBalanceInfo.Balance)
+			if inferredReward > 0 {
+				logReward = strconv.FormatFloat(inferredReward, 'f', -1, 64)
 			}
 		}
 	}

--- a/service/checkin/checkin_reward_provenance_test.go
+++ b/service/checkin/checkin_reward_provenance_test.go
@@ -1,0 +1,162 @@
+package checkin
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/service/balance"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// #1275: a newly password-bound account has balance DEFAULT 0, but upstream
+// quota is already 10,000,000 ($20). New API adds 1000 quota ($0.002), not $20.002.
+// These tests use the real rc.34 response shape and the runner's real DB writes.
+func TestCheckinAccount_RewardProvenance(t *testing.T) {
+	const nativeReward = `{"success":true,"message":"签到成功","data":{"quota_awarded":1000,"checkin_date":"2026-09-07"}}`
+	const missingReward = `{"success":true,"message":"签到成功"}`
+	cases := []struct {
+		name               string
+		initialQuota       int64
+		quotaDelta         int64
+		response           string
+		refreshBefore      bool
+		nullBaseline       bool
+		emptyRefreshMarker bool
+		failPostBalance    bool
+		wantReward         string
+	}{
+		{name: "new_account_native_reward", initialQuota: 10_000_000, quotaDelta: 1000, response: nativeReward, wantReward: "0.002"},
+		{name: "new_account_unknown_reward_not_total_balance_or_zero", initialQuota: 10_000_000, quotaDelta: 1000, response: missingReward, wantReward: ""},
+		{name: "null_baseline_is_unknown", initialQuota: 10_000_000, quotaDelta: 1000, response: missingReward, nullBaseline: true, wantReward: ""},
+		{name: "empty_refresh_marker_is_not_proof", initialQuota: 10_000_000, quotaDelta: 1000, response: missingReward, emptyRefreshMarker: true, wantReward: ""},
+		{name: "confirmed_balance_delta", initialQuota: 10_000_000, quotaDelta: 1000, response: missingReward, refreshBefore: true, wantReward: "0.002"},
+		{name: "confirmed_zero_balance_is_valid", initialQuota: 0, quotaDelta: 1000, response: missingReward, refreshBefore: true, wantReward: "0.002"},
+		{name: "one_quota_delta_keeps_decimal_units", initialQuota: 10_000_000, quotaDelta: 1, response: missingReward, refreshBefore: true, wantReward: "0.000002"},
+		{name: "native_reward_wins_over_unrelated_balance_increase", initialQuota: 10_000_000, quotaDelta: 501000, response: nativeReward, refreshBefore: true, wantReward: "0.002"},
+		{name: "native_reward_survives_failed_balance_refresh", initialQuota: 10_000_000, quotaDelta: 1000, response: nativeReward, failPostBalance: true, wantReward: "0.002"},
+		{name: "native_zero_is_authoritative", initialQuota: 10_000_000, quotaDelta: 0, response: `{"success":true,"message":"签到成功","data":{"quota_awarded":0}}`, wantReward: "0"},
+		{name: "native_zero_is_not_overwritten_by_other_income", initialQuota: 10_000_000, quotaDelta: 500000, response: `{"success":true,"message":"签到成功","data":{"quota_awarded":0}}`, refreshBefore: true, wantReward: "0"},
+		{name: "balance_and_date_in_response_are_not_rewards", initialQuota: 10_000_000, quotaDelta: 1000, response: `{"success":true,"message":"balance: 20.002; check-in date: 2026-09-07","data":{"quota":10001000,"balance":20.002}}`, wantReward: ""},
+		{name: "already_checked_in_success_with_zero_gain", initialQuota: 10_000_000, quotaDelta: 0, response: `{"success":false,"message":"今日已签到"}`, wantReward: ""},
+		{name: "already_checked_in_date_is_not_a_reward", initialQuota: 10_000_000, quotaDelta: 0, response: `{"success":false,"message":"already checked in today (2026-09-07)"}`, refreshBefore: true, wantReward: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var quota atomic.Int64
+			quota.Store(tc.initialQuota)
+			var checkinCalls atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/api/user/checkin":
+					checkinCalls.Add(1)
+					quota.Add(tc.quotaDelta)
+					fmt.Fprint(w, tc.response)
+				case r.Method == http.MethodGet && r.URL.Path == "/api/user/self":
+					if tc.failPostBalance && checkinCalls.Load() > 0 {
+						w.WriteHeader(http.StatusServiceUnavailable)
+						fmt.Fprint(w, `{"success":false,"message":"balance temporarily unavailable"}`)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"success": true, "data": map[string]any{"id": 17, "username": "reward-user", "quota": quota.Load(), "used_quota": 0},
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			db, err := store.Open(store.DialectSQLite, ":memory:", false)
+			if err != nil {
+				t.Fatalf("open sqlite: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			if err := store.AutoMigrate(db); err != nil {
+				t.Fatalf("migrate: %v", err)
+			}
+			now := time.Now().UTC().Format(time.RFC3339)
+			siteRes, err := db.Exec("INSERT INTO sites (name,url,platform,status,created_at,updated_at) VALUES (?,?,'new-api','active',?,?)", "reward upstream", srv.URL, now, now)
+			if err != nil {
+				t.Fatalf("insert site: %v", err)
+			}
+			siteID, _ := siteRes.LastInsertId()
+			// Deliberately omit balance and last_balance_refresh: this is the
+			// real new-account DEFAULT 0, not an invented confirmed baseline.
+			accountRes, err := db.Exec(`INSERT INTO accounts (site_id,username,access_token,status,checkin_enabled,extra_config,created_at,updated_at) VALUES (?,?,'test-dashboard-pat','active',TRUE,'{"platformUserId":17}',?,?)`, siteID, "reward-user", now, now)
+			if err != nil {
+				t.Fatalf("insert account: %v", err)
+			}
+			accountID, _ := accountRes.LastInsertId()
+			var initialBalance *float64
+			var initialRefresh *string
+			if err := db.QueryRow("SELECT balance,last_balance_refresh FROM accounts WHERE id=?", accountID).Scan(&initialBalance, &initialRefresh); err != nil {
+				t.Fatalf("read default account: %v", err)
+			}
+			if initialBalance == nil || *initialBalance != 0 || initialRefresh != nil {
+				t.Fatal("fixture must reproduce the unrefreshed DEFAULT 0 account")
+			}
+			if tc.refreshBefore {
+				// Obtain a trustworthy baseline through the same balance
+				// service that owns the last_balance_refresh marker.
+				if _, err := balance.RefreshBalance(&config.Config{}, db.DB, accountID); err != nil {
+					t.Fatalf("confirm baseline: %v", err)
+				}
+			}
+			if tc.nullBaseline {
+				if _, err := db.Exec("UPDATE accounts SET balance=NULL WHERE id=?", accountID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.emptyRefreshMarker {
+				if _, err := db.Exec("UPDATE accounts SET last_balance_refresh='' WHERE id=?", accountID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			result := CheckinAccount(&config.Config{}, db.DB, accountID, &CheckinOptions{ScheduleMode: "manual"})
+			if !result.Success || result.Status != CheckinSuccess || result.Skipped {
+				t.Fatalf("CheckinAccount = %+v; want success, never SKIP", result)
+			}
+			if result.Reward != tc.wantReward {
+				t.Errorf("result.Reward = %q, want %q", result.Reward, tc.wantReward)
+			}
+			var logStatus string
+			var logReward *string
+			var failureReason *string
+			if err := db.QueryRow("SELECT status,reward,failure_reason FROM checkin_logs WHERE account_id=? ORDER BY id DESC LIMIT 1", accountID).Scan(&logStatus, &logReward, &failureReason); err != nil {
+				t.Fatalf("read checkin log: %v", err)
+			}
+			if logStatus != "success" || failureReason != nil || logReward == nil || *logReward != tc.wantReward {
+				t.Errorf("persisted log status=%q reward=%v failure=%v; want success/reward %q/no failure", logStatus, logReward, failureReason, tc.wantReward)
+			}
+			if tc.wantReward == "0.002" || tc.wantReward == "0.000002" {
+				if ParseCheckinRewardAmount(result.Reward) != float64(1000)/500000 && tc.wantReward == "0.002" {
+					t.Error("monetary reward parser changed the native quota units")
+				}
+				if tc.wantReward == "0.000002" && ParseCheckinRewardAmount(result.Reward) != float64(1)/500000 {
+					t.Error("small quota reward must not become a whole-dollar reward")
+				}
+			}
+			if checkinCalls.Load() != 1 || quota.Load()-tc.initialQuota != tc.quotaDelta {
+				t.Fatalf("upstream checkin calls=%d quotaDelta=%d, want 1/%d", checkinCalls.Load(), quota.Load()-tc.initialQuota, tc.quotaDelta)
+			}
+			if !tc.failPostBalance {
+				var savedBalance float64
+				var refreshedAt *string
+				if err := db.QueryRow("SELECT balance,last_balance_refresh FROM accounts WHERE id=?", accountID).Scan(&savedBalance, &refreshedAt); err != nil {
+					t.Fatal(err)
+				}
+				if math.Abs(savedBalance-float64(quota.Load())/500000) > 1e-9 || refreshedAt == nil || strings.TrimSpace(*refreshedAt) == "" {
+					t.Fatal("post-checkin balance must still be refreshed and stamped independently of reward")
+				}
+			}
+		})
+	}
+}

--- a/service/checkin/checkin_success_event_test.go
+++ b/service/checkin/checkin_success_event_test.go
@@ -27,8 +27,8 @@ func TestCheckinAccount_SuccessPersistsItsEvent(t *testing.T) {
 		case "/api/user/self":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"success": true,
-				// quota rises by 5000 (=0.01 in the 500k-per-unit convention) so the
-				// reward is inferred the same way production infers it.
+				// The balance provides context; the check-in response below is the
+				// authority for its 5000-quota ($0.01) award.
 				"data": map[string]any{"id": 11, "username": "success-user", "quota": 505000, "used_quota": 0},
 			})
 		case "/api/user/checkin":

--- a/web/knip.config.ts
+++ b/web/knip.config.ts
@@ -1,6 +1,8 @@
 import type { KnipConfig } from 'knip'
 
 const config: KnipConfig = {
+  // The Node evidence tests are invoked directly by CI, outside Vitest's graph.
+  entry: ['src/main.tsx', 'scripts/__tests__/*.test.mjs'],
   ignore: [
     // Type declaration files for JS modules under shared/ — knip cannot trace
     // .d.ts consumers via the .js import path, so these show as unused files.

--- a/web/scripts/__tests__/acceptance-evidence.test.mjs
+++ b/web/scripts/__tests__/acceptance-evidence.test.mjs
@@ -420,3 +420,66 @@ test('route must bind the verified token on the verified account, not any non-nu
     )
   }
 })
+
+test('account-scoped channels use a verified ready account default, not a mandatory tokenId', () => {
+  const channel = {
+    accountId: 7,
+    tokenId: null,
+    enabled: 1,
+    account: { apiTokenMasked: 'masked-relay-value' },
+  }
+  const defaultToken = {
+    id: 3,
+    accountId: 7,
+    valueStatus: 'ready',
+    enabled: true,
+    isDefault: true,
+  }
+  assert.doesNotThrow(() => requireTokenChannel([channel], 7, 3, defaultToken))
+  for (const invalid of [
+    null,
+    { ...defaultToken, id: 4 },
+    { ...defaultToken, accountId: 8 },
+    { ...defaultToken, enabled: false },
+    { ...defaultToken, isDefault: false },
+    { ...defaultToken, valueStatus: 'masked_pending' },
+  ]) {
+    assert.throws(() => requireTokenChannel([channel], 7, 3, invalid))
+  }
+  assert.throws(() =>
+    requireTokenChannel([{ ...channel, enabled: 0 }], 7, 3, defaultToken)
+  )
+  assert.throws(() =>
+    requireTokenChannel(
+      [{ ...channel, account: { accessTokenMasked: 'management-only' } }],
+      7,
+      3,
+      defaultToken
+    )
+  )
+  assert.throws(() =>
+    requireTokenChannel([{ ...channel, tokenId: 99 }], 7, 3, defaultToken)
+  )
+})
+
+test('a successful check-in cannot claim the total balance as its expected reward', () => {
+  const row = record(11, 'success')
+  row.checkin_logs.reward = '0.002'
+  const ui = {
+    id: 11,
+    account: target.username,
+    site: target.siteName,
+    siteUrl: target.siteUrl,
+    tableStatus: 'Success',
+    detailStatus: 'Success',
+    reward: '0.002',
+  }
+  assert.equal(checkinVerdict(row, ui, 'success', '1', '0.002'), 'PASS')
+  assert.throws(() =>
+    checkinVerdict(row, { ...ui, reward: '20.002' }, 'success', '1', '0.002')
+  )
+  row.checkin_logs.reward = '20.002'
+  assert.throws(() =>
+    checkinVerdict(row, { ...ui, reward: '20.002' }, 'success', '1', '0.002')
+  )
+})

--- a/web/scripts/__tests__/acceptance-evidence.test.mjs
+++ b/web/scripts/__tests__/acceptance-evidence.test.mjs
@@ -1,0 +1,422 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  checkinRunStatus,
+  checkinVerdict,
+  freshCheckinLog,
+  freshUpstreamToken,
+  readAccountTokens,
+  readCheckinPage,
+  readyAccountToken,
+  requireTokenChannel,
+  resolveAcceptanceAccount,
+} from '../acceptance-evidence.mjs'
+
+// Fixtures test the acceptance instrument only. No server, browser, credentials
+// or upstream is involved; these results are NOT live acceptance evidence.
+const target = {
+  accountId: 7,
+  username: 'acceptance-user',
+  siteName: 'acceptance-site',
+  siteUrl: 'https://upstream.example.test',
+}
+const record = (id = 11, status = 'success') => ({
+  checkin_logs: {
+    id,
+    accountId: target.accountId,
+    status,
+    message: 'upstream result',
+    reward: null,
+    createdAt: '2026-09-07T00:00:00Z',
+  },
+  accounts: { id: target.accountId, username: target.username },
+  sites: { name: target.siteName, url: target.siteUrl },
+  failureReason: null,
+})
+const page = (...items) => ({
+  items,
+  total: items.length,
+  page: 1,
+  pageSize: 200,
+})
+const trigger = (status = 'success') => ({
+  status: 'completed',
+  queued: false,
+  results: [
+    {
+      AccountID: target.accountId,
+      Username: target.username,
+      Site: target.siteName,
+      Result: { Status: status },
+    },
+  ],
+})
+const visible = (row = record()) => ({
+  id: row.checkin_logs.id,
+  account: row.accounts.username,
+  site: row.sites.name,
+  siteUrl: row.sites.url,
+  tableStatus: { success: 'Success', failed: 'Failed', skipped: 'Skipped' }[
+    row.checkin_logs.status
+  ],
+  detailStatus: { success: 'Success', failed: 'Failed', skipped: 'Skipped' }[
+    row.checkin_logs.status
+  ],
+})
+function verdict(
+  after,
+  { ui = visible(), run = trigger(), expected = '0' } = {}
+) {
+  // The old UI row is deliberately still visible unless the fixture changes it.
+  const fresh = freshCheckinLog(readCheckinPage(after, target), 10)
+  return checkinVerdict(fresh, ui, checkinRunStatus(run, target), expected)
+}
+
+test('fresh success for the exact account passes only with matching table and detail', () => {
+  assert.equal(verdict(page(record()), { expected: '1' }), 'PASS')
+})
+
+test('historical success row and a completed trigger cannot produce PASS', () => {
+  const historical = record(10)
+  assert.throws(
+    () => verdict(page(historical), { ui: visible(historical) }),
+    /no fresh check-in log/
+  )
+})
+
+test('no new row is FAIL, not success or an unsupported SKIP', () => {
+  assert.throws(() => verdict(page()), /no fresh check-in log/)
+})
+
+test('a fresh log for another account with the same username is FAIL', () => {
+  const wrong = record()
+  wrong.checkin_logs.accountId = 8
+  wrong.accounts.id = 8
+  assert.throws(() => verdict(page(wrong)), /different account or site/)
+})
+
+test('wrong joined account, username, site name or URL cannot flatter the target', () => {
+  for (const change of [
+    (row) => {
+      row.accounts.id = 8
+    },
+    (row) => {
+      row.accounts.username += '-other'
+    },
+    (row) => {
+      row.sites.name += '-other'
+    },
+    (row) => {
+      row.sites.url = 'https://other.example.test'
+    },
+  ]) {
+    const wrong = record()
+    change(wrong)
+    assert.throws(() => verdict(page(wrong)), /different account or site/)
+  }
+})
+
+test('fresh failed log stays FAIL even when its message claims success', () => {
+  const failed = record(11, 'failed')
+  failed.checkin_logs.message = 'success; already checked in'
+  assert.throws(
+    () =>
+      verdict(page(failed), { ui: visible(failed), run: trigger('failed') }),
+    /failed/
+  )
+})
+
+test('an explicit fresh skipped log is SKIP by default, never PASS', () => {
+  const skipped = record(11, 'skipped')
+  assert.equal(
+    verdict(page(skipped), { ui: visible(skipped), run: trigger('skipped') }),
+    'SKIP'
+  )
+})
+
+test('required-checkin mode makes even an explicit skipped log FAIL', () => {
+  const skipped = record(11, 'skipped')
+  assert.throws(
+    () =>
+      verdict(page(skipped), {
+        ui: visible(skipped),
+        run: trigger('skipped'),
+        expected: '1',
+      }),
+    /skipped.*successful check-in was required/
+  )
+})
+
+test('unknown or missing log status is malformed, never a wording-based success/skip', () => {
+  for (const status of [
+    undefined,
+    null,
+    '',
+    'completed',
+    'unsupported',
+    'SUCCESS',
+  ]) {
+    const malformed = record(11, status)
+    malformed.checkin_logs.status = status
+    malformed.checkin_logs.message = 'success / unsupported'
+    assert.throws(() => verdict(page(malformed)), /malformed check-in log/)
+  }
+})
+
+test('malformed envelope, ID, time or nested log cannot pass', () => {
+  for (const malformed of [
+    null,
+    [],
+    {},
+    { items: [] },
+    { ...page(), total: -1 },
+    { ...page(), pageSize: 0 },
+    { ...page(record()), items: [null] },
+  ]) {
+    assert.throws(() => verdict(malformed), /malformed/)
+  }
+  for (const change of [
+    (row) => {
+      row.checkin_logs.id = '11'
+    },
+    (row) => {
+      row.checkin_logs.id = 0
+    },
+    (row) => {
+      row.checkin_logs.createdAt = 'not-a-time'
+    },
+    (row) => {
+      delete row.checkin_logs.message
+    },
+  ]) {
+    const malformed = record()
+    change(malformed)
+    assert.throws(() => verdict(page(malformed)), /malformed/)
+  }
+})
+
+test('multiple new outcomes fail closed instead of selecting a flattering success', () => {
+  assert.throws(
+    () => verdict(page(record(12), record(11, 'failed'))),
+    /ambiguous new/
+  )
+})
+
+test('the triggered round must name the exact account and a normal status', () => {
+  for (const change of [
+    (run) => {
+      run.results = []
+    },
+    (run) => {
+      run.results[0].AccountID = 8
+    },
+    (run) => {
+      run.results[0].Site = 'other-site'
+    },
+    (run) => {
+      run.results[0].Result.Status = 'unsupported'
+    },
+    (run) => {
+      run.results.push(run.results[0])
+    },
+  ]) {
+    const run = trigger()
+    change(run)
+    assert.throws(() => verdict(page(record()), { run }), /unique valid result/)
+  }
+  assert.throws(
+    () => verdict(page(record()), { run: { status: 'queued' } }),
+    /malformed/
+  )
+  assert.throws(
+    () => verdict(page(record()), { run: trigger('skipped') }),
+    /does not match/
+  )
+})
+
+test('API success cannot hide missing, historical, wrong-account or wrong-status UI evidence', () => {
+  for (const ui of [
+    null,
+    { ...visible(), id: 10 },
+    { ...visible(), account: 'other-user' },
+    { ...visible(), site: 'other-site' },
+    { ...visible(), siteUrl: 'https://other.example.test' },
+    { ...visible(), tableStatus: 'Failed' },
+    { ...visible(), detailStatus: 'Failed' },
+  ]) {
+    assert.throws(() => verdict(page(record()), { ui }), /UI does not show/)
+  }
+})
+
+test('a skipped API response also requires a real matching UI outcome', () => {
+  const skipped = record(11, 'skipped')
+  assert.throws(
+    () => verdict(page(skipped), { ui: visible(), run: trigger('skipped') }),
+    /UI does not show/
+  )
+})
+
+test('invalid expectation values cannot silently opt out of check-in', () => {
+  assert.throws(
+    () => verdict(page(record()), { expected: 'true' }),
+    /ACCEPT_EXPECT_CHECKIN/
+  )
+})
+
+test('account resolution uses both site ID and exact configured site name/URL', () => {
+  const snapshot = {
+    sites: [
+      { id: 2, name: 'other-site', url: 'https://other.example.test' },
+      { id: 3, name: target.siteName, url: `${target.siteUrl}/` },
+    ],
+    accounts: [
+      { id: 6, siteId: 2, username: target.username },
+      { id: target.accountId, siteId: 3, username: target.username },
+    ],
+  }
+  assert.equal(
+    resolveAcceptanceAccount(snapshot, target).accountId,
+    target.accountId
+  )
+  assert.throws(
+    () =>
+      resolveAcceptanceAccount(snapshot, {
+        ...target,
+        siteUrl: 'https://wrong.example.test',
+      }),
+    /exactly one acceptance site/
+  )
+  snapshot.accounts.push({ ...snapshot.accounts[1], id: 9 })
+  assert.throws(
+    () => resolveAcceptanceAccount(snapshot, target),
+    /exactly one acceptance account/
+  )
+})
+
+const token = (id = 22) => ({
+  id,
+  accountId: target.accountId,
+  name: 'acceptance-upstream-token',
+  valueStatus: 'ready',
+  enabled: true,
+  isDefault: true,
+})
+const created = (value = token()) => ({
+  success: true,
+  synced: true,
+  created: 1,
+  token: value,
+})
+
+test('new upstream-create response must prove a fresh ready/default token', () => {
+  assert.deepEqual(
+    freshUpstreamToken(created(), [token(21)], target.accountId, token().name),
+    token()
+  )
+  for (const value of [
+    token(21),
+    { ...token(), valueStatus: 'masked_pending' },
+    { ...token(), enabled: false },
+    { ...token(), isDefault: false },
+    { ...token(), name: 'old-token' },
+  ]) {
+    assert.throws(
+      () =>
+        freshUpstreamToken(
+          created(value),
+          [token(21)],
+          target.accountId,
+          token().name
+        ),
+      /fresh ready\/default/
+    )
+  }
+  assert.throws(
+    () =>
+      freshUpstreamToken(
+        created({ ...token(), accountId: 8 }),
+        [],
+        target.accountId,
+        token().name
+      ),
+    /wrong-account/
+  )
+})
+
+test('HTTP-success-like envelopes without actual upstream creation cannot pass', () => {
+  for (const result of [
+    null,
+    {},
+    { ...created(), success: false },
+    { ...created(), synced: false },
+    { ...created(), created: 0 },
+    { ...created(), token: undefined },
+  ]) {
+    assert.throws(() =>
+      freshUpstreamToken(result, [], target.accountId, token().name)
+    )
+  }
+})
+
+test('reuse requires ready AND enabled; masked or disabled tokens cannot unlock route creation', () => {
+  assert.equal(readyAccountToken([]), null)
+  assert.equal(
+    readyAccountToken([{ ...token(), valueStatus: 'masked_pending' }]),
+    null
+  )
+  assert.equal(readyAccountToken([{ ...token(), enabled: false }]), null)
+  assert.equal(
+    readyAccountToken([{ ...token(21), isDefault: false }, token()]).id,
+    22
+  )
+})
+
+test('token evidence retains metadata only and rejects wrong-account or malformed lists', () => {
+  assert.deepEqual(
+    readAccountTokens(
+      [
+        {
+          ...token(),
+          token: 'fixture-only-do-not-retain',
+          tokenMasked: 'fixture-only',
+        },
+      ],
+      target.accountId
+    ),
+    [token()]
+  )
+  assert.throws(() => readAccountTokens(null, target.accountId), /malformed/)
+  assert.throws(
+    () => readAccountTokens([{ ...token(), accountId: 8 }], target.accountId),
+    /wrong-account/
+  )
+})
+
+test('route must bind the verified token on the verified account, not any non-null tokenId', () => {
+  const channel = {
+    accountId: target.accountId,
+    tokenId: token().id,
+    enabled: true,
+  }
+  requireTokenChannel([channel], target.accountId, token().id)
+  requireTokenChannel(
+    [{ ...channel, enabled: 1 }],
+    target.accountId,
+    token().id
+  )
+  for (const channels of [
+    [],
+    null,
+    [{ ...channel, accountId: 8 }],
+    [{ ...channel, tokenId: 21 }],
+    [{ ...channel, tokenId: null }],
+    [{ ...channel, enabled: false }],
+    [{ ...channel, enabled: 0 }],
+  ]) {
+    assert.throws(
+      () => requireTokenChannel(channels, target.accountId, token().id),
+      /no enabled channel/
+    )
+  }
+})

--- a/web/scripts/acceptance-e2e.mjs
+++ b/web/scripts/acceptance-e2e.mjs
@@ -22,18 +22,22 @@
 //   backend performs a REAL login against the live upstream and the account must
 //   appear in the table.
 // Journey 3 — Check-in (opt-in, needs journey 2's account): enable check-in on
-//   the account, run all check-ins from the check-in page, and assert a check-in
-//   log row is recorded.
+//   the account, run all check-ins from the check-in page, and assert that a
+//   fresh log for that exact account/site succeeds AND the UI shows its ID
+//   and outcome. An explicit skipped outcome is SKIP, not PASS.
 //
 // Journeys 4-7 are the tail of the core chain, and the reason this gate exists.
-// Journeys 1-3 only prove configuration succeeded, which is precisely the shape
+// Journeys 1-3 do not prove that relay works, which is precisely the shape
 // of the "I deployed it and it basically does not work" complaint: every step
 // green, chain dead. So the tail is asserted where the operator stands (the UI)
 // and then from outside the browser with the key the UI just issued.
 // Journey 4 — Models (opt-in): the bound account shows a NON-EMPTY model list in
 //   its detail sheet, cross-checked against the API so a UI rendering "0 models"
 //   over a populated backend (or the reverse) fails.
-// Journey 5 — Route + usable channel (opt-in): "Auto-rebuild" turns those models
+// Journey 4b — Upstream token (opt-in): reuse a ready/enabled token, or create
+//   one through the account detail UI with a blank token value. Verify fresh
+//   ready/default metadata and UI presence before attempting a route.
+// Journey 5 — Route + usable channel (opt-in): "Add route" turns those models
 //   into routes, and one route must have a channel whose relay credential is
 //   BOUND. The unbound state is asserted absent in the wire payload (tokenId)
 //   AND in the sheet, because a channel with no token cannot serve anything.
@@ -56,6 +60,9 @@
 //   ACCEPT_LOGIN      set to "1" to also run journeys 2-7
 //   ACCEPT_KEY_NAME   downstream key name to issue  (default acceptance-e2e-key)
 //   ACCEPT_KEY_VALUE  downstream key value to issue (default sk-acceptance-e2e-key)
+//   ACCEPT_EXPECT_CHECKIN  require a successful check-in in journey 3 (1).
+//                     Default 0 allows only an explicit API skipped outcome as
+//                     SKIP; failed/malformed/missing fresh logs always FAIL.
 //   ACCEPT_EXPECT_RELAY  require a real relay in journey 7 (default 1; set 0
 //                     only for an upstream with no relay capability, which then
 //                     reports an honest SKIP instead of a fake PASS)
@@ -76,6 +83,17 @@
 
 import { chromium, request } from 'playwright'
 
+import {
+  checkinRunStatus,
+  checkinVerdict,
+  freshCheckinLog,
+  freshUpstreamToken,
+  readAccountTokens,
+  readCheckinPage,
+  readyAccountToken,
+  requireTokenChannel,
+  resolveAcceptanceAccount,
+} from './acceptance-evidence.mjs'
 import { loginSession } from './session-auth.mjs'
 
 const BASE_URL = (process.env.BASE_URL ?? 'http://127.0.0.1:4000').replace(
@@ -90,6 +108,7 @@ const PLATFORM = process.env.PLATFORM ?? 'new-api'
 const ACCEPT_SITE_NAME = process.env.ACCEPT_SITE_NAME ?? 'acceptance-real-site'
 const ACCEPT_KEY_NAME = process.env.ACCEPT_KEY_NAME ?? 'acceptance-e2e-key'
 const ACCEPT_KEY_VALUE = process.env.ACCEPT_KEY_VALUE ?? 'sk-acceptance-e2e-key'
+const ACCEPT_EXPECT_CHECKIN = process.env.ACCEPT_EXPECT_CHECKIN ?? '0'
 const ACCEPT_EXPECT_RELAY = process.env.ACCEPT_EXPECT_RELAY ?? '1'
 const ACCEPT_RELAY_MODEL = process.env.ACCEPT_RELAY_MODEL ?? ''
 const EXPECTED_COMPLETION_CONTENT =
@@ -384,11 +403,8 @@ async function journeyAccountLogin(context) {
   }
 }
 
-// Journey 3 — Check-in via UI: enable check-in on the account from journey 2,
-//   open the check-in page, run all check-ins, and assert a check-in log row
-//   appears. Against a real upstream that does not enable check-in the result is
-//   an honest skipped/failed log — the point is the full UI + backend round-trip
-//   runs and records something, not that the upstream grants reward.
+// Journey 3: the trigger, fresh persisted log, table and detail sheet must all
+// agree on the SAME account/site and outcome. Historical rows prove nothing.
 async function journeyCheckin(context) {
   const label = 'journey: check-in via UI'
   const headers = {
@@ -398,54 +414,168 @@ async function journeyCheckin(context) {
   const page = await context.newPage()
   collectPageFailures(page, label)
   try {
-    // Find the account created in journey 2 and make sure check-in is enabled
-    // so "run all" actually targets it.
-    let accountId = null
-    await act('locate account', async () => {
+    if (!['0', '1'].includes(ACCEPT_EXPECT_CHECKIN)) {
+      throw new Error('ACCEPT_EXPECT_CHECKIN must be 0 or 1')
+    }
+    let target
+    await act('locate exact account and site', async () => {
       const resp = await context.request.get(`${BASE_URL}/api/accounts`, {
         headers,
       })
-      const data = await resp.json().catch(() => null)
-      const accounts = data?.accounts ?? []
-      const match = accounts.find((a) => a?.username === UPSTREAM_USERNAME)
-      if (!match) throw new Error(`account "${UPSTREAM_USERNAME}" not found`)
-      accountId = match.id
+      if (resp.status() !== 200) {
+        throw new Error(`accounts HTTP ${resp.status()}`)
+      }
+      target = resolveAcceptanceAccount(await resp.json().catch(() => null), {
+        username: UPSTREAM_USERNAME,
+        siteName: ACCEPT_SITE_NAME,
+        siteUrl: UPSTREAM_URL,
+      })
     })
     await act('enable check-in', async () => {
       const resp = await context.request.put(
-        `${BASE_URL}/api/accounts/${accountId}`,
+        `${BASE_URL}/api/accounts/${target.accountId}`,
         { headers, data: { checkinEnabled: true } }
       )
       if (resp.status() !== 200) {
         throw new Error(`enable check-in HTTP ${resp.status()}`)
       }
     })
-
-    await act('goto /checkin', () =>
-      page.goto(`${BASE_URL}/checkin`, {
-        waitUntil: 'networkidle',
-        timeout: 30_000,
+    await act('goto account-filtered /checkin', () =>
+      page.goto(
+        `${BASE_URL}/checkin?accountId=${target.accountId}&pageSize=200`,
+        {
+          waitUntil: 'networkidle',
+          timeout: 30_000,
+        }
+      )
+    )
+    const readLogs = async (offset = 0) => {
+      const resp = await context.request.get(`${BASE_URL}/api/checkin/logs`, {
+        headers,
+        params: { accountId: target.accountId, limit: 200, offset },
+        timeout: 10_000,
       })
+      if (resp.status() !== 200) {
+        throw new Error(`check-in logs HTTP ${resp.status()}`)
+      }
+      return readCheckinPage(await resp.json().catch(() => null), target)
+    }
+    let cursor = 0
+    await act('capture pre-trigger log IDs', async () => {
+      // The API sorts by createdAt, NOT id. Scan the target's paginated history
+      // rather than treating the first row/page as a trustworthy high-water mark.
+      for (let offset = 0; ;) {
+        const before = await readLogs(offset)
+        for (const row of before.items) {
+          cursor = Math.max(cursor, row.checkin_logs.id)
+        }
+        offset += before.items.length
+        if (offset >= before.total) break
+        if (before.items.length === 0) {
+          throw new Error('incomplete pre-trigger logs page')
+        }
+      }
+    })
+    let runStatus
+    await act(
+      'click Run all check-ins and verify its target result',
+      async () => {
+        const [resp] = await Promise.all([
+          page.waitForResponse(
+            (response) =>
+              response.url() === `${BASE_URL}/api/checkin/trigger` &&
+              response.request().method() === 'POST',
+            { timeout: 60_000 }
+          ),
+          page
+            .getByRole('button', { name: 'Run all check-ins', exact: true })
+            .click({ timeout: 10_000 }),
+        ])
+        if (resp.status() !== 200) {
+          throw new Error(`check-in trigger HTTP ${resp.status()}`)
+        }
+        runStatus = checkinRunStatus(
+          await resp.json().catch(() => null),
+          target
+        )
+      }
     )
-    await page.waitForTimeout(800)
-
-    await act('click Run all check-ins', () =>
-      page
-        .getByRole('button', { name: /Run all check-ins|运行所有签到|签到/i })
-        .first()
-        .click({ timeout: 10_000 })
-    )
-
-    // The run records a check-in log row (success / skipped / failed). Wait for
-    // any row to appear in the check-in records table.
-    await act('check-in log appears', () =>
-      page
-        .locator('table tbody tr')
-        .first()
-        .waitFor({ state: 'visible', timeout: 25_000 })
-    )
-
-    pass(`${label}: ran all check-ins and a check-in log row was recorded`)
+    let entry
+    let rowIndex
+    await act('wait for this account new check-in log', async () => {
+      const deadline = Date.now() + 25_000
+      for (;;) {
+        const after = await readLogs()
+        entry = freshCheckinLog(after, cursor)
+        if (entry) {
+          rowIndex = after.items.indexOf(entry)
+          return
+        }
+        if (Date.now() >= deadline) {
+          throw new Error('no fresh check-in log for the target account')
+        }
+        await page.waitForTimeout(500)
+      }
+    })
+    let ui
+    await act('UI shows the fresh log ID and actual result', async () => {
+      const deadline = Date.now() + 25_000
+      // Both pages use the same account filter, page size and server ordering.
+      // Opening details exposes the ID; matching only time/message is unsafe
+      // because two runs can have identical text and second-resolution times.
+      for (;;) {
+        const row = page.locator('table tbody tr').nth(rowIndex)
+        await row
+          .getByRole('cell', { name: target.username, exact: true })
+          .waitFor({ timeout: 15_000 })
+        await row
+          .getByRole('cell', { name: target.siteName, exact: true })
+          .waitFor({ timeout: 10_000 })
+        await row
+          .getByRole('button', { name: 'Check-in record actions', exact: true })
+          .click()
+        await page
+          .getByRole('menuitem', { name: 'View details', exact: true })
+          .click()
+        const sheet = page.locator('[data-slot="sheet-content"]')
+        const field = (name) =>
+          sheet
+            .locator('dt', { hasText: new RegExp(`^${name}$`) })
+            .locator('..')
+            .locator('dd')
+        const idText = (await field('Log ID').innerText()).trim()
+        if (idText === `#${entry.checkin_logs.id}`) {
+          ui = {
+            id: entry.checkin_logs.id,
+            account: (await field('Account').innerText()).trim(),
+            site: (await field('Site').innerText()).trim(),
+            siteUrl: (await field('Site URL').innerText()).trim(),
+            tableStatus: (
+              await row.getByRole('cell').nth(3).innerText()
+            ).trim(),
+            detailStatus: (
+              await sheet
+                .getByRole('heading')
+                .locator('[data-slot="badge"]')
+                .innerText()
+            ).trim(),
+          }
+          return
+        }
+        await page.keyboard.press('Escape')
+        await sheet.waitFor({ state: 'hidden', timeout: 5_000 })
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `UI never displayed fresh check-in log #${entry.checkin_logs.id}`
+          )
+        }
+        await page.waitForTimeout(250)
+      }
+    })
+    const verdict = checkinVerdict(entry, ui, runStatus, ACCEPT_EXPECT_CHECKIN)
+    const evidence = `${label}: account ${target.accountId}, fresh log #${entry.checkin_logs.id} > ${cursor}, status=${entry.checkin_logs.status}; table and detail agree`
+    if (verdict === 'SKIP') skip(evidence)
+    else pass(evidence)
   } catch (error) {
     fail(`${label}: ${String(error?.message ?? error).split('\n')[0]}`)
   } finally {
@@ -464,17 +594,22 @@ async function journeyAccountModels(context) {
   collectPageFailures(page, label)
   try {
     let accountId = null
+    let targetAccount
     let apiModels = []
     await act('locate account', async () => {
       const resp = await context.request.get(`${BASE_URL}/api/accounts`, {
         headers,
       })
       const data = await resp.json().catch(() => null)
-      const match = (data?.accounts ?? []).find(
-        (account) => account?.username === UPSTREAM_USERNAME
-      )
-      if (!match) throw new Error(`account "${UPSTREAM_USERNAME}" not found`)
-      accountId = match.id
+      if (resp.status() !== 200) {
+        throw new Error(`accounts HTTP ${resp.status()}`)
+      }
+      targetAccount = resolveAcceptanceAccount(data, {
+        username: UPSTREAM_USERNAME,
+        siteName: ACCEPT_SITE_NAME,
+        siteUrl: UPSTREAM_URL,
+      })
+      accountId = targetAccount.accountId
     })
 
     // The post-login sync is triggered by the login itself but lands
@@ -514,8 +649,9 @@ async function journeyAccountModels(context) {
       })
     )
     const row = page
-      .locator('table tbody tr', { hasText: UPSTREAM_USERNAME })
-      .first()
+      .locator('table tbody tr')
+      .filter({ has: page.getByText(targetAccount.username, { exact: true }) })
+      .filter({ has: page.getByText(targetAccount.siteName, { exact: true }) })
     await act('account row visible', () =>
       row.waitFor({ state: 'visible', timeout: 20_000 })
     )
@@ -576,9 +712,158 @@ async function journeyAccountModels(context) {
         .waitFor({ state: 'visible', timeout: 10_000 })
     )
 
+    journeyState.account = targetAccount
     journeyState.accountModels = apiModels
     pass(
       `${label}: account ${accountId} shows ${uiCount} models in its detail sheet, API agrees`
+    )
+  } catch (error) {
+    fail(`${label}: ${String(error?.message ?? error).split('\n')[0]}`)
+  } finally {
+    await page.close().catch(() => {})
+  }
+}
+
+// Journey 4b: model discovery needs only a login/session; relay needs a usable
+// upstream API token. Provision through the real UI, never an API seed/reveal.
+async function journeyUpstreamToken(context) {
+  const label = 'journey: upstream token via UI'
+  const headers = { Authorization: `Bearer ${AUTH_TOKEN}` }
+  const page = await context.newPage()
+  collectPageFailures(page, label)
+  try {
+    const target = journeyState.account
+    if (!target) {
+      throw new Error('the exact account/models journey did not pass')
+    }
+    const readTokens = async () => {
+      const resp = await context.request.get(`${BASE_URL}/api/account-tokens`, {
+        headers,
+        params: { accountId: target.accountId },
+        timeout: 10_000,
+      })
+      if (resp.status() !== 200) {
+        throw new Error(`account tokens HTTP ${resp.status()}`)
+      }
+      return readAccountTokens(
+        await resp.json().catch(() => null),
+        target.accountId
+      )
+    }
+    const before = await readTokens()
+    let token = readyAccountToken(before)
+    const reused = Boolean(token)
+    await act('open the exact account detail', async () => {
+      await page.goto(`${BASE_URL}/accounts`, {
+        waitUntil: 'networkidle',
+        timeout: 30_000,
+      })
+      const row = page
+        .locator('table tbody tr')
+        .filter({ has: page.getByText(target.username, { exact: true }) })
+        .filter({ has: page.getByText(target.siteName, { exact: true }) })
+      await row
+        .getByRole('button', { name: 'Account actions', exact: true })
+        .click({ timeout: 15_000 })
+      await page
+        .getByRole('menuitem', { name: 'View details', exact: true })
+        .click()
+    })
+    const sheet = page.locator('[data-slot="sheet-content"]')
+    const panel = sheet
+      .getByRole('heading', { name: 'Access tokens', exact: true })
+      .locator('../..')
+    await panel.waitFor({ state: 'visible', timeout: 15_000 })
+    if (!token) {
+      await act(
+        'create an upstream token with an empty Token value via UI',
+        async () => {
+          // The header says Add in the baseline, Add token in the onboarding fix.
+          await panel.getByRole('button', { name: /^(Add|Add token)$/ }).click()
+          const form = panel.locator('form')
+          await form
+            .getByLabel('Token name', { exact: true })
+            .fill('acceptance-upstream-token')
+          await form.getByLabel('Token value', { exact: true }).fill('')
+          await form.getByLabel('Group', { exact: true }).fill('default')
+          const [resp] = await Promise.all([
+            page.waitForResponse(
+              (response) =>
+                response.url() === `${BASE_URL}/api/account-tokens` &&
+                response.request().method() === 'POST',
+              { timeout: 45_000 }
+            ),
+            form
+              .getByRole('button', { name: 'Add token', exact: true })
+              .click({ timeout: 10_000 }),
+          ])
+          const submitted = resp.request().postDataJSON()
+          if (
+            submitted?.accountId !== target.accountId ||
+            submitted.name !== 'acceptance-upstream-token' ||
+            (submitted.token !== undefined && submitted.token !== '')
+          ) {
+            throw new Error(
+              'token form did not submit an upstream-create request for the exact account'
+            )
+          }
+          if (resp.status() !== 200) {
+            throw new Error(`upstream token creation HTTP ${resp.status()}`)
+          }
+          token = freshUpstreamToken(
+            await resp.json().catch(() => null),
+            before,
+            target.accountId,
+            'acceptance-upstream-token'
+          )
+          await form.waitFor({ state: 'hidden', timeout: 15_000 })
+        }
+      )
+    }
+    await act('ready token is persisted and visible in the UI', async () => {
+      const persisted = (await readTokens()).find(
+        (entry) => entry.id === token.id
+      )
+      if (
+        !persisted ||
+        !readyAccountToken([persisted]) ||
+        persisted.name !== token.name ||
+        persisted.isDefault !== token.isDefault
+      ) {
+        throw new Error(
+          'verified upstream token is not persisted ready/enabled with the same default state'
+        )
+      }
+      let row = panel.locator('li').filter({
+        has: page.getByText(token.name || 'Unnamed token', { exact: true }),
+      })
+      if (token.isDefault) {
+        row = row.filter({
+          has: page.locator('[data-slot="badge"]', { hasText: /^Default$/ }),
+        })
+      }
+      await row.waitFor({ state: 'visible', timeout: 15_000 })
+      await row
+        .getByRole('switch', { name: 'Enable/disable token', checked: true })
+        .waitFor({ timeout: 10_000 })
+      if (
+        await row
+          .locator('[data-slot="badge"]', { hasText: /^Pending$/ })
+          .count()
+      ) {
+        throw new Error('UI still labels the ready upstream token as Pending')
+      }
+      const uiDefault =
+        (await row
+          .locator('[data-slot="badge"]', { hasText: /^Default$/ })
+          .count()) > 0
+      if (uiDefault !== token.isDefault) {
+        throw new Error('UI token default badge disagrees with the API')
+      }
+    })
+    journeyState.upstreamToken = token
+    pass(
+      `${label}: ${reused ? 'reuse' : 'fresh-token'} #${token.id}, account ${target.accountId}, ready/enabled, default=${token.isDefault}; visible in account detail`
     )
   } catch (error) {
     fail(`${label}: ${String(error?.message ?? error).split('\n')[0]}`)
@@ -602,6 +887,10 @@ async function journeyRouteChannel(context) {
     const accountModels = journeyState.accountModels ?? []
     if (accountModels.length === 0) {
       throw new Error('the account serves no models (journey 4 did not pass)')
+    }
+    const upstreamToken = journeyState.upstreamToken
+    if (!upstreamToken) {
+      throw new Error('upstream token provisioning/reuse did not pass')
     }
     const model = ACCEPT_RELAY_MODEL || accountModels[0]
     if (!accountModels.includes(model)) {
@@ -717,14 +1006,11 @@ async function journeyRouteChannel(context) {
         )
       }
       channels = (await resp.json().catch(() => [])) ?? []
-      const bound = channels.filter(
-        (channel) => channel?.tokenId !== null && channel?.tokenId !== undefined
+      requireTokenChannel(
+        channels,
+        journeyState.account.accountId,
+        upstreamToken.id
       )
-      if (bound.length === 0) {
-        throw new Error(
-          `route ${target.id} has ${channels.length} channel(s) but none carries a relay credential`
-        )
-      }
     })
     await act('channel rows rendered', () =>
       sheet
@@ -767,7 +1053,7 @@ async function journeyRouteChannel(context) {
     )
 
     pass(
-      `${label}: route "${model}" created via UI with ${channels.length} channel(s); the sheet names each credential as the wire reports it`
+      `${label}: route "${model}" created via UI with ${channels.length} channel(s), bound to verified upstream token #${upstreamToken.id} for account ${journeyState.account.accountId}; the sheet names each credential as the wire reports it`
     )
   } catch (error) {
     fail(`${label}: ${String(error?.message ?? error).split('\n')[0]}`)
@@ -1093,6 +1379,7 @@ if (process.env.ACCEPT_LOGIN === '1') {
     })
     await seedAuth(tailContext)
     await journeyAccountModels(tailContext)
+    await journeyUpstreamToken(tailContext)
     await journeyRouteChannel(tailContext)
     await journeyDownstreamKey(tailContext)
     await tailContext.close()

--- a/web/scripts/acceptance-e2e.mjs
+++ b/web/scripts/acceptance-e2e.mjs
@@ -39,8 +39,8 @@
 //   ready/default metadata and UI presence before attempting a route.
 // Journey 5 — Route + usable channel (opt-in): "Add route" turns those models
 //   into routes, and one route must have a channel whose relay credential is
-//   BOUND. The unbound state is asserted absent in the wire payload (tokenId)
-//   AND in the sheet, because a channel with no token cannot serve anything.
+//   usable through a token binding or the verified account default. A null
+//   tokenId alone is not an unbound channel; the selector supports both paths.
 // Journey 6 — Downstream key (opt-in): issue a key through the UI, authorize the
 //   model journey 5 verified (an empty model policy is deny-all by design), and
 //   capture the key value.
@@ -109,6 +109,7 @@ const ACCEPT_SITE_NAME = process.env.ACCEPT_SITE_NAME ?? 'acceptance-real-site'
 const ACCEPT_KEY_NAME = process.env.ACCEPT_KEY_NAME ?? 'acceptance-e2e-key'
 const ACCEPT_KEY_VALUE = process.env.ACCEPT_KEY_VALUE ?? 'sk-acceptance-e2e-key'
 const ACCEPT_EXPECT_CHECKIN = process.env.ACCEPT_EXPECT_CHECKIN ?? '0'
+const ACCEPT_EXPECT_REWARD = process.env.ACCEPT_EXPECT_REWARD ?? ''
 const ACCEPT_EXPECT_RELAY = process.env.ACCEPT_EXPECT_RELAY ?? '1'
 const ACCEPT_RELAY_MODEL = process.env.ACCEPT_RELAY_MODEL ?? ''
 const EXPECTED_COMPLETION_CONTENT =
@@ -133,7 +134,7 @@ const skip = (message) => {
 // Wrap a step so a failure names the step instead of dumping a Playwright stack.
 async function act(name, fn) {
   try {
-    await fn()
+    return await fn()
   } catch (error) {
     throw new Error(
       `step "${name}": ${String(error?.message ?? error).split('\n')[0]}`
@@ -383,7 +384,39 @@ async function journeyAccountLogin(context) {
     await act('submit visible', () =>
       submit.waitFor({ state: 'visible', timeout: 10_000 })
     )
-    await act('click submit', () => submit.click({ timeout: 10_000 }))
+    await act('submit real upstream login', async () => {
+      if (
+        (await page.getByLabel('Username').first().inputValue()) !==
+          UPSTREAM_USERNAME ||
+        (await page
+          .getByLabel('Password', { exact: true })
+          .first()
+          .inputValue()) !== UPSTREAM_PASSWORD
+      ) {
+        throw new Error(
+          'account form reset the supplied login fields before submission'
+        )
+      }
+      const [response] = await Promise.all([
+        page.waitForResponse(
+          (reply) =>
+            reply.request().method() === 'POST' &&
+            new URL(reply.url()).pathname === '/api/accounts/login',
+          { timeout: 30_000 }
+        ),
+        submit.click({ timeout: 10_000 }),
+      ])
+      const result = await response.json().catch(() => null)
+      if (
+        response.status() !== 200 ||
+        result?.success !== true ||
+        !result.account?.id
+      ) {
+        throw new Error(
+          `upstream login did not create an account (HTTP ${response.status()})`
+        )
+      }
+    })
 
     // The real upstream login happens on submit; the account row must appear.
     await act('account row appears', () =>
@@ -531,6 +564,11 @@ async function journeyCheckin(context) {
         await row
           .getByRole('cell', { name: target.siteName, exact: true })
           .waitFor({ timeout: 10_000 })
+        // The modal makes the background table aria-hidden. Read the row
+        // while it is still accessible, then bind it to the detail's log ID.
+        const tableStatus = (
+          await row.getByRole('cell').nth(3).innerText()
+        ).trim()
         await row
           .getByRole('button', { name: 'Check-in record actions', exact: true })
           .click()
@@ -538,21 +576,25 @@ async function journeyCheckin(context) {
           .getByRole('menuitem', { name: 'View details', exact: true })
           .click()
         const sheet = page.locator('[data-slot="sheet-content"]')
+        await sheet.waitFor({ state: 'visible', timeout: 10_000 })
         const field = (name) =>
           sheet
             .locator('dt', { hasText: new RegExp(`^${name}$`) })
             .locator('..')
             .locator('dd')
-        const idText = (await field('Log ID').innerText()).trim()
+        const readField = (name) =>
+          act(`check-in detail ${name}`, () =>
+            field(name).innerText({ timeout: 5_000 })
+          )
+        const idText = (await readField('Log ID')).trim()
         if (idText === `#${entry.checkin_logs.id}`) {
           ui = {
             id: entry.checkin_logs.id,
-            account: (await field('Account').innerText()).trim(),
-            site: (await field('Site').innerText()).trim(),
-            siteUrl: (await field('Site URL').innerText()).trim(),
-            tableStatus: (
-              await row.getByRole('cell').nth(3).innerText()
-            ).trim(),
+            account: (await readField('Account')).trim(),
+            site: (await readField('Site')).trim(),
+            siteUrl: (await readField('Site URL')).trim(),
+            reward: (await readField('Reward')).trim(),
+            tableStatus,
             detailStatus: (
               await sheet
                 .getByRole('heading')
@@ -572,7 +614,13 @@ async function journeyCheckin(context) {
         await page.waitForTimeout(250)
       }
     })
-    const verdict = checkinVerdict(entry, ui, runStatus, ACCEPT_EXPECT_CHECKIN)
+    const verdict = checkinVerdict(
+      entry,
+      ui,
+      runStatus,
+      ACCEPT_EXPECT_CHECKIN,
+      ACCEPT_EXPECT_REWARD
+    )
     const evidence = `${label}: account ${target.accountId}, fresh log #${entry.checkin_logs.id} > ${cursor}, status=${entry.checkin_logs.status}; table and detail agree`
     if (verdict === 'SKIP') skip(evidence)
     else pass(evidence)
@@ -1006,10 +1054,25 @@ async function journeyRouteChannel(context) {
         )
       }
       channels = (await resp.json().catch(() => [])) ?? []
+      const defaultResp = await context.request.get(
+        `${BASE_URL}/api/account-tokens/account/${journeyState.account.accountId}/default`,
+        { headers }
+      )
+      const defaultData = await defaultResp.json().catch(() => null)
+      if (defaultResp.status() !== 200 || defaultData?.success !== true) {
+        throw new Error('could not verify the account default relay credential')
+      }
+      const defaultToken = defaultData.token
+        ? readAccountTokens(
+            [defaultData.token],
+            journeyState.account.accountId
+          )[0]
+        : null
       requireTokenChannel(
         channels,
         journeyState.account.accountId,
-        upstreamToken.id
+        upstreamToken.id,
+        defaultToken
       )
     })
     await act('channel rows rendered', () =>
@@ -1053,7 +1116,7 @@ async function journeyRouteChannel(context) {
     )
 
     pass(
-      `${label}: route "${model}" created via UI with ${channels.length} channel(s), bound to verified upstream token #${upstreamToken.id} for account ${journeyState.account.accountId}; the sheet names each credential as the wire reports it`
+      `${label}: route "${model}" created via UI with ${channels.length} channel(s), using verified upstream token #${upstreamToken.id} directly or through account ${journeyState.account.accountId} default; the sheet names each credential as the wire reports it`
     )
   } catch (error) {
     fail(`${label}: ${String(error?.message ?? error).split('\n')[0]}`)

--- a/web/scripts/acceptance-evidence.mjs
+++ b/web/scripts/acceptance-evidence.mjs
@@ -126,7 +126,13 @@ export function checkinRunStatus(payload, target) {
   return results[0].Result.Status
 }
 
-export function checkinVerdict(row, ui, runStatus, expected = '0') {
+export function checkinVerdict(
+  row,
+  ui,
+  runStatus,
+  expected = '0',
+  expectedReward = ''
+) {
   if (expected !== '0' && expected !== '1') {
     throw new Error('ACCEPT_EXPECT_CHECKIN must be 0 or 1')
   }
@@ -147,6 +153,14 @@ export function checkinVerdict(row, ui, runStatus, expected = '0') {
   ) {
     throw new Error(
       `UI does not show check-in log #${log.id} with its real result`
+    )
+  }
+  if (
+    expectedReward &&
+    (log.reward !== expectedReward || ui.reward !== expectedReward)
+  ) {
+    throw new Error(
+      'check-in reward does not match the independently configured upstream reward'
     )
   }
   if (log.status === 'success') return 'PASS'
@@ -216,7 +230,17 @@ export function freshUpstreamToken(payload, before, accountId, name) {
 }
 
 // The channel endpoint exposes DB booleans: true on PG, 1 on SQLite.
-export function requireTokenChannel(channels, accountId, tokenId) {
+export function requireTokenChannel(
+  channels,
+  accountId,
+  tokenId,
+  defaultToken = null
+) {
+  const isVerifiedDefault =
+    defaultToken?.id === tokenId &&
+    defaultToken.accountId === accountId &&
+    defaultToken.isDefault === true &&
+    readyAccountToken([defaultToken]) !== null
   if (
     !positiveId(accountId) ||
     !positiveId(tokenId) ||
@@ -224,12 +248,16 @@ export function requireTokenChannel(channels, accountId, tokenId) {
     !channels.some(
       (channel) =>
         channel?.accountId === accountId &&
-        channel.tokenId === tokenId &&
-        (channel.enabled === true || channel.enabled === 1)
+        (channel.enabled === true || channel.enabled === 1) &&
+        (channel.tokenId === tokenId ||
+          (channel.tokenId === null &&
+            isVerifiedDefault &&
+            typeof channel.account?.apiTokenMasked === 'string' &&
+            channel.account.apiTokenMasked.trim() !== ''))
     )
   ) {
     throw new Error(
-      'route has no enabled channel bound to the verified account token'
+      'route has no enabled channel using the verified account token or its account default'
     )
   }
 }

--- a/web/scripts/acceptance-evidence.mjs
+++ b/web/scripts/acceptance-evidence.mjs
@@ -1,0 +1,235 @@
+// Pure evidence checks shared by the real-UI acceptance journeys and their
+// offline negative controls. Never infer an outcome from an upstream message.
+
+const positiveId = (value) => Number.isSafeInteger(value) && value > 0
+const checkinStatuses = new Set(['success', 'failed', 'skipped'])
+// Display assertions only: the status is always taken from the API enum.
+const checkinLabels = {
+  success: 'Success',
+  failed: 'Failed',
+  skipped: 'Skipped',
+}
+
+function siteUrl(value) {
+  try {
+    return new URL(value).href.replace(/\/$/, '')
+  } catch {
+    throw new Error('malformed acceptance site URL')
+  }
+}
+
+export function resolveAcceptanceAccount(snapshot, expected) {
+  if (!Array.isArray(snapshot?.accounts) || !Array.isArray(snapshot?.sites)) {
+    throw new Error('malformed accounts snapshot')
+  }
+  const sites = snapshot.sites.filter(
+    (site) =>
+      site?.name === expected.siteName &&
+      siteUrl(site.url) === siteUrl(expected.siteUrl)
+  )
+  if (sites.length !== 1 || !positiveId(sites[0].id)) {
+    throw new Error(
+      'expected exactly one acceptance site with the configured name and URL'
+    )
+  }
+  const accounts = snapshot.accounts.filter(
+    (account) =>
+      account?.siteId === sites[0].id && account?.username === expected.username
+  )
+  if (accounts.length !== 1 || !positiveId(accounts[0].id)) {
+    throw new Error(
+      'expected exactly one acceptance account on the target site'
+    )
+  }
+  return {
+    accountId: accounts[0].id,
+    username: accounts[0].username,
+    siteName: sites[0].name,
+    siteUrl: sites[0].url,
+  }
+}
+
+export function readCheckinPage(payload, target) {
+  if (
+    !Array.isArray(payload?.items) ||
+    !Number.isSafeInteger(payload.total) ||
+    payload.total < payload.items.length ||
+    !positiveId(payload.page) ||
+    !positiveId(payload.pageSize) ||
+    payload.items.length > payload.pageSize
+  ) {
+    throw new Error('malformed check-in logs page')
+  }
+  const ids = new Set()
+  for (const row of payload.items) {
+    const log = row?.checkin_logs
+    if (
+      !positiveId(log?.id) ||
+      !positiveId(log?.accountId) ||
+      !checkinStatuses.has(log?.status) ||
+      typeof log?.createdAt !== 'string' ||
+      !Number.isFinite(Date.parse(log.createdAt)) ||
+      (log.message !== null && typeof log.message !== 'string') ||
+      (log.reward !== null && typeof log.reward !== 'string') ||
+      ids.has(log.id)
+    ) {
+      throw new Error('malformed check-in log')
+    }
+    ids.add(log.id)
+    if (
+      log.accountId !== target.accountId ||
+      row.accounts?.id !== target.accountId ||
+      row.accounts?.username !== target.username ||
+      row.sites?.name !== target.siteName ||
+      siteUrl(row.sites?.url) !== siteUrl(target.siteUrl)
+    ) {
+      throw new Error('check-in log belongs to a different account or site')
+    }
+  }
+  return payload
+}
+
+export function freshCheckinLog(page, cursor) {
+  if (!Number.isSafeInteger(cursor) || cursor < 0) {
+    throw new Error('invalid pre-trigger check-in cursor')
+  }
+  const fresh = page.items.filter((row) => row.checkin_logs.id > cursor)
+  if (fresh.length > 1) {
+    throw new Error('ambiguous new check-in logs for the target account')
+  }
+  return fresh[0] ?? null
+}
+
+export function checkinRunStatus(payload, target) {
+  if (
+    payload?.status !== 'completed' ||
+    payload.queued !== false ||
+    !Array.isArray(payload.results)
+  ) {
+    throw new Error('malformed check-in trigger response')
+  }
+  // CheckinAllResult currently has no JSON tags: these wire fields are Go-cased.
+  const results = payload.results.filter(
+    (entry) =>
+      entry?.AccountID === target.accountId &&
+      entry.Username === target.username &&
+      entry.Site === target.siteName
+  )
+  if (
+    results.length !== 1 ||
+    !checkinStatuses.has(results[0]?.Result?.Status)
+  ) {
+    throw new Error(
+      'check-in trigger has no unique valid result for the target account'
+    )
+  }
+  return results[0].Result.Status
+}
+
+export function checkinVerdict(row, ui, runStatus, expected = '0') {
+  if (expected !== '0' && expected !== '1') {
+    throw new Error('ACCEPT_EXPECT_CHECKIN must be 0 or 1')
+  }
+  if (!row) throw new Error('no fresh check-in log for the target account')
+  const log = row.checkin_logs
+  if (!checkinStatuses.has(log.status) || log.status !== runStatus) {
+    throw new Error(
+      'fresh check-in log does not match the UI-triggered run status'
+    )
+  }
+  if (
+    ui?.id !== log.id ||
+    ui.account !== row.accounts.username ||
+    ui.site !== row.sites.name ||
+    siteUrl(ui.siteUrl) !== siteUrl(row.sites.url) ||
+    ui.tableStatus !== checkinLabels[log.status] ||
+    ui.detailStatus !== checkinLabels[log.status]
+  ) {
+    throw new Error(
+      `UI does not show check-in log #${log.id} with its real result`
+    )
+  }
+  if (log.status === 'success') return 'PASS'
+  if (log.status === 'skipped' && expected === '0') return 'SKIP'
+  throw new Error(
+    `check-in log #${log.id}: ${log.status}; a successful check-in was required`
+  )
+}
+
+export function readAccountTokens(payload, accountId) {
+  if (!Array.isArray(payload)) {
+    throw new Error('malformed account tokens response')
+  }
+  for (const token of payload) {
+    if (
+      !positiveId(token?.id) ||
+      token.accountId !== accountId ||
+      typeof token.name !== 'string' ||
+      typeof token.enabled !== 'boolean' ||
+      typeof token.isDefault !== 'boolean' ||
+      !['ready', 'masked_pending'].includes(token.valueStatus)
+    ) {
+      throw new Error('malformed or wrong-account token metadata')
+    }
+  }
+  // Retain only non-secret evidence. In particular, never read /:id/value.
+  return payload.map(
+    ({ id, accountId, name, valueStatus, enabled, isDefault }) => ({
+      id,
+      accountId,
+      name,
+      valueStatus,
+      enabled,
+      isDefault,
+    })
+  )
+}
+
+export function readyAccountToken(tokens) {
+  const ready = tokens.filter(
+    (token) => token.valueStatus === 'ready' && token.enabled === true
+  )
+  return ready.find((token) => token.isDefault) ?? ready[0] ?? null
+}
+
+export function freshUpstreamToken(payload, before, accountId, name) {
+  if (
+    payload?.success !== true ||
+    payload.synced !== true ||
+    !Number.isSafeInteger(payload.created) ||
+    payload.created < 1
+  ) {
+    throw new Error('UI submission did not create and sync an upstream token')
+  }
+  const [token] = readAccountTokens([payload.token], accountId)
+  if (
+    !readyAccountToken([token]) ||
+    !token.isDefault ||
+    token.name !== name ||
+    before.some((entry) => entry.id === token.id)
+  ) {
+    throw new Error(
+      'UI submission did not return a fresh ready/default upstream token'
+    )
+  }
+  return token
+}
+
+// The channel endpoint exposes DB booleans: true on PG, 1 on SQLite.
+export function requireTokenChannel(channels, accountId, tokenId) {
+  if (
+    !positiveId(accountId) ||
+    !positiveId(tokenId) ||
+    !Array.isArray(channels) ||
+    !channels.some(
+      (channel) =>
+        channel?.accountId === accountId &&
+        channel.tokenId === tokenId &&
+        (channel.enabled === true || channel.enabled === 1)
+    )
+  ) {
+    throw new Error(
+      'route has no enabled channel bound to the verified account token'
+    )
+  }
+}

--- a/web/src/features/accounts/tokens/__tests__/tokens-panel-onboarding.test.tsx
+++ b/web/src/features/accounts/tokens/__tests__/tokens-panel-onboarding.test.tsx
@@ -1,0 +1,181 @@
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import i18n from 'i18next'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import type { AccountToken } from '../../types'
+import { TokensPanel } from '../components/tokens-panel'
+
+const mockState = vi.hoisted(() => ({
+  tokens: [] as AccountToken[],
+  create: vi.fn(),
+  update: vi.fn(),
+}))
+
+function makeToken(overrides: Partial<AccountToken> = {}): AccountToken {
+  return {
+    id: 9,
+    accountId: 1,
+    name: 'relay key',
+    token: '',
+    tokenMasked: 'sk-…abc',
+    tokenGroup: null,
+    valueStatus: 'normal',
+    source: '',
+    enabled: true,
+    isDefault: false,
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  } as AccountToken
+}
+
+vi.mock('../api', () => ({
+  accountTokenQueryKeys: {
+    all: ['account-tokens'] as const,
+    list: (accountId?: number) =>
+      ['account-tokens', 'list', accountId ?? 'all'] as const,
+  },
+  useAccountTokens: () => ({ data: mockState.tokens, isLoading: false }),
+  useCreateAccountToken: () => ({
+    mutateAsync: mockState.create,
+    isPending: false,
+  }),
+  useUpdateAccountToken: () => ({
+    mutateAsync: mockState.update,
+    isPending: false,
+  }),
+  useSetDefaultAccountToken: () => ({ mutate: vi.fn(), isPending: false }),
+  useSyncAccountTokens: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useToggleAccountTokenEnabled: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../../api', () => ({
+  accountQueryKeys: { all: ['accounts'] as const },
+}))
+
+vi.mock('@/lib/api', () => ({ api: { deleteAccountToken: vi.fn() } }))
+
+vi.mock('@/lib/undoable-delete', () => ({ useUndoableDelete: () => vi.fn() }))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+afterEach(() => cleanup())
+afterAll(() => vi.restoreAllMocks())
+
+const text = (key: string) => String(i18n.t(key))
+
+beforeEach(() => {
+  mockState.tokens = []
+  mockState.create.mockReset().mockResolvedValue({ success: true })
+  mockState.update.mockReset().mockResolvedValue({ success: true })
+})
+
+describe('account token onboarding', () => {
+  it('submits an upstream creation without requiring a pasted value', async () => {
+    render(<TokensPanel accountId={7} />)
+    fireEvent.click(
+      screen.getByRole('button', { name: text('accounts.tokens.add') })
+    )
+    fireEvent.change(screen.getByLabelText(text('accounts.tokens.form.name')), {
+      target: { value: 'upstream relay' },
+    })
+    expect(
+      screen.getByText(text('accounts.tokens.form.createValueHint'))
+    ).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', { name: text('accounts.tokens.form.create') })
+    )
+    await waitFor(() => expect(mockState.create).toHaveBeenCalledTimes(1))
+    expect(mockState.create.mock.calls[0][0]).toMatchObject({
+      accountId: 7,
+      name: 'upstream relay',
+      group: 'default',
+      unlimitedQuota: true,
+    })
+    expect(mockState.create.mock.calls[0][0]).not.toHaveProperty('token')
+  })
+
+  it('can edit metadata while leaving the stored secret unchanged', async () => {
+    mockState.tokens = [makeToken()]
+    render(<TokensPanel accountId={1} />)
+    fireEvent.click(screen.getByTitle(text('accounts.tokens.edit')))
+    fireEvent.change(screen.getByLabelText(text('accounts.tokens.form.name')), {
+      target: { value: 'renamed relay' },
+    })
+    expect(
+      screen.queryByLabelText(text('accounts.tokens.form.quota'))
+    ).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: text('common.save') }))
+    await waitFor(() => expect(mockState.update).toHaveBeenCalledTimes(1))
+    expect(mockState.update).toHaveBeenCalledWith({
+      id: 9,
+      payload: { name: 'renamed relay', group: 'default' },
+    })
+  })
+
+  it('hides non-operative limits when importing an existing value', () => {
+    render(<TokensPanel accountId={7} />)
+    fireEvent.click(
+      screen.getByRole('button', { name: text('accounts.tokens.add') })
+    )
+    expect(
+      screen.getByLabelText(text('accounts.tokens.form.quota'))
+    ).toBeInTheDocument()
+    fireEvent.change(
+      screen.getByLabelText(text('accounts.tokens.form.value')),
+      {
+        target: { value: 'existing-relay-value' },
+      }
+    )
+    expect(
+      screen.queryByLabelText(text('accounts.tokens.form.quota'))
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(text('accounts.tokens.form.expiresAt'))
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(text('accounts.tokens.form.allowedIps'))
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web/src/features/accounts/tokens/__tests__/tokens-schema.test.ts
+++ b/web/src/features/accounts/tokens/__tests__/tokens-schema.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getAccountTokenFormDefaultValues,
+  getAccountTokenFormSchema,
+  transformTokenFormToPayload,
+} from '../lib/tokens-schema'
+
+const values = () => ({
+  ...getAccountTokenFormDefaultValues(7),
+  name: 'relay token',
+})
+
+describe('account token form wire contract', () => {
+  it('requires a quota before issuing a finite upstream token', () => {
+    const result = getAccountTokenFormSchema().safeParse({
+      ...values(),
+      unlimited: false,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.error.issues[0].path).toEqual(['quota'])
+  })
+
+  it('accepts an empty value for upstream creation and keep-on-edit', () => {
+    expect(getAccountTokenFormSchema().safeParse(values()).success).toBe(true)
+    expect(transformTokenFormToPayload(values())).not.toHaveProperty('token')
+  })
+
+  it('uses the API field names and preserves an explicit finite quota', () => {
+    const payload = transformTokenFormToPayload({
+      ...values(),
+      tokenGroup: 'limited',
+      unlimited: false,
+      quota: 25000,
+      expiresAt: '2030-01-01T00:00:00Z',
+      allowedIps: '127.0.0.1, ::1  192.0.2.10',
+    })
+    expect(payload).toEqual({
+      accountId: 7,
+      name: 'relay token',
+      group: 'limited',
+      unlimitedQuota: false,
+      remainQuota: 25000,
+      expiredTime: 1893456000,
+      allowIps: '127.0.0.1,::1,192.0.2.10',
+    })
+    for (const ignored of ['tokenGroup', 'quota', 'allowedIps']) {
+      expect(payload).not.toHaveProperty(ignored)
+    }
+  })
+
+  it('does not pretend a local import configures upstream restrictions', () => {
+    expect(
+      transformTokenFormToPayload({
+        ...values(),
+        token: '  test-relay-value  ',
+        unlimited: false,
+        quota: 10,
+        allowedIps: '127.0.0.1',
+      })
+    ).toEqual({
+      accountId: 7,
+      name: 'relay token',
+      token: 'test-relay-value',
+      group: 'default',
+    })
+  })
+})

--- a/web/src/features/accounts/tokens/components/tokens-panel.tsx
+++ b/web/src/features/accounts/tokens/components/tokens-panel.tsx
@@ -305,6 +305,7 @@ function AccountTokenForm({
   })
 
   const unlimited = form.watch('unlimited')
+  const createsUpstream = !isEdit && form.watch('token').trim() === ''
 
   useEffect(() => {
     if (token) {
@@ -350,12 +351,7 @@ function AccountTokenForm({
           id: token.id,
           payload: {
             name: payload.name,
-            tokenGroup: payload.tokenGroup,
-            quota: payload.quota,
-            remainQuota: payload.remainQuota,
-            unlimitedQuota: payload.unlimitedQuota,
-            expiredTime: payload.expiredTime,
-            allowedIps: payload.allowedIps,
+            group: payload.group,
             ...(values.token ? { token: values.token } : {}),
           },
         })
@@ -413,14 +409,16 @@ function AccountTokenForm({
                     placeholder={
                       isEdit
                         ? t('accounts.tokens.form.valuePlaceholder')
-                        : 'sk-...'
+                        : t('accounts.tokens.form.createValuePlaceholder')
                     }
                     {...field}
                     value={field.value ?? ''}
                   />
                 </FormControl>
                 <FormDescription>
-                  {isEdit ? t('accounts.tokens.form.valueHint') : undefined}
+                  {isEdit
+                    ? t('accounts.tokens.form.valueHint')
+                    : t('accounts.tokens.form.createValueHint')}
                 </FormDescription>
                 <FormMessage />
               </FormItem>
@@ -446,94 +444,106 @@ function AccountTokenForm({
               )}
             />
 
-            <FormField
-              control={form.control}
-              name='quota'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('accounts.tokens.form.quota')}</FormLabel>
-                  <FormControl>
-                    <Input
-                      type='number'
-                      placeholder={t('accounts.tokens.form.quotaPlaceholder')}
-                      disabled={unlimited}
-                      value={field.value ?? ''}
-                      onChange={(event) =>
-                        field.onChange(
-                          event.target.value === ''
-                            ? undefined
-                            : Number(event.target.value)
-                        )
-                      }
-                      onBlur={field.onBlur}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-
-          <FormField
-            control={form.control}
-            name='unlimited'
-            render={({ field }) => (
-              <FormItem className='flex flex-row items-center justify-between rounded-lg border p-2.5'>
-                <div className='space-y-0.5'>
-                  <FormLabel>{t('accounts.tokens.form.unlimited')}</FormLabel>
-                  <FormDescription>
-                    {t('accounts.tokens.form.unlimitedHint')}
-                  </FormDescription>
-                </div>
-                <FormControl>
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                  />
-                </FormControl>
-              </FormItem>
+            {createsUpstream && (
+              <FormField
+                control={form.control}
+                name='quota'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('accounts.tokens.form.quota')}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type='number'
+                        placeholder={t('accounts.tokens.form.quotaPlaceholder')}
+                        disabled={unlimited}
+                        value={field.value ?? ''}
+                        onChange={(event) =>
+                          field.onChange(
+                            event.target.value === ''
+                              ? undefined
+                              : Number(event.target.value)
+                          )
+                        }
+                        onBlur={field.onBlur}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             )}
-          />
-
-          <div className='grid grid-cols-2 gap-3'>
-            <FormField
-              control={form.control}
-              name='expiresAt'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('accounts.tokens.form.expiresAt')}</FormLabel>
-                  <FormControl>
-                    <Input
-                      type='datetime-local'
-                      {...field}
-                      value={field.value ?? ''}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name='allowedIps'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('accounts.tokens.form.allowedIps')}</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={t(
-                        'accounts.tokens.form.allowedIpsPlaceholder'
-                      )}
-                      {...field}
-                      value={field.value ?? ''}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
           </div>
+
+          {createsUpstream && (
+            <>
+              <FormField
+                control={form.control}
+                name='unlimited'
+                render={({ field }) => (
+                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-2.5'>
+                    <div className='space-y-0.5'>
+                      <FormLabel>
+                        {t('accounts.tokens.form.unlimited')}
+                      </FormLabel>
+                      <FormDescription>
+                        {t('accounts.tokens.form.unlimitedHint')}
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <div className='grid grid-cols-2 gap-3'>
+                <FormField
+                  control={form.control}
+                  name='expiresAt'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        {t('accounts.tokens.form.expiresAt')}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          type='datetime-local'
+                          {...field}
+                          value={field.value ?? ''}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='allowedIps'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        {t('accounts.tokens.form.allowedIps')}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder={t(
+                            'accounts.tokens.form.allowedIpsPlaceholder'
+                          )}
+                          {...field}
+                          value={field.value ?? ''}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </>
+          )}
 
           <div className='flex justify-end gap-2'>
             <Button

--- a/web/src/features/accounts/tokens/lib/tokens-schema.ts
+++ b/web/src/features/accounts/tokens/lib/tokens-schema.ts
@@ -10,29 +10,37 @@ import { z } from 'zod'
 // ---------------------------------------------------------------------------
 
 export function getAccountTokenFormSchema() {
-  return z.object({
-    accountId: z
-      .number({ message: 'accounts.tokens.schema.accountRequired' })
-      .int({ message: 'accounts.tokens.schema.accountRequired' })
-      .positive({ message: 'accounts.tokens.schema.accountRequired' }),
-    name: z
-      .string({ message: 'accounts.tokens.schema.nameRequired' })
-      .trim()
-      .min(1, { message: 'accounts.tokens.schema.nameRequired' })
-      .max(120, { message: 'accounts.tokens.schema.nameTooLong' }),
-    token: z
-      .string({ message: 'accounts.tokens.schema.valueRequired' })
-      .trim()
-      .min(1, { message: 'accounts.tokens.schema.valueRequired' }),
-    tokenGroup: z.string().trim().optional(),
-    quota: z
-      .number()
-      .nonnegative({ message: 'accounts.tokens.schema.quotaNonNegative' })
-      .optional(),
-    unlimited: z.boolean(),
-    expiresAt: z.string().trim().optional(),
-    allowedIps: z.string().trim().optional(),
-  })
+  return z
+    .object({
+      accountId: z
+        .number({ message: 'accounts.tokens.schema.accountRequired' })
+        .int({ message: 'accounts.tokens.schema.accountRequired' })
+        .positive({ message: 'accounts.tokens.schema.accountRequired' }),
+      name: z
+        .string({ message: 'accounts.tokens.schema.nameRequired' })
+        .trim()
+        .min(1, { message: 'accounts.tokens.schema.nameRequired' })
+        .max(120, { message: 'accounts.tokens.schema.nameTooLong' }),
+      // An empty value creates a token upstream on add, or preserves it on edit.
+      token: z.string().trim(),
+      tokenGroup: z.string().trim().optional(),
+      quota: z
+        .number()
+        .nonnegative({ message: 'accounts.tokens.schema.quotaNonNegative' })
+        .optional(),
+      unlimited: z.boolean(),
+      expiresAt: z.string().trim().optional(),
+      allowedIps: z.string().trim().optional(),
+    })
+    .superRefine((values, ctx) => {
+      if (!values.token && !values.unlimited && values.quota === undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['quota'],
+          message: 'accounts.tokens.schema.quotaRequired',
+        })
+      }
+    })
 }
 
 export type AccountTokenFormValues = z.infer<
@@ -65,39 +73,37 @@ export function getAccountTokenFormDefaultValues(
 export interface AccountTokenPayload {
   accountId: number
   name: string
-  token: string
-  tokenGroup?: string
-  quota?: number
+  token?: string
+  group?: string
   remainQuota?: number
   unlimitedQuota?: boolean
   expiredTime?: number
-  modelLimitsEnabled?: boolean
-  allowedIps?: string[]
+  allowIps?: string
 }
 
 export function transformTokenFormToPayload(
   values: AccountTokenFormValues
 ): AccountTokenPayload {
-  const allowedIps = values.allowedIps
-    ? values.allowedIps
-        .split(/[,，\s]+/)
-        .map((ip) => ip.trim())
-        .filter(Boolean)
-    : undefined
-
-  const expiredTime = values.expiresAt
-    ? Math.floor(new Date(values.expiresAt).getTime() / 1000)
-    : undefined
-
-  return {
+  const base = {
     accountId: values.accountId,
     name: values.name,
-    token: values.token,
-    tokenGroup: values.tokenGroup || undefined,
-    quota: values.unlimited ? undefined : values.quota,
+    group: values.tokenGroup || undefined,
+  }
+  // A pasted value is a local import. Its upstream limits are not changed.
+  if (values.token.trim()) return { ...base, token: values.token.trim() }
+
+  return {
+    ...base,
     remainQuota: values.unlimited ? undefined : values.quota,
-    unlimitedQuota: values.unlimited || undefined,
-    expiredTime,
-    allowedIps,
+    unlimitedQuota: values.unlimited,
+    expiredTime: values.expiresAt
+      ? Math.floor(new Date(values.expiresAt).getTime() / 1000)
+      : undefined,
+    allowIps: values.allowedIps
+      ? values.allowedIps
+          .split(/[,，\s]+/)
+          .filter(Boolean)
+          .join(',')
+      : undefined,
   }
 }

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
@@ -34,8 +34,8 @@ import {
   vi,
 } from 'vitest'
 
-import '@/i18n/config'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
+import i18n from '@/i18n/config'
 
 import { KeyModelPolicyCell, KeySheetForm, KeyUsageCell } from '../keys-section'
 
@@ -577,6 +577,28 @@ describe('KeyUsageCell — 24h usage line', () => {
     expect(
       screen.getByText('24h: 1 req · 42 tok · $0.044216')
     ).toBeInTheDocument()
+  })
+
+  it('renders costs for the Chinese interface language code', async () => {
+    const previousLanguage = i18n.language
+    try {
+      await i18n.changeLanguage('zhCN')
+      render(
+        <KeyUsageCell
+          item={{
+            ...baseItem,
+            usedCost: 0.044216000000000005,
+            maxCost: 0.30000000000000004,
+          }}
+        />
+      )
+      expect(
+        screen.getByText('成本：$0.044216 / $0.300000')
+      ).toBeInTheDocument()
+    } finally {
+      cleanup()
+      await i18n.changeLanguage(previousLanguage)
+    }
   })
 
   it('keeps a zero cost limit distinct from an unlimited limit', () => {

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
@@ -532,7 +532,7 @@ describe('KeySheetForm — dirty reporting', () => {
 })
 
 // KeyUsageCell locks the 24h usage line rendering: when the backend returns
-// usage24h the requests/tokens/cost surface verbatim; when the field is
+// usage24h the requests/tokens and formatted USD costs surface; when the field is
 // absent (older server or failed aggregate) the line degrades to zeros
 // instead of rendering "undefined".
 describe('KeyUsageCell — 24h usage line', () => {
@@ -557,14 +557,44 @@ describe('KeyUsageCell — 24h usage line', () => {
     )
 
     expect(
-      screen.getByText('24h: 7 req · 1234 tok · $0.42')
+      screen.getByText('24h: 7 req · 1234 tok · $0.420000')
     ).toBeInTheDocument()
+  })
+
+  it('formats fractional costs without exposing floating-point tails', () => {
+    render(
+      <KeyUsageCell
+        item={{
+          ...baseItem,
+          usedCost: 0.044216000000000005,
+          maxCost: 0.30000000000000004,
+          usage24h: { requests: 1, tokens: 42, cost: 0.044216000000000005 },
+        }}
+      />
+    )
+
+    expect(screen.getByText('Cost: $0.044216 / $0.300000')).toBeInTheDocument()
+    expect(
+      screen.getByText('24h: 1 req · 42 tok · $0.044216')
+    ).toBeInTheDocument()
+  })
+
+  it('keeps a zero cost limit distinct from an unlimited limit', () => {
+    const { rerender } = render(
+      <KeyUsageCell item={{ ...baseItem, maxCost: 0 }} />
+    )
+    expect(screen.getByText('Cost: $2.000000 / $0.000000')).toBeInTheDocument()
+
+    rerender(<KeyUsageCell item={{ ...baseItem, maxCost: null }} />)
+    expect(screen.getByText('Cost: $2.000000 / unlimited')).toBeInTheDocument()
   })
 
   it('falls back to zeros when usage24h is absent', () => {
     render(<KeyUsageCell item={baseItem} />)
 
-    expect(screen.getByText('24h: 0 req · 0 tok · $0')).toBeInTheDocument()
+    expect(
+      screen.getByText('24h: 0 req · 0 tok · $0.000000')
+    ).toBeInTheDocument()
   })
 })
 

--- a/web/src/features/settings/sections/downstream/components/key-cells.tsx
+++ b/web/src/features/settings/sections/downstream/components/key-cells.tsx
@@ -1,9 +1,9 @@
 // metapi-go/features/settings/sections/downstream — downstream-key table
-// cell renderers (model policy summary badge, quota + 24h usage). Split out
-// of keys-section.tsx (S8 giant-file teardown); behavior is unchanged.
+// cell renderers (model policy summary badge, quota + 24h usage).
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
+import { formatCurrency } from '@/lib/format'
 
 import { parseIdArray } from '../lib/credential-refs'
 import {
@@ -62,7 +62,8 @@ export function KeyModelPolicyCell({
 // Exported so the usage-cell test can render it in isolation (same pattern as
 // KeySheetForm). Renders quota usage plus the per-key 24h proxy_logs summary.
 export function KeyUsageCell({ item }: { item: DownstreamApiKeyItem }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+  const moneyOptions = { fractionDigits: 6, locale: i18n.language }
   return (
     <div>
       <div>
@@ -73,15 +74,18 @@ export function KeyUsageCell({ item }: { item: DownstreamApiKeyItem }) {
       </div>
       <div>
         {t('settings.downstream.keys.cost', {
-          used: item.usedCost ?? 0,
-          max: item.maxCost ?? t('settings.common.unlimited'),
+          used: formatCurrency(item.usedCost ?? 0, moneyOptions),
+          max:
+            item.maxCost == null
+              ? t('settings.common.unlimited')
+              : formatCurrency(item.maxCost, moneyOptions),
         })}
       </div>
       <div className='mt-1 border-t pt-1'>
         {t('settings.downstream.keys.usage24h', {
           requests: item.usage24h?.requests ?? 0,
           tokens: item.usage24h?.tokens ?? 0,
-          cost: item.usage24h?.cost ?? 0,
+          cost: formatCurrency(item.usage24h?.cost ?? 0, moneyOptions),
         })}
       </div>
     </div>

--- a/web/src/features/settings/sections/downstream/components/key-cells.tsx
+++ b/web/src/features/settings/sections/downstream/components/key-cells.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
+import { toBcp47 } from '@/i18n/languages'
 import { formatCurrency } from '@/lib/format'
 
 import { parseIdArray } from '../lib/credential-refs'
@@ -63,7 +64,7 @@ export function KeyModelPolicyCell({
 // KeySheetForm). Renders quota usage plus the per-key 24h proxy_logs summary.
 export function KeyUsageCell({ item }: { item: DownstreamApiKeyItem }) {
   const { t, i18n } = useTranslation()
-  const moneyOptions = { fractionDigits: 6, locale: i18n.language }
+  const moneyOptions = { fractionDigits: 6, locale: toBcp47(i18n.language) }
   return (
     <div>
       <div>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1357,7 +1357,7 @@
           "empty": "No API keys yet. Create one to start issuing.",
           "requests": "Requests: {{used}} / {{max}}",
           "cost": "Cost: {{used}} / {{max}}",
-          "usage24h": "24h: {{requests}} req · {{tokens}} tok · ${{cost}}",
+          "usage24h": "24h: {{requests}} req · {{tokens}} tok · {{cost}}",
           "columns": {
             "name": "Name",
             "group": "Group",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2082,6 +2082,8 @@
           "value": "Token value",
           "valuePlaceholder": "Leave empty to keep unchanged",
           "valueHint": "Leave empty on edit to keep the token value unchanged",
+          "createValuePlaceholder": "Leave empty to create on the upstream site",
+          "createValueHint": "Leave empty to create an upstream token with the limits below. Paste an existing token to store it locally; its upstream limits stay unchanged.",
           "group": "Group",
           "groupPlaceholder": "default",
           "quota": "Quota",
@@ -2111,7 +2113,7 @@
           "accountRequired": "Please select an account",
           "nameRequired": "Please enter a token name",
           "nameTooLong": "Token name is too long",
-          "valueRequired": "Please enter a token value",
+          "quotaRequired": "Enter a quota when unlimited quota is off",
           "quotaNonNegative": "Quota must be a non-negative number"
         }
       },

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2082,6 +2082,8 @@
           "value": "令牌值",
           "valuePlaceholder": "留空保持不变",
           "valueHint": "编辑时留空表示不修改令牌值",
+          "createValuePlaceholder": "留空将在上游站点创建令牌",
+          "createValueHint": "留空会按下方限额在上游创建令牌。粘贴已有令牌仅在本地保存，不会修改它在上游的限额。",
           "group": "分组",
           "groupPlaceholder": "默认",
           "quota": "额度",
@@ -2111,7 +2113,7 @@
           "accountRequired": "请选择所属账号",
           "nameRequired": "请填写令牌名称",
           "nameTooLong": "令牌名称过长",
-          "valueRequired": "请填写令牌值",
+          "quotaRequired": "关闭无限额度时请填写额度",
           "quotaNonNegative": "额度需为非负数"
         }
       },

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1357,7 +1357,7 @@
           "empty": "暂无 API 密钥。创建一个以开始签发。",
           "requests": "请求：{{used}} / {{max}}",
           "cost": "成本：{{used}} / {{max}}",
-          "usage24h": "24h：{{requests}} 次 · {{tokens}} tokens · ${{cost}}",
+          "usage24h": "24h：{{requests}} 次 · {{tokens}} tokens · {{cost}}",
           "columns": {
             "name": "名称",
             "group": "分组",


### PR DESCRIPTION
## Summary
- Support NewAPI's advertised password step-up before durable PAT issuance without disabling security verification.
- Let fresh accounts create upstream relay tokens through the UI; preserve secrets on metadata-only edits and use the actual group/IP/finite-quota API fields.
- Persist model inventories after single/session and batch API-key imports, with explicit no-probe/partial-initialization results.
- Prefer native check-in awards over uninitialized balance deltas; already-complete check-ins remain successful with no new reward.
- Correct decoded chat-family JSON with mislabelled text media types, without rewriting downloads or opaque encodings.
- Make login/import/browser/protocol verdicts strict. Test both fresh routes and existing public aliases, isolate curl from host configuration, and expose bounded terminal diagnostics without response text or tool arguments.
- Format downstream-key costs with the shared USD formatter; preserve six-decimal precision and normalize the Chinese interface locale through the existing locale helper.

Closes #1272
Closes #1274
Closes #1275
Closes #1276

Supersedes #1273, whose narrower check-in-verdict fix is included.

## Local verification
- Complete Go build/vet/SQLite race/PostgreSQL gates passed. Go/dependency source hashes remain unchanged; the affected embedded-web/app/server race checks were additionally rerun after the final UI build.
- Complete frontend suite passed, followed by focused key-rendering and shared-locale regressions for the last locale correction. Final typecheck/lint/format/Knip/build all passed.
- Shell positive/negative controls, 39 Python protocol tests, 23 Node evidence tests, documentation contracts, actionlint and leak guard passed.
- Known-bad implementations fail the added gates; restored source hashes match. No local gate was waived.

## Real-service and browser evidence
- Official NewAPI v1.0.0-rc.34, with disposable users/databases and a real provider.
- Fresh-account UI: 9 PASS, 0 FAIL, 1 explicitly optional deterministic-request-log SKIP. Login, actual check-in, visible models, UI upstream-token creation, route/key issuance and a real completion passed.
- Check-in independently reconciles +1,000 upstream quota units with the displayed 0.002 reward.
- Isolated password-login smoke: 14 PASS / 0 WARN / 0 SKIP / 0 FAIL.
- Isolated API-key first import: persisted inventory and real relay pass without manual refresh/rebuild; API-key-only check-in is correctly SKIP.
- Codex CLI 0.147.0 completes exactly one read-only shell tool invocation and returns its actual result, 10063.
- 41 desktop + 19 mobile route/interaction checks; 41 routes × 2 locales with zero serious/critical accessibility violations; 112 full-sweep screenshots plus 8 final cost-page locale/theme/viewport cases.
- Final application binary is built from `19cf5e93`; the subsequent commit only adds protocol-diagnostic code/tests/docs. Separate read-only consumption records corroborate actual provider traffic.

## Explicit residuals — not greenwashed
The provider's native terminal fields are inconsistent, reproduced directly and through both relay hops:
- Chat SSE sends empty-string `finish_reason` values before its terminal frame.
- Chat tool responses contain tool calls but end with `finish_reason: stop`.
- Anthropic tool responses contain `tool_use` blocks but end with `stop_reason: end_turn`.

The latest strict run fails those three scenarios. Earlier Chat passes do not establish stability. Responses JSON/SSE/tool roundtrips and the real Codex client pass. Validation was not relaxed, and no automatic retry is used to turn the failures green.

The existing Responses-only configuration explicitly rejects Messages conversion with HTTP 400, so it is not claimed as a workaround. The deterministic upstream-log subcheck remains SKIP rather than being replaced with a fabricated request log.

No version tag, GitHub Release or production runtime deployment is part of this change. The existing master/`:latest` workflow policy is unchanged.