### PR TITLE
fix(proxy): record explicit SSE errors as failed attempts

### DIFF
--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -64,8 +64,8 @@ Gemini-native bodies are converted in `transform/gemini/generate_content`; the
 
 ## Error shape (/v1 surface)
 
-All `/v1` surface failures — auth middleware, rate limits, body limit, and
-handler errors — use one OpenAI-compatible envelope so SDKs and upstream-relay
+Before streaming begins, Metapi-generated `/v1` failures — auth middleware,
+rate limits, body limit, and handler errors — use one OpenAI-compatible envelope so SDKs and upstream-relay
 integrations (e.g. new-api consuming Metapi as a channel) parse them uniformly:
 
 ```json
@@ -94,6 +94,22 @@ Status conventions (OpenAI-aligned):
 The admin surface (`/api/*`) keeps the flat `{"error", "errorCode"}` body
 documented in [conventions.md](conventions.md); the two contracts never mix
 (the global body-limit middleware picks the shape by path prefix).
+
+### Errors inside an upstream SSE response
+
+An explicit error in a readable HTTP 200 SSE response (such as `event: error`,
+`response.failed`, or a non-null top-level `error` payload) records a failed
+request with HTTP 502 in the proxy log and does not count as channel success.
+This does not require `PROXY_ERROR_KEYWORDS` or `PROXY_EMPTY_CONTENT_FAIL`.
+The default log classification is `upstream_error_event`; an explicitly
+configured keyword match retains its existing classification.
+
+Once SSE headers have been sent, the downstream HTTP 200 and relayed event
+bytes remain intact: no channel retry, protocol fallback, or appended JSON
+response is attempted. Only usage actually parsed from the stream is recorded.
+Ordinary output containing the word "error", `error: null`, and a healthy
+client disconnect are not upstream errors; a disconnect cannot erase an
+explicit upstream error already observed.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-**Last updated**: 2026-09-03
+**Last updated**: 2026-09-07
 
 > **Navigation**: full docs map in [`docs/README.md`](README.md) · route list in [`api/routes-inventory.md`](api/routes-inventory.md) · environment variables in [`configuration.md`](configuration.md).
 >
@@ -189,16 +189,15 @@ truncation, or downstream disconnect.
 
 Two rules keep that classification honest:
 
-- **One judge for content.** Whether an upstream answer counts as a failure on
-  its content — a configured `PROXY_ERROR_KEYWORDS` hit, or an empty completion
-  when `PROXY_EMPTY_CONTENT_FAIL` is on — is decided by a single pure function
-  in `proxy`, fed by both paths: the buffered body directly, the stream through
-  the bounded SSE analyser. The two paths cannot reach different verdicts for
-  the same upstream content.
-- **A downstream disconnect is not an upstream fault.** The channel answered
-  correctly, so recording the cancel against it would poison channel health
-  with user behaviour. Usage already extracted from earlier SSE events is still
-  accounted; tokens are never invented for content that did not arrive.
+- **One judge for content.** A single pure function in `proxy` applies the
+  optional `PROXY_ERROR_KEYWORDS` and `PROXY_EMPTY_CONTENT_FAIL` heuristics to
+  facts supplied by the buffered body or bounded SSE analyser. Explicit SSE
+  error events also fail without either heuristic being enabled; prior output,
+  usage, or a later `[DONE]` cannot turn an observed error into success.
+- **A downstream disconnect alone is not an upstream fault.** A client cancel
+  does not penalize a healthy channel, but cannot erase an upstream error
+  already parsed before the disconnect. Usage extracted from earlier SSE
+  events is still accounted; tokens are never invented for missing content.
 
 Every other ending — an idle upstream, a mid-stream reset, a truncated relay —
 goes through the failure path, whose status, reason text and terminal metric

--- a/handler/proxy/sse_parser.go
+++ b/handler/proxy/sse_parser.go
@@ -287,7 +287,7 @@ func trimLeadingSpace(s string) string {
 }
 
 // IsSseErrorEvent checks if an SSE event's data payload represents an error.
-// Detects JSON objects containing "error" keys at the top level, or error
+// Detects JSON objects containing non-null "error" keys at the top level, or error
 // event types like "response.failed", "error".
 func IsSseErrorEvent(ev SseEvent) bool {
 	if ev.Event == "error" || ev.Event == "response.failed" {
@@ -307,7 +307,7 @@ func IsSseErrorEvent(ev SseEvent) bool {
 		return false
 	}
 
-	if _, hasError := parsed["error"]; hasError {
+	if parsed["error"] != nil {
 		return true
 	}
 

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -655,9 +655,9 @@ func dispatchEndpointAttemptWithContinue(
 			return true, nil, false
 		}
 		if streamVerdict != nil && streamVerdict.Failed {
-			// Content-level failure on a stream that ended cleanly at the
-			// transport level: judged by the same pure judge the buffered path
-			// uses, so the two paths cannot disagree. Streaming already began,
+			// A content-level failure remains authoritative even if the client
+			// disconnected after an explicit upstream error was observed. The
+			// shared content judge owns this verdict. Streaming already began,
 			// so this is terminal; partial usage is still accounted.
 			totalLatencyMs := time.Since(startedAt).Milliseconds()
 			slog.Warn("stream content-based failure recorded",

--- a/handler/proxy/upstream_stream.go
+++ b/handler/proxy/upstream_stream.go
@@ -37,10 +37,10 @@ const (
 	// and stopped early, so the client received an incomplete answer.
 	streamEndedTruncated
 	// streamEndedClientDisconnect means the downstream client cancelled or its
-	// write side went away. Deliberately NOT an upstream fault: the channel
-	// answered correctly, so recording it as a failure would poison channel
-	// health with user cancel behaviour. Usage already extracted is still
-	// returned for accounting.
+	// write side went away. This ending alone is NOT an upstream fault:
+	// without an explicit upstream error, recording it as a failure would
+	// poison channel health with user cancel behaviour. Usage already
+	// extracted is still returned for accounting.
 	streamEndedClientDisconnect
 )
 
@@ -152,10 +152,10 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 				LogSseErrorEvents(result.ErrorEvents)
 			}
 		}
-		if end == streamEndedClientDisconnect {
-			// The client left before the upstream finished: there is no complete
-			// upstream answer to judge, and a content verdict here would be
-			// recorded against a channel that never got to finish. Still return
+		if end == streamEndedClientDisconnect && !result.HasErrorEvent {
+			// Without an explicit upstream error already observed, a client
+			// disconnect leaves no complete answer to judge. Do not penalize a
+			// channel that never got to finish. Still return
 			// any usage already extracted from earlier SSE events (best-effort
 			// partial) — never invent tokens.
 			if result.Usage.Found {
@@ -295,12 +295,13 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 // being special-cased here, keeping one owner of the verdict.
 func judgeStreamContent(statusCode int, result incrementalSseAnalysisResult, latencyMs int64, bodyUnreadable bool) proxy.UpstreamVerdict {
 	verdict := proxy.JudgeUpstreamContent(proxy.UpstreamContentFacts{
-		StatusCode: statusCode,
-		Streaming:  true,
-		RawText:    sseErrorEventText(result.ErrorEvents),
-		HasOutput:  result.HasDataEvent,
-		Usage:      result.Usage.ToUsageSummary(),
-		Unreadable: bodyUnreadable,
+		StatusCode:    statusCode,
+		Streaming:     true,
+		RawText:       sseErrorEventText(result.ErrorEvents),
+		HasOutput:     result.HasDataEvent,
+		HasErrorEvent: result.HasErrorEvent,
+		Usage:         result.Usage.ToUsageSummary(),
+		Unreadable:    bodyUnreadable,
 	})
 	if verdict.Failed {
 		slog.Warn("stream content-based failure detected",

--- a/handler/proxy/upstream_stream_error_accounting_test.go
+++ b/handler/proxy/upstream_stream_error_accounting_test.go
@@ -1,0 +1,227 @@
+package proxyhandler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/proxy"
+	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// Exercise the production handlers with the optional content heuristics off.
+// A spare channel and retry budget make any retry after SSE commitment visible.
+func TestDispatchStreamExplicitErrorAccounting(t *testing.T) {
+	prevCfg, prevRt := config.GetSafe(), config.RuntimeSafe()
+	config.Set(&config.Config{ProxyMaxChannelAttempts: 3})
+	config.SetRuntime(&config.RuntimeSettings{})
+	t.Cleanup(func() {
+		config.Set(prevCfg)
+		config.SetRuntime(prevRt)
+	})
+
+	protocols := []struct {
+		name, path, model, request string
+		handle                     http.HandlerFunc
+		output, failure, done      string
+		hasUsage                   bool
+	}{
+		{
+			name: "chat", path: "/v1/chat/completions", model: "gpt-4o",
+			request: `{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`,
+			handle:  HandleChatCompletions,
+			output: `data: {"choices":[{"delta":{"content":"The word error, including insufficient_quota, is ordinary output."}}]}` + "\n\n" +
+				`data: {"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}` + "\n\n",
+			failure: `data: {"type":"error","error":{"message":"insufficient_quota","type":"invalid_request_error"}}` + "\n\n",
+			done:    "data: [DONE]\n\n", hasUsage: true,
+		},
+		{
+			name: "messages", path: "/v1/messages", model: "claude-sonnet-test",
+			request: `{"model":"claude-sonnet-test","stream":true,"max_tokens":32,"messages":[{"role":"user","content":"hi"}]}`,
+			handle:  HandleClaudeMessages,
+			output: "event: message_start\n" + `data: {"type":"message_start","message":{"usage":{"input_tokens":2,"output_tokens":0}}}` + "\n\n" +
+				"event: content_block_delta\n" + `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The word error is ordinary output."}}` + "\n\n" +
+				"event: message_delta\n" + `data: {"type":"message_delta","usage":{"output_tokens":3}}` + "\n\n",
+			failure: "event: error\n" + `data: {"type":"error","error":{"type":"overloaded_error","message":"fixture stream failure"}}` + "\n\n",
+			done:    "event: message_stop\n" + `data: {"type":"message_stop"}` + "\n\n", hasUsage: true,
+		},
+		{
+			name: "responses", path: "/v1/responses", model: "gpt-4o",
+			request: `{"model":"gpt-4o","stream":true,"input":"hi"}`,
+			handle:  func(w http.ResponseWriter, r *http.Request) { HandleResponses(w, r, "/v1/responses") },
+			output:  "event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","delta":"The word error is ordinary output."}` + "\n\n",
+			failure: "event: response.failed\n" + `data: {"type":"response.failed","response":{"status":"failed","error":{"code":"server_error","message":"fixture stream failure"}}}` + "\n\n",
+			done:    "event: response.completed\n" + `data: {"type":"response.completed","response":{"status":"completed","error":null}}` + "\n\n",
+		},
+	}
+	for _, p := range protocols {
+		for _, scenario := range []struct {
+			name             string
+			withOutput, fail bool
+		}{
+			{name: "error_only", fail: true},
+			{name: "output_then_error", withOutput: true, fail: true},
+			{name: "healthy_output_mentions_error", withOutput: true},
+		} {
+			t.Run(p.name+"/"+scenario.name, func(t *testing.T) {
+				var frames []string
+				if scenario.withOutput {
+					frames = append(frames, p.output)
+				}
+				if scenario.fail {
+					frames = append(frames, p.failure)
+				} else {
+					frames = append(frames, p.done)
+				}
+				// A trailing [DONE] must not erase an earlier explicit error.
+				if scenario.fail && p.name == "chat" {
+					frames = append(frames, p.done)
+				}
+				var calls atomic.Int32
+				upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					calls.Add(1)
+					w.Header().Set("Content-Type", "text/event-stream")
+					w.WriteHeader(http.StatusOK)
+					for _, frame := range frames {
+						_, _ = w.Write([]byte(frame))
+						w.(http.Flusher).Flush()
+					}
+				}))
+				t.Cleanup(upstream.Close)
+
+				selected := routing.SelectedChannel{
+					Channel:    store.RouteChannel{ID: 42, Enabled: true},
+					Account:    store.Account{ID: 7, Status: "active"},
+					Site:       store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+					TokenValue: "upstream-token", ActualModel: p.model,
+				}
+				next := selected
+				next.Channel.ID = 43
+				router := &upstreamTestRouter{selected: selected, next: &next}
+				var logs []proxy.ProxyLogEntry
+				SetUpstreamConfig(&UpstreamConfig{
+					Router: router, Executor: proxy.NewRuntimeExecutor(10 * time.Second),
+					LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+						logs = append(logs, entry)
+						return nil
+					},
+				})
+				t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+				rec := httptest.NewRecorder()
+				p.handle(rec, makeProxyReq(http.MethodPost, p.path, p.request))
+				if calls.Load() != 1 || len(router.policies) != 1 {
+					t.Fatalf("committed stream retried: upstream calls=%d, channel selections=%d", calls.Load(), len(router.policies))
+				}
+				if rec.Code != http.StatusOK || !rec.Flushed || !strings.HasPrefix(rec.Header().Get("Content-Type"), "text/event-stream") {
+					t.Fatalf("committed SSE response changed: status=%d, flushed=%v, headers=%v", rec.Code, rec.Flushed, rec.Header())
+				}
+				if got, want := rec.Body.String(), strings.Join(frames, ""); got != want {
+					t.Fatalf("SSE was rewritten or appended to:\n got %q\nwant %q", got, want)
+				}
+				if len(logs) != 1 || logs[0].RetryCount != 0 {
+					t.Fatalf("proxy logs = %+v, want one terminal attempt without retry", logs)
+				}
+				entry := logs[0]
+				if scenario.fail {
+					assertFailureSurface(t, router, &logs, http.StatusBadGateway, "Upstream returned an error event")
+					if entry.Status != "failed" {
+						t.Fatalf("proxy log status = %q, want failed", entry.Status)
+					}
+				} else if len(router.failures) != 0 || len(router.successes) != 1 || entry.Status != "success" || entry.HTTPStatus != http.StatusOK {
+					t.Fatalf("healthy stream was penalized: failures=%+v successes=%+v log=%+v", router.failures, router.successes, entry)
+				}
+				wantUsage := [3]int64{}
+				wantSource := usageSourceUnknown
+				if scenario.withOutput && p.hasUsage {
+					wantUsage = [3]int64{2, 3, 5}
+					wantSource = usageSourceUpstream
+				}
+				if entry.PromptTokens == nil || entry.CompletionTokens == nil || entry.TotalTokens == nil {
+					t.Fatalf("usage fields missing: %+v", entry)
+				}
+				if got := [3]int64{*entry.PromptTokens, *entry.CompletionTokens, *entry.TotalTokens}; got != wantUsage || entry.UsageSource != wantSource {
+					t.Fatalf("usage = %v (%s), want %v (%s)", got, entry.UsageSource, wantUsage, wantSource)
+				}
+			})
+		}
+	}
+}
+
+func TestStreamExplicitErrorRecognitionAndVerdict(t *testing.T) {
+	prevRt := config.RuntimeSafe()
+	config.SetRuntime(&config.RuntimeSettings{})
+	t.Cleanup(func() { config.SetRuntime(prevRt) })
+
+	for _, tc := range []struct {
+		name, frame string
+		wantError   bool
+	}{
+		{"named_error_without_data", "event: error\n\n", true},
+		{"named_response_failed", "event: response.failed\ndata: {}\n\n", true},
+		{"payload_error_type", `data: {"type":"error","message":"fixture failure"}` + "\n\n", true},
+		{"payload_response_failed", `data: {"type":"response.failed","response":{"error":{"code":"server_error"}}}` + "\n\n", true},
+		{"error_object", `data: {"error":{"message":"fixture failure"}}` + "\n\n", true},
+		{"error_string", `data: {"error":"fixture failure"}` + "\n\n", true},
+		{"explicit_error_with_null_payload", `data: {"type":"error","error":null}` + "\n\n", true},
+		{"null_error_is_not_failure", `data: {"error":null,"choices":[{"delta":{"content":"hello"}}]}` + "\n\n", false},
+		{"quoted_error_in_output", `data: {"choices":[{"delta":{"content":"{\"error\":\"ordinary text\"}"}}]}` + "\n\n", false},
+		{"plain_text_mentions_error", "data: error is an ordinary word\n\n", false},
+		{"completed_response", "event: response.completed\n" + `data: {"type":"response.completed","response":{"error":null,"status":"completed"}}` + "\n\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			analyzer := newIncrementalSseAnalyzer()
+			// Split within field names, JSON and SSE boundaries, not just events.
+			for start := 0; start < len(tc.frame); start += 7 {
+				analyzer.Push([]byte(tc.frame[start:min(start+7, len(tc.frame))]))
+			}
+			result := analyzer.Result()
+			if result.HasErrorEvent != tc.wantError {
+				t.Errorf("HasErrorEvent = %v, want %v", result.HasErrorEvent, tc.wantError)
+			}
+			verdict := judgeStreamContent(http.StatusOK, result, 1, false)
+			if verdict.Failed != tc.wantError {
+				t.Fatalf("verdict = %+v, want failure=%v with default content settings", verdict, tc.wantError)
+			}
+			if tc.wantError && (verdict.Code != "upstream_error_event" || verdict.Status != http.StatusBadGateway || verdict.Reason != "Upstream returned an error event") {
+				t.Fatalf("explicit error verdict must be stable and sanitized, got %+v", verdict)
+			}
+		})
+	}
+}
+
+// Downstream cancellation alone is not an upstream failure, but it must not
+// discard an explicit upstream error already parsed before the write failed.
+func TestHandleStreamExplicitErrorBeforeClientDisconnect(t *testing.T) {
+	prevRt := config.RuntimeSafe()
+	config.SetRuntime(&config.RuntimeSettings{})
+	t.Cleanup(func() { config.SetRuntime(prevRt) })
+
+	prefix := `data: {"choices":[{"delta":{"content":"partial answer"}}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}` + "\n\n"
+	failure := `data: {"type":"error","error":{"message":"fixture stream failure"}}` + "\n\n"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"text/event-stream"}},
+		Body:       &chunkedReader{chunks: []string{prefix, failure}},
+	}
+	writer := &disconnectAfterNWriter{ResponseRecorder: httptest.NewRecorder(), n: 2}
+	usage, end, verdict := handleStreamUpstream(writer, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil), resp, 1)
+	if end != streamEndedClientDisconnect {
+		t.Fatalf("stream end = %v, want client disconnect", end)
+	}
+	if verdict == nil || !verdict.Failed || verdict.Code != "upstream_error_event" {
+		t.Fatalf("observed upstream error was discarded on downstream disconnect: %+v", verdict)
+	}
+	if !usage.Found || usage.PromptTokens != 2 || usage.CompletionTokens != 3 || usage.TotalTokens != 5 {
+		t.Fatalf("partial upstream usage lost: %+v", usage)
+	}
+	if writer.Body.String() != prefix {
+		t.Fatalf("already committed SSE was rewritten: %q", writer.Body.String())
+	}
+}

--- a/proxy/failure_judge.go
+++ b/proxy/failure_judge.go
@@ -14,14 +14,17 @@ type UsageSummary struct {
 	TotalTokens      int
 }
 
-// FailureCode names why the single content judge declared a failure. Buffered
-// and streaming paths surface exactly this set, so one code means the same
-// thing wherever it is logged, stored or alerted on.
+// FailureCode names why the single content judge declared a failure. A code
+// keeps the same meaning wherever it is logged, stored or alerted on; explicit
+// protocol-error evidence is currently supplied by the streaming path.
 type FailureCode string
 
 const (
 	// FailureCodeNone means the content judgement found no failure.
 	FailureCodeNone FailureCode = ""
+	// FailureCodeErrorEvent means the upstream explicitly reported a protocol
+	// error, independent of optional keyword and empty-content heuristics.
+	FailureCodeErrorEvent FailureCode = "upstream_error_event"
 	// FailureCodeErrorKeyword means the upstream content matched an operator
 	// configured PROXY_ERROR_KEYWORDS entry.
 	FailureCodeErrorKeyword FailureCode = "upstream_error_keyword"
@@ -49,6 +52,9 @@ type UpstreamContentFacts struct {
 	// Streaming callers set it from the analyzer data-event flag; the buffered
 	// path leaves it false and the judge derives it from RawText.
 	HasOutput bool
+	// HasErrorEvent reports a parsed protocol error, not output mentioning an
+	// error. Streaming callers set it from the SSE analyzer.
+	HasErrorEvent bool
 	// Usage is the parsed usage summary (nil when the upstream sent none).
 	Usage *UsageSummary
 	// Unreadable reports that the bytes behind these facts could not be read at
@@ -81,7 +87,8 @@ type UpstreamVerdict struct {
 // Detection:
 // 0. Unreadable body: no judgement at all (see UpstreamContentFacts.Unreadable)
 // 1. Keyword matching: if config.ProxyErrorKeywords is non-empty, case-insensitive
-// 2. Empty content check: if ProxyEmptyContentFailEnabled and no completion tokens + no output
+// 2. Explicit protocol error events: always fail, even with output or usage
+// 3. Empty content check: if ProxyEmptyContentFailEnabled and no completion tokens + no output
 func JudgeUpstreamContent(facts UpstreamContentFacts) UpstreamVerdict {
 	pass := UpstreamVerdict{Code: FailureCodeNone}
 	if facts.Unreadable {
@@ -94,15 +101,10 @@ func JudgeUpstreamContent(facts UpstreamContentFacts) UpstreamVerdict {
 		return pass
 	}
 	rt := config.RuntimeSafe()
-	if rt == nil {
-		// No published runtime snapshot: nothing is configured, so nothing can
-		// be judged. Never invent a failure (and never panic on a request path).
-		return pass
-	}
 	rawText := strings.TrimSpace(facts.RawText)
 
 	// 1. Keyword matching
-	if len(rt.ProxyErrorKeywords) > 0 {
+	if rt != nil && len(rt.ProxyErrorKeywords) > 0 {
 		normalizedText := strings.ToLower(rawText)
 		for _, kw := range rt.ProxyErrorKeywords {
 			kw = strings.TrimSpace(strings.ToLower(kw))
@@ -120,8 +122,18 @@ func JudgeUpstreamContent(facts UpstreamContentFacts) UpstreamVerdict {
 		}
 	}
 
-	// 2. Empty content check
-	if rt.ProxyEmptyContentFailEnabled {
+	// 2. Explicit errors are evidence, not an opt-in content heuristic.
+	if facts.HasErrorEvent {
+		return UpstreamVerdict{
+			Failed: true,
+			Code:   FailureCodeErrorEvent,
+			Status: 502,
+			Reason: "Upstream returned an error event",
+		}
+	}
+
+	// 3. Empty content check
+	if rt != nil && rt.ProxyEmptyContentFailEnabled {
 		compTokens := 0
 		if facts.Usage != nil {
 			compTokens = facts.Usage.CompletionTokens

--- a/proxy/failure_judge_error_event_test.go
+++ b/proxy/failure_judge_error_event_test.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+func TestJudgeUpstreamContent_ExplicitErrorEvent(t *testing.T) {
+	prevRt := config.RuntimeSafe()
+	t.Cleanup(func() { config.SetRuntime(prevRt) })
+
+	errorVerdict := UpstreamVerdict{
+		Failed: true, Code: FailureCodeErrorEvent, Status: 502,
+		Reason: "Upstream returned an error event",
+	}
+	for _, tc := range []struct {
+		name                  string
+		runtime               *config.RuntimeSettings
+		hasError, hasOutput   bool
+		unreadable, withUsage bool
+		want                  UpstreamVerdict
+	}{
+		{
+			name: "default settings", runtime: &config.RuntimeSettings{},
+			hasError: true, want: errorVerdict,
+		},
+		{
+			name: "no runtime snapshot", hasError: true, want: errorVerdict,
+		},
+		{
+			name: "output and usage do not erase an error", runtime: &config.RuntimeSettings{},
+			hasError: true, hasOutput: true, withUsage: true, want: errorVerdict,
+		},
+		{
+			name: "explicit error before empty heuristic", runtime: &config.RuntimeSettings{ProxyEmptyContentFailEnabled: true},
+			hasError: true, want: errorVerdict,
+		},
+		{
+			name: "configured keyword retains its existing verdict", runtime: &config.RuntimeSettings{ProxyErrorKeywords: []string{"fixture"}},
+			hasError: true,
+			want:     UpstreamVerdict{Failed: true, Code: FailureCodeErrorKeyword, Status: 502, Reason: "Upstream response matched failure keyword: fixture"},
+		},
+		{
+			name: "unreadable body is not evidence", runtime: &config.RuntimeSettings{},
+			hasError: true, unreadable: true,
+		},
+		{
+			name: "ordinary output mentioning error", runtime: &config.RuntimeSettings{},
+			hasOutput: true,
+		},
+		{
+			name: "no runtime and no explicit error", hasOutput: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config.SetRuntime(tc.runtime)
+			facts := UpstreamContentFacts{
+				StatusCode: 200, Streaming: true,
+				RawText:       "fixture text mentioning error",
+				HasErrorEvent: tc.hasError, HasOutput: tc.hasOutput, Unreadable: tc.unreadable,
+			}
+			if tc.withUsage {
+				facts.Usage = &UsageSummary{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5}
+			}
+			if got := JudgeUpstreamContent(facts); got != tc.want {
+				t.Fatalf("verdict = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Feed the SSE analyzer's explicit error evidence into the existing content judge. HTTP 200 streams containing protocol errors now use the failure accounting/logging path even when optional content heuristics are disabled.
- Keep a committed downstream HTTP 200/SSE response unchanged: no channel retry, protocol fallback, extra JSON response, or success recording. Already parsed usage is retained.
- Do not classify `error: null` or ordinary output mentioning errors as failures. A later client disconnect no longer erases an upstream error already observed.
- Document the distinction between downstream wire status and the proxy log's `failed` / HTTP 502 result. Existing keyword priority, 504/524 retry defaults, quota semantics, and buffered JSON handling are unchanged.

## Verification
- Complete build, vet, SQLite race suite, and PostgreSQL suite passed against this commit. The PostgreSQL run used a fresh test database, removed after verification. All 1,905 tracked file hashes still match the tested input.
- Frontend: 250 files / 1,607 tests passed; typecheck, lint, format, knip and production build passed on the same commit. Only hash-verified static assets were transferred between test hosts; dependency directories were not shared.
- Validator: 54 offline tests passed. Focused Go regressions also passed on Windows and under Linux race detection.
- Full-stack fixture: real binary, fresh SQLite, admin onboarding/model discovery, downstream key, routing and actual HTTP relay passed the default 9 scenarios / 12 requests and opt-in 12 scenarios / 18 requests.
- Additional end-to-end error probe: downstream SSE bytes and HTTP 200 remained unchanged; exactly one failed proxy log with HTTP 502, 8 observed tokens and zero retries was persisted.
- Negative control: the same full-stack error probe fails against the pre-fix binary and passes against this binary. Helper/binary SHA-256 checks passed. Unit/handler red-to-green regressions independently cover Chat, Messages, Responses and disconnect/null-error boundaries.
- Whitespace, gofmt and branch leak checks passed. Interrupted runner output and the resource-limited frontend compiler attempt were retained; only checkpoints with matching source hashes and successful exit codes were reused.

## Scope
These full-stack checks use a deterministic upstream, not a real-provider or downstream-CLI acceptance claim. No production deployment, credential change, retry-policy change or release-policy change is included.