### PR TITLE
fix(proxy): preserve native tool completion and verify streamed tool replay

### DIFF
--- a/docs/client-integration.md
+++ b/docs/client-integration.md
@@ -81,3 +81,16 @@ request** shortcut into the model tester.
 
 See [`api.md`](api.md) for the full endpoint inventory and
 [`getting-started.md`](getting-started.md) for the first-request walkthrough.
+
+## Native tool response compatibility
+
+For OpenAI Chat Completions and Anthropic Messages, complete native tool calls
+are returned with their protocol-specific tool termination reason. A provider's
+ordinary `stop` or `end_turn` is corrected only when all observed tool arguments
+form complete JSON objects; streamed tool blocks must also be closed. Empty
+Chat streaming finish reasons become `null` on non-terminal chunks.
+
+This does not turn errors, token-limit endings, refusals, malformed arguments,
+or interrupted streams into success. Reasoning/signatures, tool identifiers,
+arguments, usage and provider extension fields remain intact. Non-chat APIs,
+attachments and undecodable representations are not rewritten.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -145,7 +145,7 @@ fixtures, plus `decision` (policy truth tables) and `unit` (leaf helpers).
 | `transform/gemini/generate_content` | OpenAI→Gemini request conversion (tool calls + thought signatures, multimodal placeholders, thinking config) + Gemini request normalization |
 | `transform/openai/completions`, `transform/openai/embeddings`, `transform/openai/images` | Pass-through identity contract (request/response/stream bytes unchanged) |
 | `transform/shared` | Leaf helper edge cases |
-| `handler/proxy` | Response-body usage extraction and incremental SSE stream parsing (usage/finish/error/done state, chunk-boundary independence). In this codebase the response/stream half of protocol handling lives here: SSE streams are relayed byte-for-byte and only parsed for accounting. |
+| `handler/proxy` | Response-body usage extraction and incremental SSE stream parsing (usage/finish/error/done state, chunk-boundary independence). In this codebase the response/stream half of protocol handling lives here: SSE bytes are generally preserved, except the documented native Chat/Messages complete-tool termination and empty Chat finish normalization ([`client-integration.md#native-tool-response-compatibility`](client-integration.md#native-tool-response-compatibility)); attachment responses and frames after `[DONE]` are left untouched. |
 
 Run the suite like any other test (it is part of `go test ./...` and therefore
 part of CI):
@@ -220,15 +220,24 @@ than putting it in a command line, shell history, or committed file.
 
 ```bash
 python3 scripts/e2e/verify-real-relay.py --protocol all --timeout 120 --max-tokens 256
+python3 scripts/e2e/verify-real-relay.py --tool-stream --protocol all --timeout 120 --max-tokens 256
 ```
 
 Each protocol checks JSON, SSE completion, and a complete echo-tool/result
-roundtrip. The tool result contains a fresh receipt that must appear in the final
-answer; merely announcing a tool call is not sufficient. The command makes at
-most 12 model POSTs, performs no automatic retries, and can incur upstream usage.
-It prints metadata only and exits nonzero for any failed scenario. Tool streaming
-is not covered by this runner; exercise a real downstream CLI separately when
-that client contract is part of the release scope.
+roundtrip. With `--tool-stream`, it additionally exercises a streamed echo-tool
+call with reassembly of fragmented arguments, then a streamed result followup; the
+tool result contains a fresh receipt that must appear in the final answer, and
+merely announcing a tool call is not sufficient. Without the flag the default
+scenarios and 12-POST budget are unchanged. The streamed result followup must
+preserve the same native replay context as the non-stream contract: Chat
+`reasoning_content`, Messages thinking (including signature), and Responses
+reasoning items. Unsupported stream events and unsupported reasoning deltas
+fail explicitly. The command makes at most 12 model POSTs by default (18 with
+`--tool-stream`), performs no automatic retries, and can incur upstream usage.
+It prints metadata only and exits nonzero for any failed scenario. Offline
+validator fixtures are instrument checks, not a substitute for a live `--tool-stream` run when claiming real streaming-tool
+coverage; a real downstream CLI contract still needs a separate exercise when it
+is part of the release scope.
 
 A passing client report does not identify the physical upstream provider. Pair it
 with verified test configuration, model request IDs, and gateway/Metapi logs for

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -764,6 +764,9 @@ func dispatchEndpointAttemptWithContinue(
 	}
 	recordUpstreamSuccess(r.Context(), cfg, selected, ctx.RequestedModel, upstreamModel, latencyMs, usage)
 	writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry, requestID)
+	if body.readable {
+		respBody = normalizeNativeTerminalResponse(resp, respBody, r.URL.Path)
+	}
 	// Videos create: map upstream id → publicId before the client sees the body.
 	respBody = maybeRewriteVideosCreateResponse(ctx, selected, upstreamPath, respBody)
 	relayBufferedUpstreamResponse(w, resp, respBody)

--- a/handler/proxy/upstream_stream.go
+++ b/handler/proxy/upstream_stream.go
@@ -118,6 +118,9 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 	idleBody := &streamIdleBody{ReadCloser: resp.Body}
 	idleBody.guard = newStreamIdleGuard(idleTimeout, idleBody.closeUnderlying)
 	resp.Body = idleBody
+	if bodyReadable && !strings.HasPrefix(strings.ToLower(resp.Header.Get("Content-Disposition")), "attachment") {
+		resp.Body = withNativeTerminalBody(resp.Body, r.URL.Path)
+	}
 
 	analyzer := newIncrementalSseAnalyzer()
 	sawStreamBytes := false

--- a/handler/proxy/upstream_terminal.go
+++ b/handler/proxy/upstream_terminal.go
@@ -1,0 +1,152 @@
+package proxyhandler
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/deliciousbuding/metapi-go/proxy"
+	transformshared "github.com/deliciousbuding/metapi-go/transform/shared"
+)
+
+func nativeTerminalProtocol(path string) transformshared.NativeTerminalProtocol {
+	endpoint, ok := proxy.EndpointFromPath(path)
+	if !ok {
+		return 0
+	}
+	switch endpoint {
+	case proxy.EndpointChat:
+		return transformshared.NativeChatCompletions
+	case proxy.EndpointMessages:
+		return transformshared.NativeMessages
+	default:
+		return 0
+	}
+}
+
+// This reader sits after decoding and the existing upstream idle guard. It holds
+// at most one bounded SSE frame, preserves untouched framing/metadata verbatim,
+// and never appends a terminal event at EOF or hides an underlying read error.
+type nativeTerminalBody struct {
+	io.ReadCloser
+	normalizer  transformshared.NativeTerminalStream
+	pending     []byte
+	output      []byte
+	end         error
+	passthrough bool
+	readBuf     [4096]byte
+}
+
+func withNativeTerminalBody(body io.ReadCloser, path string) io.ReadCloser {
+	protocol := nativeTerminalProtocol(path)
+	if protocol == 0 {
+		return body
+	}
+	return &nativeTerminalBody{ReadCloser: body, normalizer: transformshared.NativeTerminalStream{Protocol: protocol}}
+}
+
+func (b *nativeTerminalBody) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	for len(b.output) == 0 {
+		if b.end != nil {
+			return 0, b.end
+		}
+		n, err := b.ReadCloser.Read(b.readBuf[:])
+		if b.passthrough {
+			b.output = append(b.output, b.readBuf[:n]...)
+		} else {
+			b.pending = append(b.pending, b.readBuf[:n]...)
+			for {
+				boundary, sepLen := nextSseBoundary(string(b.pending))
+				if boundary < 0 {
+					break
+				}
+				if boundary > maxIncrementalSsePendingBytes {
+					b.output = append(b.output, b.pending...)
+					b.pending = nil
+					b.passthrough = true
+					break
+				}
+				block := b.pending[:boundary]
+				b.output = append(b.output, b.normalizeBlock(block)...)
+				b.output = append(b.output, b.pending[boundary:boundary+sepLen]...)
+				b.pending = b.pending[boundary+sepLen:]
+			}
+			if len(b.pending) > maxIncrementalSsePendingBytes {
+				// Stop normalizing after an oversized frame: client-visible bytes and
+				// the existing analyzer's oversized/error verdict remain authoritative.
+				b.output = append(b.output, b.pending...)
+				b.pending = nil
+				b.passthrough = true
+			}
+		}
+		if err != nil {
+			b.output = append(b.output, b.pending...)
+			b.pending = nil
+			b.end = err
+		}
+		if n == 0 && err == nil {
+			return 0, nil
+		}
+	}
+	n := copy(p, b.output)
+	b.output = b.output[n:]
+	return n, nil
+}
+
+func (b *nativeTerminalBody) normalizeBlock(block []byte) []byte {
+	event := parseSseBlock(string(block))
+	if event == nil || event.Data == "" {
+		return block
+	}
+	raw := []byte(event.Data)
+	normalized := b.normalizer.AddData(raw)
+	if bytes.Equal(normalized, raw) {
+		return block
+	}
+	// Only the data field changes. Comments, event/id/retry and line endings
+	// retain their original order. A multiline JSON payload may become one line.
+	lines := bytes.Split(block, []byte("\n"))
+	out := make([][]byte, 0, len(lines))
+	replaced := false
+	for _, line := range lines {
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			out = append(out, line)
+			continue
+		}
+		if replaced {
+			continue
+		}
+		replaced = true
+		next := append([]byte("data: "), normalized...)
+		if bytes.HasSuffix(line, []byte("\r")) {
+			next = append(next, '\r')
+		}
+		out = append(out, next)
+	}
+	if !replaced {
+		return block
+	}
+	return bytes.Join(out, []byte("\n"))
+}
+
+func normalizeNativeTerminalResponse(resp *http.Response, body []byte, path string) []byte {
+	protocol := nativeTerminalProtocol(path)
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if protocol == 0 || err != nil || (mediaType != "application/json" && !strings.HasSuffix(mediaType, "+json")) || strings.HasPrefix(strings.ToLower(resp.Header.Get("Content-Disposition")), "attachment") {
+		return body
+	}
+	normalized := transformshared.NormalizeNativeTerminalJSON(body, protocol)
+	if !bytes.Equal(normalized, body) {
+		// Original validators and lengths describe different response bytes.
+		resp.Header.Del("Content-Length")
+		resp.Header.Del("ETag")
+		resp.Header.Del("Content-MD5")
+		resp.Header.Del("Digest")
+	}
+	return normalized
+}

--- a/handler/proxy/upstream_terminal_test.go
+++ b/handler/proxy/upstream_terminal_test.go
@@ -1,0 +1,167 @@
+package proxyhandler
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+const wireToolResponse = `{"id":"chat-1","object":"chat.completion","model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":null,"reasoning_content":"reason","tool_calls":[{"id":"call-1","type":"function","function":{"name":"echo","arguments":"{}"}}]},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13}}`
+const wireMessageTool = `{"id":"msg-1","type":"message","role":"assistant","model":"test-model","content":[{"type":"tool_use","id":"call-1","name":"echo","input":{}}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":3}}`
+
+func TestNativeToolTerminalReachesClientThroughDispatch(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, request, response, want string
+		handler                             http.HandlerFunc
+	}{
+		{"chat", "/v1/chat/completions", `{"model":"test-model","messages":[{"role":"user","content":"echo"}]}`, wireToolResponse, `"finish_reason":"tool_calls"`, HandleChatCompletions},
+		{"messages", "/v1/messages", `{"model":"test-model","max_tokens":64,"messages":[{"role":"user","content":"echo"}]}`, wireMessageTool, `"stop_reason":"tool_use"`, HandleClaudeMessages},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("ETag", "original-body")
+				_, _ = io.WriteString(w, tc.response)
+			}))
+			defer upstream.Close()
+			SetUpstreamConfig(&UpstreamConfig{Router: &upstreamTestRouter{selected: routing.SelectedChannel{Channel: store.RouteChannel{ID: 42, Enabled: true}, Account: store.Account{ID: 7, Status: "active"}, Site: store.Site{ID: 3, URL: upstream.URL, Platform: "new-api", Status: "active"}, TokenValue: "fixture-token", ActualModel: "test-model"}}})
+			defer SetUpstreamConfig(nil)
+			rec := httptest.NewRecorder()
+			tc.handler(rec, makeProxyReq("POST", tc.path, tc.request))
+			if rec.Code != 200 || !strings.Contains(rec.Body.String(), tc.want) {
+				t.Fatalf("HTTP %d: %s", rec.Code, rec.Body.String())
+			}
+			if rec.Header().Get("ETag") != "" {
+				t.Fatal("forwarded a validator for different bytes")
+			}
+		})
+	}
+}
+func TestNativeTerminalBufferedSkipsOtherRepresentations(t *testing.T) {
+	for _, tc := range []struct{ name, path, ctype, disposition string }{
+		{"download", "/v1/files/one/content", "application/json", ""},
+		{"responses", "/v1/responses", "application/json", ""},
+		{"attachment", "/v1/chat/completions", "application/json", "attachment; filename=data.json"},
+		{"binary", "/v1/chat/completions", "application/octet-stream", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{Header: make(http.Header)}
+			resp.Header.Set("Content-Type", tc.ctype)
+			resp.Header.Set("Content-Disposition", tc.disposition)
+			resp.Header.Set("ETag", "same")
+			out := normalizeNativeTerminalResponse(resp, []byte(wireToolResponse), tc.path)
+			if string(out) != wireToolResponse || resp.Header.Get("ETag") != "same" {
+				t.Fatal("modified unrelated representation")
+			}
+		})
+	}
+}
+
+type terminalChunkReader struct {
+	data   []byte
+	size   int
+	end    error
+	closed bool
+}
+
+func (r *terminalChunkReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.end
+	}
+	n := min(len(p), r.size, len(r.data))
+	copy(p, r.data[:n])
+	r.data = r.data[n:]
+	return n, nil
+}
+func (r *terminalChunkReader) Close() error { r.closed = true; return nil }
+func TestNativeTerminalSSEFramingAcrossEveryByte(t *testing.T) {
+	input := ": comment\r\nevent: message\r\nid: one\r\nretry: 250\r\ndata: {\"id\":\"one\",\"object\":\"chat.completion.chunk\",\"choices\":[\r\ndata: {\"index\":0,\"delta\":{\"content\":\"你好\"},\"finish_reason\":\"\"}]}\r\n\r\ndata: [DONE]\r\n\r\n"
+	for _, size := range []int{1, 2, 7, 4096} {
+		source := &terminalChunkReader{data: []byte(input), size: size, end: io.EOF}
+		reader := withNativeTerminalBody(source, "/v1/chat/completions")
+		out, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Contains(out, []byte(`"finish_reason":null`)) || !bytes.Contains(out, []byte(`你好`)) {
+			t.Fatalf("bad normalized data: %s", out)
+		}
+		for _, part := range []string{": comment\r\n", "event: message\r\n", "id: one\r\n", "retry: 250\r\n", "\r\n\r\ndata: [DONE]\r\n\r\n"} {
+			if !bytes.Contains(out, []byte(part)) {
+				t.Fatalf("lost frame metadata %q: %s", part, out)
+			}
+		}
+		if err := reader.Close(); err != nil || !source.closed {
+			t.Fatal("underlying reader was not closed")
+		}
+	}
+}
+func TestNativeTerminalReaderPreservesPartialErrorAndOversize(t *testing.T) {
+	upstreamErr := errors.New("interrupted")
+	for _, tc := range []struct {
+		name, data, path string
+		end              error
+	}{
+		{"partial", "data: {\"object\":\"chat.completion.chunk\"", "/v1/chat/completions", io.EOF},
+		{"read_error", "data: {\"object\":\"chat.completion.chunk\"", "/v1/chat/completions", upstreamErr},
+		{"unrecognized", "data: {\"choices\":[{\"finish_reason\":\"\"}]}\n\n", "/v1/chat/completions", io.EOF},
+		{"other_api", "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"\"}]}\n\n", "/v1/responses", io.EOF},
+		{"oversized", "data: " + strings.Repeat("x", maxIncrementalSsePendingBytes+10) + "\n\n", "/v1/chat/completions", io.EOF},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := &terminalChunkReader{data: []byte(tc.data), size: 4096, end: tc.end}
+			out, err := io.ReadAll(withNativeTerminalBody(source, tc.path))
+			if !bytes.Equal(out, []byte(tc.data)) {
+				t.Fatal("changed partial/unsupported stream or appended a false terminal")
+			}
+			if tc.end == io.EOF {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if !errors.Is(err, tc.end) {
+				t.Fatalf("lost source error: %v", err)
+			}
+		})
+	}
+}
+func TestNativeTerminalStreamDispatchKeepsToolEndAndUsage(t *testing.T) {
+	stream := `data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"echo","arguments":"{}"}}]},"finish_reason":""}]}` + "\n\n" + `data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":8,"total_tokens":12}}` + "\n\ndata: [DONE]\n\n"
+	resp := &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(stream))}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	usage, end, verdict := handleStreamUpstream(rec, req, resp, 1)
+	if end != streamEndedNormally || (verdict != nil && verdict.Failed) {
+		t.Fatalf("relay failed: %v %v", end, verdict)
+	}
+	if usage.TotalTokens != 12 || !strings.Contains(rec.Body.String(), `"finish_reason":"tool_calls"`) || !strings.Contains(rec.Body.String(), `"finish_reason":null`) {
+		t.Fatalf("wire/usage mismatch: %+v %s", usage, rec.Body.String())
+	}
+}
+
+func TestNativeTerminalStreamDispatchPreservesAttachmentsAndPostDoneData(t *testing.T) {
+	start := `data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"echo","arguments":"{}"}}]},"finish_reason":null}]}` + "\n\n"
+	terminal := `data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n"
+	for _, tc := range []struct{ name, disposition, stream string }{
+		{"attachment", "attachment; filename=completion.sse", start + terminal + "data: [DONE]\n\n"},
+		{"attachment_case", "Attachment; filename=completion.sse", start + terminal + "data: [DONE]\n\n"},
+		{"after_done", "", start + "data: [DONE]\n\n" + terminal},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(tc.stream))}
+			resp.Header.Set("Content-Disposition", tc.disposition)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+			handleStreamUpstream(rec, req, resp, 1)
+			if rec.Body.String() != tc.stream {
+				t.Fatalf("changed protected stream bytes: %s", rec.Body.String())
+			}
+		})
+	}
+}

--- a/scripts/e2e/test_verify_real_relay.py
+++ b/scripts/e2e/test_verify_real_relay.py
@@ -23,6 +23,10 @@ SPEC.loader.exec_module(relay)
 MODEL = "fixture-response-model"
 VALUE = "echo-fixture"
 RECEIPT = "receipt-fixture"
+TOOL_NAME = relay.TOOL_NAME
+CHAT_REASONING = "private reasoning fixture"
+MESSAGE_THINKING = "private thinking fixture"
+MESSAGE_SIGNATURE = "private-signature-fixture"
 TEXT = "Private fixture text, not report output."
 KEY = "fixture-key-never-log"
 ENV = {"RELAY_BASE_URL": "http://127.0.0.1:12345", "RELAY_API_KEY": KEY,
@@ -67,34 +71,104 @@ def call_item(protocol, doc):
     return doc["output"][-1] if protocol == "responses" else doc["content"][0]
 
 
-def stream_events(protocol):
-    doc = document(protocol)
+def stream_events(protocol, text=TEXT):
+    doc = document(protocol, text=text)
     if protocol == "chat":
         def chunk(delta, finish=None):
             return {"id": doc["id"], "model": MODEL, "object": "chat.completion.chunk",
                     "choices": [{"index": 0, "delta": delta, "finish_reason": finish}]}
         return [("", chunk({"role": "assistant", "content": ""})),
-                ("", chunk({"content": TEXT})), ("", chunk({}, "stop")),
+                ("", chunk({"content": text})), ("", chunk({}, "stop")),
                 ("", {"id": doc["id"], "model": MODEL, "object": "chat.completion.chunk",
                       "choices": [], "usage": doc["usage"]}), ("", "[DONE]")]
     if protocol == "responses":
         return [("response.created", {"type": "response.created", "response": {
                     "id": doc["id"], "model": MODEL, "status": "in_progress"}}),
                 ("response.output_text.delta", {"type": "response.output_text.delta", "item_id": "msg_fixture",
-                    "output_index": 0, "content_index": 0, "delta": TEXT}),
+                    "output_index": 0, "content_index": 0, "delta": text}),
                 ("response.output_text.done", {"type": "response.output_text.done", "item_id": "msg_fixture",
-                    "output_index": 0, "content_index": 0, "text": TEXT}),
+                    "output_index": 0, "content_index": 0, "text": text}),
                 ("response.completed", {"type": "response.completed", "response": doc})]
     start = dict(doc, content=[], stop_reason=None, usage={"input_tokens": 12})
     return [("message_start", {"type": "message_start", "message": start}),
             ("content_block_start", {"type": "content_block_start", "index": 0,
                                      "content_block": {"type": "text", "text": ""}}),
             ("content_block_delta", {"type": "content_block_delta", "index": 0,
-                                     "delta": {"type": "text_delta", "text": TEXT}}),
+                                     "delta": {"type": "text_delta", "text": text}}),
             ("content_block_stop", {"type": "content_block_stop", "index": 0}),
             ("message_delta", {"type": "message_delta", "delta": {"stop_reason": "end_turn"},
                                "usage": {"output_tokens": 5}}),
             ("message_stop", {"type": "message_stop"})]
+
+
+def tool_stream_events(protocol, value=VALUE):
+    doc = document(protocol, tool=True)
+    raw = json.dumps({"value": value}, separators=(",", ":"))
+    width = max(1, len(raw) // 3)
+    fragments = [raw[pos:pos + width] for pos in range(0, len(raw), width)]
+    if protocol == "chat":
+        item = doc["choices"][0]["message"]["tool_calls"][0]
+        def chunk(delta, finish=None):
+            return {"id": doc["id"], "model": MODEL, "object": "chat.completion.chunk",
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": finish}]}
+        return [("", chunk({"role": "assistant", "content": ""})),
+                ("", chunk({"reasoning_content": CHAT_REASONING})),
+                ("", chunk({"tool_calls": [{"index": 0, "id": item["id"], "type": "function",
+                                            "function": {"name": TOOL_NAME, "arguments": fragments[0]}}]})),
+                ("", chunk({"tool_calls": [{"index": 0, "function": {"arguments": fragments[1]}}]})),
+                ("", chunk({"tool_calls": [{"index": 0, "function": {"arguments": fragments[2]}}]})),
+                ("", chunk({}, "tool_calls")),
+                ("", {"id": doc["id"], "model": MODEL, "object": "chat.completion.chunk",
+                      "choices": [], "usage": doc["usage"]}), ("", "[DONE]")]
+    if protocol == "responses":
+        item = doc["output"][-1]
+        item_id, call_id = item["id"], item["call_id"]
+        base_item = {"type": "function_call", "id": item_id, "call_id": call_id,
+                     "name": TOOL_NAME, "arguments": "", "status": "in_progress"}
+        return [("response.created", {"type": "response.created", "response": {
+                    "id": doc["id"], "model": MODEL, "status": "in_progress"}}),
+                ("response.output_item.added", {"type": "response.output_item.added", "output_index": 0,
+                                                "item": base_item}),
+                ("response.function_call_arguments.delta", {"type": "response.function_call_arguments.delta",
+                    "output_index": 0, "item_id": item_id,
+                    "delta": fragments[0]}),
+                ("response.function_call_arguments.delta", {"type": "response.function_call_arguments.delta",
+                    "output_index": 0, "item_id": item_id,
+                    "delta": fragments[1]}),
+                ("response.function_call_arguments.delta", {"type": "response.function_call_arguments.delta",
+                    "output_index": 0, "item_id": item_id,
+                    "delta": fragments[2]}),
+                ("response.function_call_arguments.done", {"type": "response.function_call_arguments.done",
+                    "output_index": 0, "item_id": item_id,
+                    "arguments": raw}),
+                ("response.output_item.done", {"type": "response.output_item.done", "output_index": 0,
+                    "item": dict(base_item, arguments=raw, status="completed")}),
+                ("response.completed", {"type": "response.completed", "response": doc})]
+    start = {"id": doc["id"], "model": MODEL, "type": "message", "role": "assistant",
+             "content": [], "stop_reason": None, "stop_sequence": None, "usage": {"input_tokens": 12}}
+    thinking_block = {"type": "thinking", "thinking": "", "signature": ""}
+    tool_block = {"type": "tool_use", "id": "toolu_fixture", "name": TOOL_NAME, "input": {}}
+    return [("message_start", {"type": "message_start", "message": start}),
+            ("content_block_start", {"type": "content_block_start", "index": 0,
+                                     "content_block": thinking_block}),
+            ("content_block_delta", {"type": "content_block_delta", "index": 0,
+                                     "delta": {"type": "thinking_delta", "thinking": MESSAGE_THINKING}}),
+            ("content_block_delta", {"type": "content_block_delta", "index": 0,
+                                     "delta": {"type": "signature_delta", "signature": MESSAGE_SIGNATURE}}),
+            ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            ("content_block_start", {"type": "content_block_start", "index": 1,
+                                     "content_block": tool_block}),
+            ("content_block_delta", {"type": "content_block_delta", "index": 1,
+                                     "delta": {"type": "input_json_delta", "partial_json": fragments[0]}}),
+            ("content_block_delta", {"type": "content_block_delta", "index": 1,
+                                     "delta": {"type": "input_json_delta", "partial_json": fragments[1]}}),
+            ("content_block_delta", {"type": "content_block_delta", "index": 1,
+                                     "delta": {"type": "input_json_delta", "partial_json": fragments[2]}}),
+            ("content_block_stop", {"type": "content_block_stop", "index": 1}),
+            ("message_delta", {"type": "message_delta", "delta": {"stop_reason": "tool_use"},
+                               "usage": {"output_tokens": 5}}),
+            ("message_stop", {"type": "message_stop"})]
+
 
 
 def pack(events):
@@ -129,6 +203,225 @@ class ValidatorTests(unittest.TestCase):
                 value = relay.validate_json(protocol, encode(document(protocol, tool=True)), tool=True, expected_value=VALUE)
                 self.assertEqual(value["_call"]["name"], "metapi_echo")
                 self.assertEqual(value["_call"]["arguments"], {"value": VALUE})
+
+    def test_all_normal_streaming_tool_fixtures(self):
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                value = relay.validate_http(protocol, (200, "text/event-stream", pack(tool_stream_events(protocol))),
+                                            stream=True, tool=True, expected_value=VALUE)
+                self.assertEqual(value["_call"]["name"], "metapi_echo")
+                self.assertEqual(value["_call"]["arguments"], {"value": VALUE})
+                self.assertEqual(value["_document"]["id"], document(protocol, tool=True)["id"])
+
+    def test_responses_function_call_delta_binds_item_id_and_optional_call_identity(self):
+        events = tool_stream_events("responses")
+        relay.validate_sse("responses", pack(events), tool=True, expected_value=VALUE)
+        for field in ("item_id", "call_id", "name"):
+            damaged = copy.deepcopy(events)
+            found = False
+            for event, obj in damaged:
+                if isinstance(obj, dict) and obj.get("type") in (
+                        "response.function_call_arguments.delta",
+                        "response.function_call_arguments.done"):
+                    if field == "item_id":
+                        obj["item_id"] = "wrong_item"
+                    elif field == "call_id":
+                        obj["call_id"] = "wrong_call"
+                    else:
+                        obj["name"] = "wrong_name"
+                    found = True
+                    break
+            self.assertTrue(found)
+            with self.subTest(field=field):
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse("responses", pack(damaged), tool=True, expected_value=VALUE)
+
+    def test_chat_streaming_tool_name_fragments_accumulate_and_id_consistency(self):
+        events = tool_stream_events("chat")
+        doc = document("chat", tool=True)
+        first = events[2][1]["choices"][0]
+        split = len(TOOL_NAME) // 2
+        first["delta"]["tool_calls"][0]["function"]["name"] = TOOL_NAME[:split]
+        events.insert(3, ("", {"id": doc["id"], "model": MODEL, "object": "chat.completion.chunk",
+                               "choices": [{"index": 0, "delta": {"tool_calls": [{
+                                   "index": 0, "function": {"name": TOOL_NAME[split:]}}]},
+                                   "finish_reason": None}]}))
+        validated = relay.validate_sse("chat", pack(events), tool=True, expected_value=VALUE)
+        self.assertEqual(validated["_call"]["name"], TOOL_NAME)
+        invalid = copy.deepcopy(events)
+        invalid.insert(4, ("", {"id": doc["id"], "model": MODEL, "object": "chat.completion.chunk",
+                                "choices": [{"index": 0, "delta": {"tool_calls": [{"index": 0, "id": "wrong_call"}]},
+                                             "finish_reason": None}]}))
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("chat", pack(invalid), tool=True, expected_value=VALUE)
+
+    def test_messages_tool_use_input_placeholder_is_required(self):
+        events = tool_stream_events("messages")
+        for bad in (None, "", "not a dict", [0], {"value": VALUE}):
+            damaged = copy.deepcopy(events)
+            found = False
+            for event, obj in damaged:
+                if isinstance(obj, dict) and obj.get("type") == "content_block_start":
+                    block = obj.get("content_block")
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        block["input"] = bad
+                        found = True
+                        break
+            self.assertTrue(found)
+            with self.subTest(bad=bad):
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse("messages", pack(damaged), tool=True, expected_value=VALUE)
+
+    def test_streaming_tool_followup_receipt_uses_streamed_document(self):
+        for protocol in relay.PROTOCOLS:
+            original = relay.request_body(protocol, "requested", 256, stream=True, tool_value=VALUE)
+            validated = relay.validate_sse(protocol, pack(tool_stream_events(protocol)), tool=True, expected_value=VALUE)
+            followup = relay.followup_body(protocol, original, validated, RECEIPT)
+            with self.subTest(protocol=protocol):
+                if protocol == "chat":
+                    result = followup["messages"][-1]
+                    self.assertEqual(result["tool_call_id"], "call_fixture")
+                    self.assertEqual(followup["messages"][-2], validated["_document"]["choices"][0]["message"])
+                    raw = result["content"]
+                elif protocol == "responses":
+                    self.assertEqual(followup["input"][-1]["call_id"], "call_fixture")
+                    raw = followup["input"][-1]["output"]
+                else:
+                    result = followup["messages"][-1]["content"][0]
+                    self.assertEqual(result["tool_use_id"], "toolu_fixture")
+                    raw = result["content"]
+                self.assertEqual(json.loads(raw), {"value": VALUE, "receipt": RECEIPT})
+                self.assertTrue(followup["stream"])
+
+    def test_streaming_tool_replay_preserves_native_reasoning_context(self):
+        for protocol in relay.PROTOCOLS:
+            original = relay.request_body(protocol, "requested", 256, stream=True, tool_value=VALUE)
+            validated = relay.validate_sse(protocol, pack(tool_stream_events(protocol)), tool=True, expected_value=VALUE)
+            followup = relay.followup_body(protocol, original, validated, RECEIPT)
+            with self.subTest(protocol=protocol):
+                if protocol == "chat":
+                    stream_message = validated["_document"]["choices"][0]["message"]
+                    followup_message = followup["messages"][-2]
+                    self.assertEqual(stream_message["reasoning_content"], CHAT_REASONING)
+                    self.assertEqual(followup_message["reasoning_content"], CHAT_REASONING)
+                elif protocol == "responses":
+                    reasoning = [item for item in validated["_document"]["output"] if item.get("type") == "reasoning"]
+                    self.assertTrue(reasoning)
+                    self.assertEqual(followup["input"][1:-1], validated["_document"]["output"])
+                else:
+                    assistant = followup["messages"][-2]
+                    thinking = [part for part in assistant["content"] if part.get("type") == "thinking"]
+                    self.assertEqual(len(thinking), 1)
+                    self.assertEqual(thinking[0]["thinking"], MESSAGE_THINKING)
+                    self.assertEqual(thinking[0]["signature"], MESSAGE_SIGNATURE)
+
+    def test_unpreserved_stream_context_fails_explicitly(self):
+        events = tool_stream_events("chat")
+        events.insert(2, ("", {"id": document("chat", tool=True)["id"], "model": MODEL,
+                               "object": "chat.completion.chunk",
+                               "choices": [{"index": 0, "delta": {"reasoning": "not preserved"},
+                                            "finish_reason": None}]}))
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("chat", pack(events), tool=True, expected_value=VALUE)
+        events = tool_stream_events("responses")
+        events[1][1]["item"]["type"] = "unknown_output_item"
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("responses", pack(events), tool=True, expected_value=VALUE)
+        events = tool_stream_events("messages")
+        events[2][1]["delta"]["type"] = "unknown_delta"
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("messages", pack(events), tool=True, expected_value=VALUE)
+
+    def test_streaming_tool_truncation_fails(self):
+        for protocol in relay.PROTOCOLS:
+            events = tool_stream_events(protocol)
+            for damaged in (events[:-1], events[:-2]):
+                with self.subTest(protocol=protocol, tail=damaged[-1][0]):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_sse(protocol, pack(damaged), tool=True, expected_value=VALUE)
+
+    def test_streaming_tool_error_fails(self):
+        for protocol in relay.PROTOCOLS:
+            events = tool_stream_events(protocol)
+            error = ("error", {"type": "error", "error": {"message": "private failure detail"}})
+            for damaged in ([error] + events, events + [error], events[:-1] + [error]):
+                with self.subTest(protocol=protocol, placement=len(damaged)):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_sse(protocol, pack(damaged), tool=True, expected_value=VALUE)
+
+    def test_streaming_tool_wrong_termination_fails(self):
+        for protocol in relay.PROTOCOLS:
+            events = tool_stream_events(protocol)
+            if protocol == "chat":
+                for event, obj in events:
+                    if isinstance(obj, dict):
+                        for choice in obj.get("choices", []):
+                            choice["finish_reason"] = "stop"
+            elif protocol == "responses":
+                events[-1][1]["response"]["status"] = "incomplete"
+            else:
+                for event, obj in events:
+                    if event == "message_delta":
+                        obj["delta"]["stop_reason"] = "end_turn"
+            with self.subTest(protocol=protocol):
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse(protocol, pack(events), tool=True, expected_value=VALUE)
+
+    def test_streaming_tool_duplicate_terminal_fails(self):
+        for protocol in relay.PROTOCOLS:
+            events = tool_stream_events(protocol)
+            if protocol == "chat":
+                events = events + [("", "[DONE]")]
+            elif protocol == "responses":
+                events = events + [("response.completed", copy.deepcopy(events[-1][1]))]
+            else:
+                events = events + [("message_stop", {"type": "message_stop"})]
+            with self.subTest(protocol=protocol):
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse(protocol, pack(events), tool=True, expected_value=VALUE)
+
+    def test_streaming_tool_identity_and_arguments_are_strict(self):
+        def mutate(protocol, field, value):
+            events = tool_stream_events(protocol)
+            if protocol == "chat":
+                for event, obj in events:
+                    if isinstance(obj, dict):
+                        for choice in obj.get("choices", []):
+                            for item in choice.get("delta", {}).get("tool_calls", []):
+                                if field == "name":
+                                    item["function"]["name"] = value
+                                elif field == "id":
+                                    item["id"] = ""
+                                elif field == "args":
+                                    item["function"]["arguments"] = "wrong"
+            elif protocol == "responses":
+                for event, obj in events:
+                    if isinstance(obj, dict) and obj.get("type") == "response.function_call_arguments.delta":
+                        if field == "name":
+                            obj["name"] = value
+                        elif field == "id":
+                            obj["call_id"] = value
+                        elif field == "args":
+                            obj["delta"] = "wrong"
+            else:
+                for event, obj in events:
+                    if isinstance(obj, dict) and obj.get("type") == "content_block_start":
+                        if field == "name":
+                            obj["content_block"]["name"] = value
+                        elif field == "id":
+                            obj["content_block"]["id"] = None
+                        elif field == "args":
+                            pass
+                    if isinstance(obj, dict) and obj.get("type") == "content_block_delta" and field == "args":
+                        obj["delta"]["partial_json"] = "wrong"
+            return events
+
+        for protocol in relay.PROTOCOLS:
+            for field in ("name", "id", "args"):
+                with self.subTest(protocol=protocol, field=field):
+                    with self.assertRaises(relay.CheckFailed):
+                        relay.validate_sse(protocol, pack(mutate(protocol, field, "wrong")), tool=True,
+                                           expected_value=VALUE)
 
     def test_damaged_json_and_non_objects(self):
         for protocol in relay.PROTOCOLS:
@@ -506,6 +799,10 @@ class TransportAndCliValidatorTests(unittest.TestCase):
     def good_post(client, protocol, body):
         client.request_count += 1
         if body["stream"]:
+            if body.get("tool_choice") in ("none", {"type": "none"}):
+                return 200, "text/event-stream", pack(stream_events(protocol, text=RECEIPT))
+            if "tools" in body:
+                return 200, "text/event-stream", pack(tool_stream_events(protocol))
             return 200, "text/event-stream", pack(stream_events(protocol))
         if body.get("tool_choice") in ("none", {"type": "none"}):
             doc = document(protocol, text=RECEIPT)
@@ -566,6 +863,48 @@ class TransportAndCliValidatorTests(unittest.TestCase):
                 self.assertEqual(code, 0)
                 self.assertEqual(report["requestCount"], 4)
                 self.assertEqual({r["protocol"] for r in report["results"]}, {protocol})
+
+    def test_tool_stream_uses_eighteen_posts_and_streamed_receipt_followup(self):
+        code, report, raw = self.run_cli(["--tool-stream"], self.good_post)
+        self.assertEqual(code, 0)
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["requestCount"], 18)
+        self.assertEqual(report["requestLimit"], 18)
+        self.assertEqual(report["toolStream"], True)
+        self.assertEqual(len(report["results"]), 12)
+        self.assertEqual(sum(row["scenario"] == "tool_stream" for row in report["results"]), 3)
+        for row in report["results"]:
+            if row["scenario"] == "tool_stream":
+                self.assertEqual(row["status"], "pass")
+                self.assertEqual(row["followup"]["status"], "pass")
+        for private in (KEY, TEXT, VALUE, RECEIPT, "Preserve this reasoning"):
+            self.assertNotIn(private, raw)
+
+    def test_tool_stream_protocol_selection_uses_six_posts(self):
+        for protocol in relay.PROTOCOLS:
+            with self.subTest(protocol=protocol):
+                code, report, _ = self.run_cli(["--protocol", protocol, "--tool-stream"], self.good_post)
+                self.assertEqual(code, 0)
+                self.assertEqual(report["requestCount"], 6)
+                self.assertEqual(report["requestLimit"], 6)
+                self.assertEqual({r["protocol"] for r in report["results"]}, {protocol})
+
+    def test_streaming_followup_requires_receipt_not_just_any_text(self):
+        def post(client, protocol, body):
+            if body["stream"]:
+                client.request_count += 1
+                if body.get("tool_choice") in ("none", {"type": "none"}):
+                    return 200, "text/event-stream", pack(stream_events(protocol))
+                if "tools" in body:
+                    return 200, "text/event-stream", pack(tool_stream_events(protocol))
+                return 200, "text/event-stream", pack(stream_events(protocol))
+            return self.good_post(client, protocol, body)
+        code, report, _ = self.run_cli(["--tool-stream"], post)
+        self.assertEqual(code, 1)
+        self.assertEqual(report["requestCount"], 18)
+        for row in report["results"]:
+            if row["scenario"] == "tool_stream":
+                self.assertEqual(row["followup"]["error"], "followup_did_not_use_tool_result")
 
     def test_missing_tool_skips_followup_and_is_nonzero(self):
         def post(client, protocol, body):

--- a/scripts/e2e/verify-real-relay.py
+++ b/scripts/e2e/verify-real-relay.py
@@ -4,7 +4,8 @@
 Required environment: RELAY_BASE_URL (origin or /v1 base), RELAY_API_KEY,
 RELAY_MODEL. No service discovery, provisioning, retries, or built-in tools.
 Requires system curl >= 8.4 for unknown-length transfer-size enforcement.
-Each protocol uses at most four POSTs: JSON, SSE, echo call, echo followup.
+Each protocol uses at most four POSTs by default (six with --tool-stream):
+JSON, SSE, echo call, echo followup, streaming echo call, streaming followup.
 Only metadata is printed. Bodies, prompts, tool payloads and auth stay in memory.
 A pass proves client-visible relay semantics, NOT upstream/provider provenance.
 The companion unittest file contains validator tests, never live relay proof.
@@ -230,12 +231,29 @@ def sse_events(raw):
     return events
 
 
-def validate_sse(protocol, raw):
+def chat_tool_document(model, response_id, text, usage, call, reasoning_content=None):
+    """Build the only streamed replay document that needs synthesis: OpenAI Chat."""
+    arguments = json.dumps(call["arguments"], ensure_ascii=True, separators=(",", ":"))
+    message = {"role": "assistant", "content": text or None,
+               "tool_calls": [{"id": call["id"], "type": "function",
+                               "function": {"name": call["name"], "arguments": arguments}}]}
+    if reasoning_content:
+        message["reasoning_content"] = reasoning_content
+    return {"id": response_id, "model": model, "object": "chat.completion",
+            "choices": [{"index": 0, "message": message, "finish_reason": "tool_calls"}],
+            "usage": usage}
+
+
+def validate_sse(protocol, raw, *, tool=False, expected_value=None):
     events = sse_events(raw)
     text, model, response_id, usage = "", None, None, {}
+    chat_reasoning = ""
     finished, done, started, stop_reason = False, False, False, None
     blocks, closed = {}, set()
     response_parts, part_ids, ended_parts = {}, {}, set()
+    response_calls = {}
+    tool_calls = {}
+    stream_call, stream_document = None, None
 
     def metadata(doc):
         nonlocal model, response_id, usage
@@ -275,14 +293,56 @@ def validate_sse(protocol, raw):
             delta = choice.get("delta")
             no_error(delta)
             require(delta.get("role", "assistant") == "assistant", "invalid_role")
-            require(not delta.get("tool_calls") and not delta.get("function_call") and not delta.get("refusal"),
-                    "unexpected_tool_or_refusal")
+            require(not delta.get("function_call") and not delta.get("refusal"), "unexpected_tool_or_refusal")
+            require(delta.get("reasoning") is None, "unpreserved_chat_reasoning_delta")
+            reasoning_delta = delta.get("reasoning_content")
+            require(reasoning_delta is None or isinstance(reasoning_delta, str), "invalid_reasoning_content")
+            chat_reasoning += reasoning_delta or ""
+            raw_tool_calls = delta.get("tool_calls")
+            if raw_tool_calls is not None:
+                if tool:
+                    require(isinstance(raw_tool_calls, list), "invalid_tool_calls")
+                    seen = set()
+                    for item in raw_tool_calls:
+                        no_error(item)
+                        require(isinstance(item, dict), "invalid_tool_call")
+                        index = item.get("index")
+                        require(integer(index) and index not in seen, "invalid_or_duplicate_tool_index")
+                        seen.add(index)
+                        entry = tool_calls.get(index)
+                        if entry is None:
+                            entry = {"id": None, "name": "", "arguments": ""}
+                            tool_calls[index] = entry
+                        if item.get("type") not in (None, "function"):
+                            require(False, "unexpected_tool_type")
+                        if "id" in item:
+                            value = identifier(item["id"])
+                            require(entry["id"] is None or entry["id"] == value, "stream_tool_identity_changed")
+                            entry["id"] = value
+                        function = item.get("function")
+                        if function is not None:
+                            no_error(function)
+                            require(isinstance(function, dict), "invalid_tool_function")
+                            if "name" in function:
+                                value = function["name"]
+                                require(isinstance(value, str) and value, "invalid_tool_name")
+                                entry["name"] += value
+                            if "arguments" in function:
+                                value = function["arguments"]
+                                require(isinstance(value, str), "invalid_tool_arguments")
+                                entry["arguments"] += value
+                else:
+                    require(not raw_tool_calls, "unexpected_tool_or_refusal")
             content = delta.get("content")
             require(content is None or isinstance(content, str), "invalid_content")
             text += content or ""
             reason = choice.get("finish_reason")
-            require(reason in (None, "stop"), "abnormal_finish")
-            finished = reason == "stop"
+            if tool:
+                require(reason in (None, "tool_calls"), "abnormal_finish")
+                finished = reason == "tool_calls"
+            else:
+                require(reason in (None, "stop"), "abnormal_finish")
+                finished = reason == "stop"
         elif protocol == "responses":
             require(not finished, "event_after_completion")
             kind = obj.get("type")
@@ -303,11 +363,50 @@ def validate_sse(protocol, raw):
                             and obj["text"] == response_parts[index], "stream_text_mismatch")
                     ended_parts.add(index)
                 text = "".join(response_parts[i] for i in sorted(response_parts))
+            elif kind in ("response.function_call_arguments.delta", "response.function_call_arguments.done"):
+                require(tool, "unexpected_tool_or_refusal")
+                index = obj.get("output_index")
+                require(integer(index), "invalid_output_index")
+                entry = response_calls.get(index)
+                require(entry is not None, "missing_function_call_item")
+                item_id = identifier(obj.get("item_id"))
+                require(item_id == entry["item_id"], "stream_tool_identity_changed")
+                if "call_id" in obj:
+                    optional_call_id = identifier(obj["call_id"])
+                    require(optional_call_id == entry["call_id"], "stream_tool_identity_changed")
+                if "name" in obj:
+                    optional_name = identifier(obj["name"])
+                    require(optional_name == entry["name"], "stream_tool_identity_changed")
+                if kind.endswith(".delta"):
+                    require(not entry["args_done"], "arguments_after_done")
+                    delta = obj.get("delta")
+                    require(isinstance(delta, str), "invalid_tool_arguments")
+                    entry["arguments"] += delta
+                else:
+                    require(not entry["args_done"], "duplicate_function_args_done")
+                    arguments = obj.get("arguments")
+                    require(isinstance(arguments, str), "invalid_tool_arguments")
+                    require(entry["arguments"] == arguments, "stream_tool_arguments_mismatch")
+                    entry["args_done"] = True
             elif kind == "response.completed":
-                final = validate_json("responses", json.dumps(obj.get("response")))
+                final = validate_json("responses", json.dumps(obj.get("response")), tool=tool,
+                                      expected_value=expected_value)
                 metadata(final["_document"])
-                require(has_text(text) and text == final["_text"], "stream_text_mismatch")
+                require(text == final["_text"], "stream_text_mismatch")
                 output = final["_document"]["output"]
+                if tool:
+                    require(len(response_calls) == 1, "expected_one_tool_call")
+                    entry = next(iter(response_calls.values()))
+                    require(entry["args_done"] and entry["output_done"], "missing_function_call_completion")
+                    function_items = [item for item in output if item.get("type") == "function_call"]
+                    require(len(function_items) == 1, "expected_one_tool_call")
+                    item = function_items[0]
+                    require(item.get("id") == entry["item_id"] and item.get("call_id") == entry["call_id"]
+                            and item.get("name") == entry["name"]
+                            and json_value(item.get("arguments")) == json_value(entry["arguments"]),
+                            "stream_tool_identity_or_arguments_mismatch")
+                    stream_call = final["_call"]
+                    stream_document = final["_document"]
                 for (item_index, content_index), item_id in part_ids.items():
                     require(item_index < len(output), "invalid_output_index")
                     item = output[item_index]
@@ -319,9 +418,33 @@ def validate_sse(protocol, raw):
             elif kind in ("response.output_item.added", "response.output_item.done"):
                 item = obj.get("item")
                 no_error(item)
-                require(item.get("type") in ("message", "reasoning"), "unexpected_output_type")
-                if kind.endswith(".done"):
-                    require(item.get("status", "completed") == "completed", "incomplete_output_item")
+                item_kind = item.get("type")
+                if item_kind == "function_call":
+                    require(tool, "unexpected_tool_or_refusal")
+                    index = obj.get("output_index")
+                    require(integer(index), "invalid_output_index")
+                    item_id = identifier(item.get("id"))
+                    call_id = identifier(item.get("call_id"))
+                    name = identifier(item.get("name"))
+                    arguments = item.get("arguments", "")
+                    require(isinstance(arguments, str), "invalid_tool_arguments")
+                    entry = response_calls.get(index)
+                    if kind.endswith(".added"):
+                        require(entry is None, "duplicate_function_call")
+                        response_calls[index] = {"item_id": item_id, "call_id": call_id, "name": name,
+                                                 "arguments": arguments, "args_done": False, "output_done": False}
+                    else:
+                        require(entry is not None, "missing_function_call_item")
+                        require(item_id == entry["item_id"] and call_id == entry["call_id"]
+                                and name == entry["name"], "stream_tool_identity_changed")
+                        require(entry["args_done"], "missing_function_call_args_done")
+                        require(not entry["output_done"], "duplicate_function_call_done")
+                        require(arguments == entry["arguments"], "stream_tool_arguments_mismatch")
+                        entry["output_done"] = True
+                else:
+                    require(item_kind in ("message", "reasoning"), "unexpected_output_type")
+                    if kind.endswith(".done"):
+                        require(item.get("status", "completed") == "completed", "incomplete_output_item")
             elif kind in ("response.content_part.added", "response.content_part.done"):
                 part = obj.get("part")
                 no_error(part)
@@ -354,11 +477,31 @@ def validate_sse(protocol, raw):
                         require(index not in blocks, "duplicate_content_block")
                         block = obj.get("content_block")
                         no_error(block)
-                        require(block.get("type") in ("text", "thinking", "redacted_thinking"),
-                                "unexpected_content_type")
-                        initial = block.get("text", "")
-                        require(isinstance(initial, str), "invalid_content")
-                        blocks[index] = {"type": block["type"], "text": initial if block["type"] == "text" else ""}
+                        block_kind = block.get("type")
+                        if block_kind == "tool_use":
+                            require(tool, "unexpected_tool_or_refusal")
+                            require(block.get("input") == {}, "invalid_tool_input_placeholder")
+                            blocks[index] = {"type": "tool_use", "id": identifier(block.get("id")),
+                                             "name": identifier(block.get("name")), "arguments": ""}
+                        elif block_kind in ("text", "thinking", "redacted_thinking"):
+                            if block_kind == "text":
+                                initial = block.get("text", "")
+                                require(isinstance(initial, str), "invalid_content")
+                                blocks[index] = {"type": block_kind, "text": initial}
+                            elif block_kind == "thinking":
+                                initial = block.get("thinking", "")
+                                require(isinstance(initial, str), "invalid_thinking")
+                                blocks[index] = {"type": block_kind, "thinking": initial, "signature": ""}
+                                signature = block.get("signature")
+                                if signature is not None:
+                                    require(isinstance(signature, str), "invalid_thinking_signature")
+                                    blocks[index]["signature"] = signature
+                            else:
+                                data = block.get("data", "")
+                                require(isinstance(data, str), "invalid_redacted_thinking")
+                                blocks[index] = {"type": block_kind, "data": data}
+                        else:
+                            raise CheckFailed("unexpected_content_type")
                     else:
                         require(index in blocks and index not in closed, "unopened_or_closed_block")
                         if kind == "content_block_stop":
@@ -366,32 +509,76 @@ def validate_sse(protocol, raw):
                         else:
                             delta = obj.get("delta")
                             no_error(delta)
-                            if blocks[index]["type"] == "text":
+                            block_kind = blocks[index]["type"]
+                            if block_kind == "text":
                                 require(delta.get("type") == "text_delta" and isinstance(delta.get("text"), str),
                                         "invalid_text_delta")
                                 blocks[index]["text"] += delta["text"]
-                            else:
+                            elif block_kind == "tool_use":
+                                require(delta.get("type") == "input_json_delta"
+                                        and isinstance(delta.get("partial_json"), str), "invalid_tool_arguments_delta")
+                                blocks[index]["arguments"] += delta["partial_json"]
+                            elif block_kind == "thinking":
                                 field = {"thinking_delta": "thinking", "signature_delta": "signature"}.get(delta.get("type"))
                                 require(field is not None and isinstance(delta.get(field), str), "invalid_thinking_delta")
+                                blocks[index][field] += delta[field]
+                            else:
+                                require(False, "unpreserved_redacted_thinking_delta")
                 elif kind == "message_delta":
                     delta = obj.get("delta")
                     no_error(delta)
-                    require(stop_reason is None and set(blocks) == closed and delta.get("stop_reason") == "end_turn",
+                    require(stop_reason is None and set(blocks) == closed, "abnormal_finish_or_unclosed_block")
+                    require(delta.get("stop_reason") == ("tool_use" if tool else "end_turn"),
                             "abnormal_finish_or_unclosed_block")
-                    stop_reason = "end_turn"
+                    stop_reason = delta.get("stop_reason")
                     usage.update(usage_summary(obj.get("usage")))
                 elif kind == "message_stop":
-                    require(stop_reason == "end_turn" and set(blocks) == closed, "missing_stop_reason_or_unclosed_block")
-                    text = "".join(blocks[i]["text"] for i in sorted(blocks))
+                    require(stop_reason == ("tool_use" if tool else "end_turn") and set(blocks) == closed,
+                            "missing_stop_reason_or_unclosed_block")
+                    text = "".join(blocks[i]["text"] for i in sorted(blocks) if blocks[i]["type"] == "text")
                     finished = True
                 else:
                     raise CheckFailed("unexpected_sse_event")
         else:
             raise CheckFailed("invalid_protocol")
     require(finished and (protocol != "chat" or done), "missing_stream_termination")
-    require(has_text(text), "missing_stream_text")
+    if tool:
+        if protocol == "chat":
+            require(len(tool_calls) == 1, "expected_one_tool_call")
+            entry = next(iter(tool_calls.values()))
+            stream_call = checked_call(entry["name"], entry["id"], json_value(entry["arguments"]), expected_value)
+            stream_document = chat_tool_document(model, response_id, text, usage, stream_call,
+                                                 reasoning_content=chat_reasoning)
+        elif protocol == "messages":
+            tool_entries = [entry for entry in blocks.values() if entry["type"] == "tool_use"]
+            require(len(tool_entries) == 1, "expected_one_tool_call")
+            entry = tool_entries[0]
+            stream_call = checked_call(entry["name"], entry["id"], json_value(entry["arguments"]), expected_value)
+            content = []
+            for index in sorted(blocks):
+                block = blocks[index]
+                if block["type"] == "text":
+                    content.append({"type": "text", "text": block["text"]})
+                elif block["type"] == "tool_use":
+                    content.append({"type": "tool_use", "id": block["id"], "name": block["name"],
+                                    "input": stream_call["arguments"]})
+                elif block["type"] == "thinking":
+                    item = {"type": "thinking", "thinking": block["thinking"]}
+                    if block["signature"]:
+                        item["signature"] = block["signature"]
+                    content.append(item)
+                elif block["type"] == "redacted_thinking":
+                    content.append({"type": "redacted_thinking", "data": block["data"]})
+            stream_document = {"id": response_id, "model": model, "type": "message", "role": "assistant",
+                               "content": content, "stop_reason": "tool_use", "stop_sequence": None,
+                               "usage": usage}
+        else:
+            require(stream_call is not None, "expected_one_tool_call")
+    else:
+        require(has_text(text), "missing_stream_text")
     return {"model": identifier(model), "responseId": identifier(response_id), "usage": usage,
-            "eventCount": len(events), "contentLength": len(text), "_text": text}
+            "eventCount": len(events), "contentLength": len(text), "_text": text,
+            "_call": stream_call, "_document": stream_document}
 
 
 def validate_http(protocol, reply, *, stream=False, tool=False, expected_value=None):
@@ -402,11 +589,10 @@ def validate_http(protocol, reply, *, stream=False, tool=False, expected_value=N
     mime = content_type.split(";", 1)[0].strip().lower()
     if stream:
         require(mime == "text/event-stream", "expected_sse_content_type")
-        return validate_sse(protocol, body)
+        return validate_sse(protocol, body, tool=tool, expected_value=expected_value)
     require(mime == "application/json" or (mime.startswith("application/") and mime.endswith("+json")),
             "expected_json_content_type")
     return validate_json(protocol, body, tool=tool, expected_value=expected_value)
-
 
 def request_body(protocol, model, max_tokens, *, stream=False, tool_value=None):
     prompt = "Reply with one short sentence confirming the relay works."
@@ -574,21 +760,23 @@ def observed_response_signals(reply):
     return {"finishReasons": reasons[:20], "finishReasonCount": len(reasons), "toolCallsPresent": tools}
 
 
-def run_protocol(client, protocol, model, max_tokens):
+def run_protocol(client, protocol, model, max_tokens, tool_stream):
     results = []
-    for scenario in ("nonstream", "stream", "tool_roundtrip"):
+    scenarios = ("nonstream", "stream", "tool_roundtrip") + (("tool_stream",) if tool_stream else ())
+    for scenario in scenarios:
         row = empty_result(protocol, scenario)
         row["requestedModel"] = model
         results.append(row)
-        tool_value = "echo-" + secrets.token_hex(8) if scenario == "tool_roundtrip" else None
+        stream = scenario in ("stream", "tool_stream")
+        tool_value = "echo-" + secrets.token_hex(8) if scenario in ("tool_roundtrip", "tool_stream") else None
         if tool_value is not None:
             row["followup"] = {"status": "not_run"}
         reply = None
         try:
-            body = request_body(protocol, model, max_tokens, stream=scenario == "stream", tool_value=tool_value)
+            body = request_body(protocol, model, max_tokens, stream=stream, tool_value=tool_value)
             reply = client.post(protocol, body)
             row["httpStatus"] = reply[0]
-            validated = validate_http(protocol, reply, stream=scenario == "stream", tool=tool_value is not None,
+            validated = validate_http(protocol, reply, stream=stream, tool=tool_value is not None,
                                       expected_value=tool_value)
             row.update({key: validated[key] for key in SUMMARY_FIELDS})
             row["responseModel"] = validated["model"]
@@ -598,13 +786,12 @@ def run_protocol(client, protocol, model, max_tokens):
                 followup["requestedModel"] = model
                 followup.pop("followup")
                 row["followup"] = followup
-                # This receipt exists only in the tool result, not in the first prompt.
                 receipt = "receipt-" + secrets.token_hex(12)
                 followup_reply = None
                 try:
                     followup_reply = client.post(protocol, followup_body(protocol, body, validated, receipt))
                     followup["httpStatus"] = followup_reply[0]
-                    final = validate_http(protocol, followup_reply)
+                    final = validate_http(protocol, followup_reply, stream=stream)
                     followup.update({key: final[key] for key in SUMMARY_FIELDS})
                     followup["responseModel"] = final["model"]
                     require(receipt in final["_text"], "followup_did_not_use_tool_result")
@@ -618,7 +805,6 @@ def run_protocol(client, protocol, model, max_tokens):
             row["error"] = error_code(error)
             row["observed"] = observed_response_signals(reply)
     return results
-
 
 class Parser(argparse.ArgumentParser):
     def error(self, message):
@@ -636,10 +822,13 @@ def main(argv=None, environment=None):
         parser.add_argument("--protocol", choices=("all",) + PROTOCOLS, default="all")
         parser.add_argument("--timeout", type=int, default=120, metavar="SECONDS", help="per POST, 5..300 (default: 120)")
         parser.add_argument("--max-tokens", type=int, default=256, metavar="TOKENS", help="per POST, 64..4096 (default: 256)")
+        parser.add_argument("--tool-stream", action="store_true",
+                            help="also verify streaming echo-tool calls and result followups (2 extra POSTs per protocol)")
         args = parser.parse_args(argv)
         require(5 <= args.timeout <= 300 and 64 <= args.max_tokens <= 4096, "invalid_limits")
         report["maxTokensPerRequest"] = args.max_tokens
         report["perRequestTimeoutSeconds"] = args.timeout
+        report["toolStream"] = args.tool_stream
         base, model = environment.get("RELAY_BASE_URL", ""), environment.get("RELAY_MODEL", "")
         require(bool(base and key and model), "missing_relay_environment")
         require(len(key) <= 4096 and all(33 <= ord(c) <= 126 for c in key), "invalid_api_key_format")
@@ -653,10 +842,10 @@ def main(argv=None, environment=None):
         if not base.endswith("/v1"):
             base += "/v1"
         selected = PROTOCOLS if args.protocol == "all" else (args.protocol,)
-        report["requestLimit"] = len(selected) * 4
+        report["requestLimit"] = len(selected) * (6 if args.tool_stream else 4)
         client = CurlClient(base, key, args.timeout, environment)
         for protocol in selected:
-            report["results"].extend(run_protocol(client, protocol, model, args.max_tokens))
+            report["results"].extend(run_protocol(client, protocol, model, args.max_tokens, args.tool_stream))
         report["requestCount"] = client.request_count
         passed = bool(report["results"]) and all(row["status"] == "pass" for row in report["results"])
         report["status"] = "pass" if passed else "fail"

--- a/transform/shared/native_terminal.go
+++ b/transform/shared/native_terminal.go
@@ -1,0 +1,444 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// NativeTerminalProtocol identifies the two native wire formats whose otherwise
+// complete tool responses sometimes carry the upstream's ordinary text stop.
+type NativeTerminalProtocol uint8
+
+const (
+	NativeChatCompletions NativeTerminalProtocol = iota + 1
+	NativeMessages
+)
+
+// Keep protocol repair narrow: never invent a terminal event, repair truncated
+// arguments, or change length/refusal/error outcomes. RawMessage preserves usage,
+// large integer metadata, reasoning, signatures, and provider extensions.
+func NormalizeNativeTerminalJSON(raw []byte, protocol NativeTerminalProtocol) []byte {
+	doc := terminalObject(raw)
+	if doc == nil || terminalHasError(doc) {
+		return raw
+	}
+	changed := false
+	switch protocol {
+	case NativeChatCompletions:
+		if terminalString(doc["object"]) != "chat.completion" {
+			return raw
+		}
+		var choices []json.RawMessage
+		if json.Unmarshal(doc["choices"], &choices) != nil {
+			return raw
+		}
+		for i, choiceRaw := range choices {
+			choice := terminalObject(choiceRaw)
+			if choice == nil || terminalHasError(choice) || terminalString(choice["finish_reason"]) != "stop" {
+				continue
+			}
+			message := terminalObject(choice["message"])
+			if message == nil || terminalString(message["role"]) != "assistant" || terminalHasError(message) || terminalPresent(message["refusal"]) {
+				continue
+			}
+			var calls []json.RawMessage
+			if json.Unmarshal(message["tool_calls"], &calls) != nil || len(calls) == 0 {
+				continue
+			}
+			ready := true
+			for _, callRaw := range calls {
+				call := terminalObject(callRaw)
+				fn := terminalObject(call["function"])
+				if terminalString(call["type"]) != "function" || !terminalName(call["id"]) || !terminalName(fn["name"]) || terminalObject([]byte(terminalString(fn["arguments"]))) == nil {
+					ready = false
+					break
+				}
+			}
+			if ready {
+				choice["finish_reason"] = json.RawMessage(`"tool_calls"`)
+				choices[i] = terminalMarshal(choice, choiceRaw)
+				changed = true
+			}
+		}
+		if changed {
+			doc["choices"] = terminalMarshal(choices, doc["choices"])
+		}
+	case NativeMessages:
+		if terminalString(doc["type"]) != "message" || terminalString(doc["role"]) != "assistant" || terminalString(doc["stop_reason"]) != "end_turn" || terminalPresent(doc["stop_sequence"]) {
+			return raw
+		}
+		var parts []json.RawMessage
+		if json.Unmarshal(doc["content"], &parts) != nil {
+			return raw
+		}
+		tools := 0
+		for _, partRaw := range parts {
+			part := terminalObject(partRaw)
+			if part == nil || terminalHasError(part) {
+				return raw
+			}
+			if terminalString(part["type"]) != "tool_use" {
+				continue
+			}
+			if !terminalName(part["id"]) || !terminalName(part["name"]) || terminalObject(part["input"]) == nil {
+				return raw
+			}
+			tools++
+		}
+		if tools > 0 {
+			doc["stop_reason"] = json.RawMessage(`"tool_use"`)
+			changed = true
+		}
+	}
+	if !changed {
+		return raw
+	}
+	return terminalMarshal(doc, raw)
+}
+
+// NativeTerminalStream owns only bounded evidence for actual tool calls. It
+// accepts complete SSE data payloads; framing, timeouts, and byte limits remain
+// with the relay. Zero values are valid when Protocol is set before use.
+type NativeTerminalStream struct {
+	Protocol NativeTerminalProtocol
+	choices  map[int]*terminalChoice
+	blocks   map[int]*terminalBlock
+	bytes    int
+	objects  int
+	invalid  bool
+	started  bool
+	ended    bool
+}
+type terminalChoice struct {
+	calls   map[int]*terminalCall
+	ended   bool
+	invalid bool
+}
+type terminalCall struct{ id, name, args string }
+type terminalBlock struct {
+	tool    bool
+	closed  bool
+	call    terminalCall
+	initial json.RawMessage
+}
+
+const terminalStateLimit = 1 << 20
+const terminalObjectLimit = 128
+
+func (s *NativeTerminalStream) AddData(raw []byte) []byte {
+	if s.invalid || s.ended {
+		return raw
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("[DONE]")) {
+		s.ended = true
+		return raw
+	}
+	doc := terminalObject(raw)
+	if doc == nil || terminalHasError(doc) {
+		s.invalid = true
+		return raw
+	}
+	switch s.Protocol {
+	case NativeChatCompletions:
+		return s.chatData(doc, raw)
+	case NativeMessages:
+		return s.messageData(doc, raw)
+	default:
+		return raw
+	}
+}
+
+func (s *NativeTerminalStream) chatData(doc map[string]json.RawMessage, raw []byte) []byte {
+	if terminalString(doc["object"]) != "chat.completion.chunk" {
+		return raw
+	}
+	var choices []json.RawMessage
+	if json.Unmarshal(doc["choices"], &choices) != nil {
+		return raw
+	}
+	changed := false
+	if s.choices == nil {
+		s.choices = make(map[int]*terminalChoice)
+	}
+	for i, choiceRaw := range choices {
+		choice := terminalObject(choiceRaw)
+		index, ok := terminalIndex(choice["index"])
+		if !ok || choice == nil || terminalHasError(choice) {
+			s.invalid = true
+			return raw
+		}
+		c := s.choices[index]
+		if c == nil {
+			if !s.addObject() {
+				return raw
+			}
+			c = &terminalChoice{calls: make(map[int]*terminalCall)}
+			s.choices[index] = c
+		}
+		if c.ended {
+			continue
+		}
+		delta := terminalObject(choice["delta"])
+		if delta == nil || terminalHasError(delta) || terminalPresent(delta["refusal"]) {
+			c.invalid = true
+			continue
+		}
+		if terminalPresent(delta["tool_calls"]) {
+			var calls []json.RawMessage
+			if json.Unmarshal(delta["tool_calls"], &calls) != nil {
+				c.invalid = true
+				continue
+			}
+			for _, callRaw := range calls {
+				call := terminalObject(callRaw)
+				idx, ok := terminalIndex(call["index"])
+				if !ok || call == nil || (terminalPresent(call["type"]) && terminalString(call["type"]) != "function") {
+					c.invalid = true
+					break
+				}
+				t := c.calls[idx]
+				if t == nil {
+					if !s.addObject() {
+						return raw
+					}
+					t = &terminalCall{}
+					c.calls[idx] = t
+				}
+				if terminalPresent(call["id"]) {
+					id := terminalString(call["id"])
+					if id == "" || (t.id != "" && t.id != id) {
+						c.invalid = true
+						break
+					}
+					if t.id == "" {
+						if !s.addBytes(len(id)) {
+							return raw
+						}
+						t.id = id
+					}
+				}
+				if terminalPresent(call["function"]) {
+					fn := terminalObject(call["function"])
+					if fn == nil {
+						c.invalid = true
+						break
+					}
+					for key, dst := range map[string]*string{"name": &t.name, "arguments": &t.args} {
+						if _, exists := fn[key]; !exists {
+							continue
+						}
+						var value string
+						if json.Unmarshal(fn[key], &value) != nil {
+							c.invalid = true
+							break
+						}
+						if !s.addBytes(len(value)) {
+							return raw
+						}
+						*dst += value
+					}
+				}
+			}
+		}
+		if c.invalid {
+			continue
+		}
+		var reason string
+		if json.Unmarshal(choice["finish_reason"], &reason) != nil {
+			continue
+		}
+		if bytes.Equal(bytes.TrimSpace(choice["finish_reason"]), []byte(`""`)) {
+			choice["finish_reason"] = json.RawMessage(`null`)
+			changed = true
+		} else if reason != "" {
+			c.ended = true
+			if reason == "stop" && len(c.calls) > 0 {
+				ready := true
+				for _, call := range c.calls {
+					if !call.ready() {
+						ready = false
+						break
+					}
+				}
+				if ready {
+					choice["finish_reason"] = json.RawMessage(`"tool_calls"`)
+					changed = true
+				}
+			}
+		}
+		choices[i] = terminalMarshal(choice, choiceRaw)
+	}
+	if !changed || s.invalid {
+		return raw
+	}
+	doc["choices"] = terminalMarshal(choices, doc["choices"])
+	return terminalMarshal(doc, raw)
+}
+
+func (s *NativeTerminalStream) messageData(doc map[string]json.RawMessage, raw []byte) []byte {
+	switch terminalString(doc["type"]) {
+	case "message_start":
+		if s.started {
+			s.invalid = true
+			return raw
+		}
+		s.started = true
+		s.blocks = make(map[int]*terminalBlock)
+	case "content_block_start":
+		idx, ok := terminalIndex(doc["index"])
+		part := terminalObject(doc["content_block"])
+		if !s.started || !ok || part == nil || s.blocks[idx] != nil || !s.addObject() {
+			s.invalid = true
+			return raw
+		}
+		b := &terminalBlock{}
+		if terminalString(part["type"]) == "tool_use" {
+			b.tool = true
+			b.call.id = terminalString(part["id"])
+			b.call.name = terminalString(part["name"])
+			b.initial = part["input"]
+			if b.call.id == "" || b.call.name == "" || terminalObject(b.initial) == nil || !s.addBytes(len(b.call.id)+len(b.call.name)+len(b.initial)) {
+				s.invalid = true
+				return raw
+			}
+		}
+		s.blocks[idx] = b
+	case "content_block_delta":
+		idx, ok := terminalIndex(doc["index"])
+		delta := terminalObject(doc["delta"])
+		b := s.blocks[idx]
+		if !ok || b == nil || b.closed || delta == nil {
+			s.invalid = true
+			return raw
+		}
+		if b.tool {
+			var text string
+			if terminalString(delta["type"]) != "input_json_delta" || json.Unmarshal(delta["partial_json"], &text) != nil || !s.addBytes(len(text)) {
+				s.invalid = true
+				return raw
+			}
+			b.call.args += text
+		}
+	case "content_block_stop":
+		idx, ok := terminalIndex(doc["index"])
+		b := s.blocks[idx]
+		if !ok || b == nil || b.closed {
+			s.invalid = true
+			return raw
+		}
+		b.closed = true
+	case "message_delta":
+		delta := terminalObject(doc["delta"])
+		if delta == nil || !terminalPresent(delta["stop_reason"]) {
+			return raw
+		}
+		s.ended = true
+		if terminalString(delta["stop_reason"]) != "end_turn" || terminalPresent(delta["stop_sequence"]) || !s.started {
+			return raw
+		}
+		tools := 0
+		for _, b := range s.blocks {
+			if !b.closed {
+				return raw
+			}
+			if !b.tool {
+				continue
+			}
+			if b.call.args == "" {
+				b.call.args = string(b.initial)
+			} else if len(terminalObject(b.initial)) != 0 {
+				return raw
+			}
+			if !b.call.ready() {
+				return raw
+			}
+			tools++
+		}
+		if tools > 0 {
+			delta["stop_reason"] = json.RawMessage(`"tool_use"`)
+			doc["delta"] = terminalMarshal(delta, doc["delta"])
+			return terminalMarshal(doc, raw)
+		}
+	case "error", "message_stop":
+		s.ended = true
+	}
+	return raw
+}
+
+func (c *terminalCall) ready() bool {
+	return strings.TrimSpace(c.id) != "" && strings.TrimSpace(c.name) != "" && terminalObject([]byte(c.args)) != nil
+}
+func (s *NativeTerminalStream) addObject() bool {
+	s.objects++
+	if s.objects > terminalObjectLimit {
+		s.invalid = true
+	}
+	return !s.invalid
+}
+func (s *NativeTerminalStream) addBytes(n int) bool {
+	s.bytes += n
+	if s.bytes > terminalStateLimit {
+		s.invalid = true
+		s.choices = nil
+		s.blocks = nil
+	}
+	return !s.invalid
+}
+func terminalIndex(raw json.RawMessage) (int, bool) {
+	var n int
+	err := json.Unmarshal(raw, &n)
+	return n, err == nil && len(raw) > 0 && string(raw) != "null" && n >= 0 && n < terminalObjectLimit
+}
+func terminalString(raw json.RawMessage) string { var s string; _ = json.Unmarshal(raw, &s); return s }
+func terminalName(raw json.RawMessage) bool     { return strings.TrimSpace(terminalString(raw)) != "" }
+func terminalPresent(raw json.RawMessage) bool {
+	return len(raw) != 0 && !bytes.Equal(bytes.TrimSpace(raw), []byte("null")) && !bytes.Equal(bytes.TrimSpace(raw), []byte(`""`))
+}
+func terminalHasError(doc map[string]json.RawMessage) bool {
+	return terminalPresent(doc["error"]) || terminalPresent(doc["incomplete_details"]) || terminalString(doc["type"]) == "error"
+}
+func terminalMarshal(v any, fallback []byte) []byte {
+	out, err := json.Marshal(v)
+	if err != nil {
+		return fallback
+	}
+	return out
+}
+
+// Reject duplicate keys in each object we interpret instead of turning an
+// ambiguous upstream payload into a seemingly valid response by re-encoding it.
+func terminalObject(raw []byte) map[string]json.RawMessage {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	t, err := d.Token()
+	if err != nil || t != json.Delim('{') {
+		return nil
+	}
+	obj := make(map[string]json.RawMessage)
+	for d.More() {
+		k, err := d.Token()
+		if err != nil {
+			return nil
+		}
+		key, ok := k.(string)
+		if !ok {
+			return nil
+		}
+		if _, duplicate := obj[key]; duplicate {
+			return nil
+		}
+		var value json.RawMessage
+		if d.Decode(&value) != nil {
+			return nil
+		}
+		obj[key] = value
+	}
+	if t, err = d.Token(); err != nil || t != json.Delim('}') {
+		return nil
+	}
+	if _, err = d.Token(); err != io.EOF {
+		return nil
+	}
+	return obj
+}

--- a/transform/shared/native_terminal_test.go
+++ b/transform/shared/native_terminal_test.go
@@ -1,0 +1,196 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const nativeChatTool = `{"id":"chat-1","object":"chat.completion","model":"example","choices":[{"index":0,"message":{"role":"assistant","content":null,"reasoning_content":"keep reasoning","tool_calls":[{"id":"call-1","type":"function","function":{"name":"echo","arguments":"{\"value\":\"ok\"}"}}]},"finish_reason":"stop"}],"usage":{"total_tokens":9007199254740993},"extension":{"signature":"keep"}}`
+const nativeMessageTool = `{"type":"message","role":"assistant","id":"msg-1","content":[{"type":"thinking","thinking":"keep","signature":"signed"},{"type":"tool_use","id":"tool-1","name":"echo","input":{"value":"ok"}}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"output_tokens":12}}`
+
+func TestNativeTerminalJSONRepairsOnlyCompleteToolStops(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		protocol  NativeTerminalProtocol
+		raw, want string
+	}{
+		{"chat", NativeChatCompletions, nativeChatTool, `"finish_reason":"tool_calls"`},
+		{"messages", NativeMessages, nativeMessageTool, `"stop_reason":"tool_use"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := NormalizeNativeTerminalJSON([]byte(tc.raw), tc.protocol)
+			if !bytes.Contains(out, []byte(tc.want)) {
+				t.Fatalf("missing corrected terminal: %s", out)
+			}
+			var before, after map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tc.raw), &before); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal(out, &after); err != nil {
+				t.Fatal(err)
+			}
+			for _, key := range []string{"usage", "extension", "content", "id", "model"} {
+				if !jsonEqual(before[key], after[key]) {
+					t.Errorf("changed %s: %s != %s", key, before[key], after[key])
+				}
+			}
+			if tc.protocol == NativeChatCompletions && !bytes.Contains(out, []byte(`9007199254740993`)) {
+				t.Fatal("large integer rounded")
+			}
+		})
+	}
+}
+func jsonEqual(a, b []byte) bool {
+	var aa, bb bytes.Buffer
+	_ = json.Compact(&aa, a)
+	_ = json.Compact(&bb, b)
+	return bytes.Equal(aa.Bytes(), bb.Bytes())
+}
+
+func TestNativeTerminalJSONDoesNotHideFailureOrAmbiguity(t *testing.T) {
+	cases := []struct {
+		name, raw string
+		protocol  NativeTerminalProtocol
+	}{
+		{"length", strings.Replace(nativeChatTool, `"finish_reason":"stop"`, `"finish_reason":"length"`, 1), NativeChatCompletions},
+		{"filter", strings.Replace(nativeChatTool, `"finish_reason":"stop"`, `"finish_reason":"content_filter"`, 1), NativeChatCompletions},
+		{"missing_finish", strings.Replace(nativeChatTool, `"finish_reason":"stop"`, `"finish_reason":null`, 1), NativeChatCompletions},
+		{"truncated_args", strings.Replace(nativeChatTool, `{\"value\":\"ok\"}`, `{\"value\":`, 1), NativeChatCompletions},
+		{"non_object_args", strings.Replace(nativeChatTool, `{\"value\":\"ok\"}`, `[]`, 1), NativeChatCompletions},
+		{"empty_id", strings.Replace(nativeChatTool, `"id":"call-1"`, `"id":""`, 1), NativeChatCompletions},
+		{"refusal", strings.Replace(nativeChatTool, `"content":null`, `"content":null,"refusal":"not allowed"`, 1), NativeChatCompletions},
+		{"error", strings.Replace(nativeChatTool, `"object":`, `"error":{"type":"failure"},"object":`, 1), NativeChatCompletions},
+		{"duplicate_finish", strings.Replace(nativeChatTool, `"finish_reason":"stop"`, `"finish_reason":"length","finish_reason":"stop"`, 1), NativeChatCompletions},
+		{"duplicate_root", strings.Replace(nativeChatTool, `"object":`, `"object":"other","object":`, 1), NativeChatCompletions},
+		{"messages_max_tokens", strings.Replace(nativeMessageTool, `"end_turn"`, `"max_tokens"`, 1), NativeMessages},
+		{"messages_sequence", strings.Replace(nativeMessageTool, `"stop_sequence":null`, `"stop_sequence":"end"`, 1), NativeMessages},
+		{"messages_bad_input", strings.Replace(nativeMessageTool, `"input":{"value":"ok"}`, `"input":"bad"`, 1), NativeMessages},
+		{"messages_empty_tool_name", strings.Replace(nativeMessageTool, `"name":"echo"`, `"name":""`, 1), NativeMessages},
+		{"wrong_protocol", nativeMessageTool, NativeChatCompletions},
+		{"not_json", "{bad", NativeChatCompletions},
+		{"already_correct", strings.Replace(nativeChatTool, `"finish_reason":"stop"`, `"finish_reason":"tool_calls"`, 1), NativeChatCompletions},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := NormalizeNativeTerminalJSON([]byte(tc.raw), tc.protocol)
+			if string(out) != tc.raw {
+				t.Fatalf("rewrote protected payload: %s", out)
+			}
+		})
+	}
+}
+func chatChunk(delta, reason string) []byte {
+	return []byte(`{"id":"chat-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":` + delta + `,"finish_reason":` + reason + `}],"usage":{"total_tokens":9007199254740993}}`)
+}
+
+func TestNativeTerminalChatStreamNullAndCompletedTool(t *testing.T) {
+	s := NativeTerminalStream{Protocol: NativeChatCompletions}
+	start := chatChunk(`{"role":"assistant","tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"echo","arguments":"{\"value\":"}}]}`, `""`)
+	out := s.AddData(start)
+	if !bytes.Contains(out, []byte(`"finish_reason":null`)) {
+		t.Fatalf("empty string not normalized: %s", out)
+	}
+	delta := chatChunk(`{"tool_calls":[{"index":0,"function":{"arguments":"\"ok\"}"}}]}`, `null`)
+	if out := s.AddData(delta); !bytes.Equal(out, delta) {
+		t.Fatalf("changed nonterminal data: %s", out)
+	}
+	stop := chatChunk(`{}`, `"stop"`)
+	out = s.AddData(stop)
+	if !bytes.Contains(out, []byte(`"finish_reason":"tool_calls"`)) {
+		t.Fatalf("missing tool stop: %s", out)
+	}
+	if !bytes.Contains(out, []byte(`9007199254740993`)) {
+		t.Fatal("lost exact usage")
+	}
+	if out := s.AddData(stop); !bytes.Equal(out, stop) {
+		t.Fatal("changed repeated terminal")
+	}
+}
+
+func TestNativeTerminalChatStreamDoesNotRepairIncompleteTools(t *testing.T) {
+	for _, reason := range []string{`"stop"`, `"length"`, `"content_filter"`} {
+		s := NativeTerminalStream{Protocol: NativeChatCompletions}
+		s.AddData(chatChunk(`{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"echo","arguments":"{"}}]}`, `null`))
+		stop := chatChunk(`{}`, reason)
+		if out := s.AddData(stop); !bytes.Equal(out, stop) {
+			t.Fatalf("rewrote incomplete/failed tool: %s", out)
+		}
+	}
+	s := NativeTerminalStream{Protocol: NativeChatCompletions}
+	stop := chatChunk(`{}`, `"stop"`)
+	if out := s.AddData(stop); !bytes.Equal(out, stop) {
+		t.Fatal("text stream became tool stream")
+	}
+}
+
+func feedMessageTool(s *NativeTerminalStream, partial string, closeBlock bool) {
+	s.AddData([]byte(`{"type":"message_start","message":{"id":"m","role":"assistant","content":[]}}`))
+	s.AddData([]byte(`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"t","name":"echo","input":{}}}`))
+	if partial != "" {
+		encoded, _ := json.Marshal(partial)
+		s.AddData([]byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":` + string(encoded) + `}}`))
+	}
+	if closeBlock {
+		s.AddData([]byte(`{"type":"content_block_stop","index":0}`))
+	}
+}
+func TestNativeTerminalMessagesStreamRequiresCompleteClosedTool(t *testing.T) {
+	for _, tc := range []struct {
+		name, args, reason string
+		closed, wantChange bool
+	}{
+		{"complete", `{"value":"ok"}`, "end_turn", true, true},
+		{"empty_object", "", "end_turn", true, true},
+		{"truncated", `{"value":`, "end_turn", true, false},
+		{"open", `{}`, "end_turn", false, false},
+		{"limit", `{}`, "max_tokens", true, false},
+		{"refusal", `{}`, "refusal", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NativeTerminalStream{Protocol: NativeMessages}
+			feedMessageTool(&s, tc.args, tc.closed)
+			raw := []byte(`{"type":"message_delta","delta":{"stop_reason":"` + tc.reason + `","stop_sequence":null},"usage":{"output_tokens":37}}`)
+			out := s.AddData(raw)
+			if tc.wantChange {
+				if !bytes.Contains(out, []byte(`"stop_reason":"tool_use"`)) {
+					t.Fatalf("not repaired: %s", out)
+				}
+			} else if !bytes.Equal(raw, out) {
+				t.Fatalf("invalid terminal repaired: %s", out)
+			}
+		})
+	}
+}
+
+func TestNativeTerminalStreamStateIsBoundedAndDoesNotRepairAfterError(t *testing.T) {
+	s := NativeTerminalStream{Protocol: NativeChatCompletions}
+	fragment, _ := json.Marshal(strings.Repeat("a", terminalStateLimit+1))
+	s.AddData(chatChunk(`{"tool_calls":[{"index":0,"id":"c","function":{"name":"echo","arguments":`+string(fragment)+`}}]}`, `null`))
+	raw := chatChunk(`{}`, `""`)
+	if out := s.AddData(raw); !bytes.Equal(out, raw) || !s.invalid || s.choices != nil {
+		t.Fatal("overflow did not disable repair/release retained tool state")
+	}
+	for _, protocol := range []NativeTerminalProtocol{NativeChatCompletions, NativeMessages} {
+		s := NativeTerminalStream{Protocol: protocol}
+		s.AddData([]byte(`{"type":"error","error":{"message":"fail"}}`))
+		raw := chatChunk(`{"content":"text"}`, `""`)
+		if out := s.AddData(raw); !bytes.Equal(out, raw) {
+			t.Fatal("repair after error")
+		}
+	}
+}
+
+func TestNativeTerminalChatStreamDoesNotRepairAfterDone(t *testing.T) {
+	s := NativeTerminalStream{Protocol: NativeChatCompletions}
+	s.AddData(chatChunk(`{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"echo","arguments":"{}"}}]}`, `null`))
+	done := []byte(" [DONE]\n")
+	if out := s.AddData(done); !bytes.Equal(out, done) {
+		t.Fatal("changed stream delimiter")
+	}
+	late := chatChunk(`{}`, `"stop"`)
+	if out := s.AddData(late); !bytes.Equal(out, late) {
+		t.Fatalf("repaired data after the stream ended: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize native Chat Completions and Messages tool termination only when the observed tool calls are complete. Convert empty non-terminal Chat finish reasons to `null` without fabricating completion events.
- Preserve error/length/refusal outcomes, reasoning and signatures, usage precision, attachment responses, opaque representations, and bytes after `[DONE]`.
- Add opt-in `--tool-stream` acceptance for Chat, Responses, and Messages, including fragmented arguments, native reasoning replay, and a fresh receipt that must be consumed in the streamed followup. The default 12-request budget is unchanged; the opt-in limit is 18.

## Verification
- `go build ./cmd/server`, `go vet ./...`, and the complete SQLite race suite via `bash scripts/go-race.sh`: passed with bounded package concurrency.
- Complete PostgreSQL suite against a dedicated test database: passed. The recorded hashes of all 874 Go/schema/module source files still match the branch.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/e2e -p test_verify_real_relay.py`: 54 tests passed.
- `go test -p 1 ./docs -count=1`: passed; diff whitespace, gofmt, and branch leak checks passed.
- Fresh-database full-stack fixture through admin onboarding, downstream key/routing, and actual HTTP relay: default 9 scenarios / 12 requests and opt-in 12 scenarios / 18 requests passed. Temporary fixture processes were stopped.
- Negative controls: removing the attachment/post-DONE fixes or the receipt requirement fails the targeted checks; restored source passes and hashes are unchanged.

## Scope
The full-stack fixture uses a deterministic upstream. It is not a real-provider or downstream-CLI acceptance claim. This change does not deploy production or alter credentials, retry defaults, or release policy.