### PR TITLE
fix: close real relay and New API acceptance gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ web/playwright/.cache/
 
 # Local repro/scratch artifacts (never commit)
 .repro/
+.local/
 
 # local dev instance matrix (Wave 7 local toolchain)
 .dev-local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,14 @@ go vet ./...                          # Static analysis
 golangci-lint run --timeout=3m        # Lint check
 ```
 
+- **Development loop**: Edit, debug, and run focused checks in a local checkout or isolated worktree; SSH-only development is not required.
+  Full CI/E2E may run on an isolated test server. This does not replace the pre-push build/vet/full-race gate or required SQLite/PostgreSQL checks.
+- **Evidence identity**: Record the tested commit and any uncommitted diff, build/artifact digest, commands, and relevant environment.
+  A server run must trace back to those exact source inputs and artifacts. Reuse successful checks only for byte-identical tested inputs within their verified scope;
+  rerun affected checks when inputs or environments change, and never label an unrun check as passed. Evidence reuse does not bypass mandatory gates.
+- **Coverage claims**: Keep deterministic-fixture, real-model relay, and downstream-client E2E results distinct; none alone proves the others.
+  See `docs/testing.md` for test layers and the testbed SOP.
+
 ## Release Workflow
 
 0. 所有改动经 `fix/*` / `feature/*` 等短命分支 → PR → Squash merge 回 master（详见 [`docs/internal/git-workflow.md`](docs/internal/git-workflow.md)；master 受保护，禁止直接 push）
@@ -92,7 +100,10 @@ golangci-lint run --timeout=3m        # Lint check
 | `CHANGELOG.md`                                             | Version narrative                                                              |
 
 **Task/state SSOT:** Open work is tracked in **GitHub issues**; product state and the version narrative live in **GitHub releases** and `CHANGELOG.md`. Maintainer process/history/research moved out of this public repo. Temporary session summaries are **not** source of truth — archive or delete after use.
-**Ops host/image pin** lives outside this repository (private deployment surface). Public deployment notes: `docs/deployment.md`.
+**Public/private boundary:** Keep product code, public contracts, reusable tests, and sanitized fixtures in this repository.
+Private deployment/runbooks, host/image pins, and raw runtime/acceptance evidence belong in private documentation, not the published tree.
+Credentials belong in an external secret store, never in Git (including private repos) or `.local/`.
+Local-only drafts/handoffs must be ignored and do not replace task or runtime SSOT. Public deployment notes: `docs/deployment.md`.
 **Honesty:** Prefer 501 / documented residual over stub theater. Do not claim cluster-wide sticky or WS product without the matching milestone.
 
 ## Related References

--- a/docs/api/accounts.md
+++ b/docs/api/accounts.md
@@ -108,13 +108,22 @@ that token's limits at the upstream. The account detail form supports both paths
 leave the value empty to create upstream, or paste an existing value to import.
 An API-key-only connection cannot create/manage separate upstream tokens.
 
-### GET /api/account-tokens/:id, PUT /api/account-tokens/:id, DELETE /api/account-tokens/:id
+### PUT /api/account-tokens/:id, DELETE /api/account-tokens/:id
 
-Get, update, delete an account token. Updates accept `name`, `token`, `group`,
+Update or delete an account token. Updates accept `name`, `token`, `group`,
 `enabled`, `isDefault`, and `source`; omitted values are preserved. A metadata-only
 edit leaves `token` out of the request, keeping the stored secret unchanged.
 Quota, expiry, and IP restrictions are upstream-creation options, not token-update
-fields; manage an existing token's restrictions at the upstream site.
+fields; manage an existing token's restrictions at the upstream site. Updates
+return the masked token projection (`tokenMasked`, never the stored `token`); use
+the explicit `/value` endpoint when the caller needs to reveal a credential.
+
+For an enabled New API account with a usable credential, deletion resolves masked
+list keys through the ownership-checked key endpoint before deleting the matching
+upstream token. A refused/incomplete key lookup or a possibly truncated listing
+cannot prove absence: the operation fails and retains the local row. Existing
+local-only cleanup rules still apply to disabled/unmanaged sites and masked-pending
+records; those paths do not claim to remove a remote credential.
 
 ### GET /api/account-tokens/{id}/value
 

--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -46,7 +46,7 @@ func TestPublicMarkdownHygiene(t *testing.T) {
 			// covers published tree paths. CI clones are clean, while ignored
 			// .dev-local evidence may contain absolute capture paths by design.
 			if name == ".git" || name == "node_modules" || name == "dist" ||
-				name == ".claude" || name == ".dev-local" || name == ".worktrees" {
+				name == ".claude" || name == ".dev-local" || name == ".worktrees" || name == ".local" {
 				return filepath.SkipDir
 			}
 			return nil
@@ -283,7 +283,7 @@ func TestRelativeMarkdownLinksResolve(t *testing.T) {
 		if entry.IsDir() {
 			name := entry.Name()
 			if name == ".git" || name == "node_modules" || name == "dist" ||
-				name == ".claude" || name == ".worktrees" || name == ".dev-local" {
+				name == ".claude" || name == ".worktrees" || name == ".dev-local" || name == ".local" {
 				return filepath.SkipDir
 			}
 			return nil

--- a/docs/env_parity_test.go
+++ b/docs/env_parity_test.go
@@ -286,7 +286,7 @@ func collectEnvReaders(t *testing.T, root string) map[string]bool {
 		}
 		if entry.IsDir() {
 			switch entry.Name() {
-			case ".git", "node_modules", "dist", ".dev-local", ".worktrees", "web":
+			case ".git", "node_modules", "dist", ".dev-local", ".worktrees", ".local", "web":
 				return filepath.SkipDir
 			}
 			return nil
@@ -357,4 +357,33 @@ func readRepoFile(t *testing.T, root, rel string) string {
 		t.Fatalf("read %s: %v", rel, err)
 	}
 	return string(data)
+}
+
+func TestEnvReaderScanIgnoresLocalDrafts(t *testing.T) {
+	const probe = "ENV_PARITY_BOUNDARY_PROBE"
+	for _, dir := range []string{".local", "service", "local"} {
+		t.Run(dir, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, dir, "draft.go")
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			source := []byte("package draft\nimport \"os\"\nvar _ = os.Getenv(\"" + probe + "\")\n")
+			if err := os.WriteFile(path, source, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			readers := collectEnvReaders(t, root)
+			keys := []string{probe}
+			drift := detectDrift(keys, keys, keys, readers)
+			if dir == ".local" {
+				if len(readers) != 0 || !strings.Contains(drift, probe) {
+					t.Fatalf("private draft must not hide a shipped key with no production reader: readers=%v drift=%q", readers, drift)
+				}
+				return
+			}
+			if !readers[probe] || drift != "" {
+				t.Fatalf("public copy must count as a production reader: readers=%v drift=%q", readers, drift)
+			}
+		})
+	}
 }

--- a/docs/package_boundary_test.go
+++ b/docs/package_boundary_test.go
@@ -253,7 +253,7 @@ func scanBoundaryViolations(t *testing.T, root string) ([]violation, map[string]
 			// architecture and must not be treated as one.
 			if name == ".git" || name == "node_modules" || name == "dist" ||
 				name == ".claude" || name == "worktrees" || name == ".worktrees" ||
-				name == ".dev-local" || name == "vendor" {
+				name == ".dev-local" || name == ".local" || name == "vendor" {
 				return filepath.SkipDir
 			}
 			return nil
@@ -296,4 +296,29 @@ func scanBoundaryViolations(t *testing.T, root string) ([]violation, map[string]
 		t.Fatal(err)
 	}
 	return out, scanned
+}
+
+func TestPackageBoundaryScanIgnoresLocalDrafts(t *testing.T) {
+	for _, dir := range []string{".local", "store", "local"} {
+		t.Run(dir, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, dir, "draft.go")
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("package draft\nimport _ \"testing\"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			violations, scanned := scanBoundaryViolations(t, root)
+			if dir == ".local" {
+				if len(violations) != 0 || len(scanned) != 0 {
+					t.Fatalf("private draft entered the production scan: violations=%v scanned=%v", violations, scanned)
+				}
+				return
+			}
+			if len(violations) != 1 || violations[0].imp != "testing" || scanned[dir] != 1 {
+				t.Fatalf("public copy must trigger the production-import gate: violations=%v scanned=%v", violations, scanned)
+			}
+		})
+	}
 }

--- a/docs/pg_boolean_gate_test.go
+++ b/docs/pg_boolean_gate_test.go
@@ -114,7 +114,7 @@ func TestPgBooleanLiteralGateNoIntComparison(t *testing.T) {
 			}
 			scannedFiles++
 			dirsReached[dir] = true
-			saw[rel] = true
+			saw[filepath.ToSlash(rel)] = true
 
 			content := string(src)
 			for _, line := range strings.Split(content, "\n") {

--- a/docs/pg_rebind_gate_test.go
+++ b/docs/pg_rebind_gate_test.go
@@ -79,7 +79,7 @@ func TestPgRebindGateNoBareQuestionMarks(t *testing.T) {
 				return nil
 			}
 			sqlxFiles++
-			saw[rel] = true
+			saw[filepath.ToSlash(rel)] = true
 			content := string(src)
 			for _, line := range strings.Split(content, "\n") {
 				for _, re := range []*regexp.Regexp{dbCallRe, ctxDBCallRe} {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -231,13 +231,24 @@ merely announcing a tool call is not sufficient. Without the flag the default
 scenarios and 12-POST budget are unchanged. The streamed result followup must
 preserve the same native replay context as the non-stream contract: Chat
 `reasoning_content`, Messages thinking (including signature), and Responses
-reasoning items. Unsupported stream events and unsupported reasoning deltas
+reasoning items (including raw `reasoning_text`, which never counts as visible
+answer text or a receipt). Empty Chat tool identity continuation fields are no-update
+fragments; the assembled call still requires a valid ID and name. Unsupported stream
+events and unsupported reasoning deltas
 fail explicitly. The command makes at most 12 model POSTs by default (18 with
 `--tool-stream`), performs no automatic retries, and can incur upstream usage.
 It prints metadata only and exits nonzero for any failed scenario. Offline
 validator fixtures are instrument checks, not a substitute for a live `--tool-stream` run when claiming real streaming-tool
 coverage; a real downstream CLI contract still needs a separate exercise when it
 is part of the release scope.
+
+Tool scenarios default to `--tool-choice forced`. Use explicit `--tool-choice auto`
+when the upstream supports tools in automatic selection mode only (for example,
+a thinking model that rejects forced selection). Auto applies to both tool legs,
+is recorded as `toolChoice` in the report, and does not change the request budget
+or acceptance criteria: a missing/wrong tool, wrong arguments, or a missing visible
+receipt still fails. There is no automatic fallback from forced to auto, and this
+option does not change how Metapi forwards another client's `tool_choice`.
 
 A passing client report does not identify the physical upstream provider. Pair it
 with verified test configuration, model request IDs, and gateway/Metapi logs for

--- a/docs/unused_const_gate_test.go
+++ b/docs/unused_const_gate_test.go
@@ -70,7 +70,7 @@ func TestUnreferencedConstGroupMemberGate(t *testing.T) {
 		}
 		if info.IsDir() {
 			switch info.Name() {
-			case ".git", "node_modules", "dist", "vendor", ".dev-local", ".worktrees", "web":
+			case ".git", "node_modules", "dist", "vendor", ".dev-local", ".worktrees", ".local", "web":
 				return filepath.SkipDir
 			}
 			return nil

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -394,7 +394,7 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	owner, err := service.GetAccountByID(h.db, existing.AccountID)
+	owner, err := service.GetAccountWithSiteByID(h.db, existing.AccountID)
 	if err != nil {
 		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
@@ -403,7 +403,7 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
-	if service.IsAPIKeyConnection(owner) {
+	if service.IsAPIKeyConnection(&owner.Account) {
 		writeErrorCode(w, http.StatusBadRequest, ErrorCodeOperationNotSupported, "API key connections do not support managing account tokens")
 		return
 	}
@@ -499,7 +499,7 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
-		"token":   latest,
+		"token":   tokenToMap(*latest, owner.Site.Platform),
 	})
 }
 

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -695,6 +695,55 @@ func TestTokens_Update(t *testing.T) {
 	}
 }
 
+func TestTokens_UpdateResponseNeverRevealsCredential(t *testing.T) {
+	const original = "test-original-credential-value"
+	const replacement = "test-replacement-credential-value"
+	for _, tc := range []struct {
+		name string
+		body map[string]any
+		want string
+	}{
+		{"metadata", map[string]any{"name": "renamed"}, original},
+		{"enabled", map[string]any{"enabled": false}, original},
+		{"default", map[string]any{"isDefault": true}, original},
+		{"replace", map[string]any{"token": replacement}, replacement},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, r := setupTokensTest(t)
+			_, accountID := tokenFixture(t, db, r)
+			id := createTokenFixture(t, db, accountID, "credential", original, "", true, false)
+			resp := doPutJSON(t, r, "/api/account-tokens/"+itoa(id), tc.body)
+			if resp.Code != http.StatusOK {
+				t.Fatalf("update status = %d", resp.Code)
+			}
+			var result struct {
+				Success bool           `json:"success"`
+				Token   map[string]any `json:"token"`
+			}
+			if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+				t.Fatal(err)
+			}
+			if !result.Success {
+				t.Fatal("update was not successful")
+			}
+			if _, exists := result.Token["token"]; exists || strings.Contains(resp.Body.String(), tc.want) {
+				t.Fatal("ordinary token update exposed the stored credential")
+			}
+			if got := result.Token["tokenMasked"]; got != service.MaskToken(tc.want, "new-api") {
+				t.Fatalf("tokenMasked = %v, want the normal masked projection", got)
+			}
+			stored, err := service.GetTokenByID(db.DB, id)
+			if err != nil || stored.Token != tc.want {
+				t.Fatalf("credential persistence changed: %v", err)
+			}
+			revealed := doGet(t, r, "/api/account-tokens/"+itoa(id)+"/value")
+			if revealed.Code != http.StatusOK || !strings.Contains(revealed.Body.String(), tc.want) {
+				t.Fatal("explicit credential reveal stopped returning the stored value")
+			}
+		})
+	}
+}
+
 func TestTokens_Update_MaskedToken(t *testing.T) {
 	db, r := setupTokensTest(t)
 	_, accountID := tokenFixture(t, db, r)
@@ -710,9 +759,9 @@ func TestTokens_Update_MaskedToken(t *testing.T) {
 	var result map[string]any
 	json.Unmarshal(resp.Body.Bytes(), &result)
 	tok, _ := result["token"].(map[string]any)
-	vs, _ := tok["value_status"].(string)
+	vs, _ := tok["valueStatus"].(string)
 	if vs != service.TokenValueStatusMaskedPending {
-		t.Logf("value_status after masked update: %q", vs)
+		t.Errorf("valueStatus after masked update: %q, want masked_pending", vs)
 	}
 	// After masked update, token should be disabled and not default
 	var enabled, isDefault bool

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -19,6 +19,7 @@
 package httpclient
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -62,8 +63,9 @@ type Options struct {
 	// never ride an operator-configured HTTP_PROXY (e.g. OAuth token
 	// exchange).
 	Proxy func(*http.Request) (*url.URL, error)
-	// SiteDialGuard wraps DialContext with the shared SSRF site dial guard
-	// (internal/ssrf): the hostname is resolved exactly once, every answer is
+	// SiteDialGuard rejects explicitly forbidden URL hosts before proxy
+	// selection and wraps DialContext with the shared SSRF site dial guard
+	// (internal/ssrf): the dial hostname is resolved exactly once, every answer is
 	// checked against the metadata / link-local / multicast / reserved deny
 	// set, and the connection is pinned to an already-validated IP — closing
 	// the DNS-rebinding window between validation and dial. Loopback, RFC1918
@@ -71,9 +73,9 @@ type Options struct {
 	// operator-hosted on private networks.
 	//
 	// Set it on transports whose target comes from operator-configured site
-	// URLs (proxy data plane, channel health probes). Note that when a proxy
-	// is resolved for the request, DialContext dials the proxy address, so the
-	// guard then validates the proxy rather than the final origin.
+	// URLs (proxy data plane, channel health probes). When a proxy is selected,
+	// DNS validation/pinning covers the proxy address; origin DNS remains the
+	// proxy's responsibility. Explicitly forbidden origins are still rejected.
 	SiteDialGuard bool
 }
 
@@ -117,6 +119,13 @@ func NewTransport(opts Options) *http.Transport {
 	}
 	dialContext := dialer.DialContext
 	if opts.SiteDialGuard {
+		resolveProxy := proxy
+		proxy = func(req *http.Request) (*url.URL, error) {
+			if host := req.URL.Hostname(); ssrf.IsForbiddenSiteHostname(host) {
+				return nil, fmt.Errorf("refusing site request to forbidden host %q", host)
+			}
+			return resolveProxy(req)
+		}
 		dialContext = ssrf.NewSiteDialContext(net.DefaultResolver, dialContext)
 	}
 	return &http.Transport{

--- a/internal/httpclient/ssrf_guard_test.go
+++ b/internal/httpclient/ssrf_guard_test.go
@@ -1,8 +1,10 @@
 package httpclient
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -56,5 +58,72 @@ func TestNewTransport_WithoutSiteDialGuardKeepsPlainDialer(t *testing.T) {
 	transport := NewTransport(Options{})
 	if transport.DialContext == nil {
 		t.Fatal("DialContext must always be set (gate R4)")
+	}
+}
+
+// Proxy callbacks run before HTTP forwarding or CONNECT. The guard must reject
+// the URL host before proxy selection, without resolving proxy-only DNS names.
+func TestNewTransport_SiteDialGuardValidatesTargetBeforeProxyResolution(t *testing.T) {
+	calls := 0
+	transport := NewTransport(Options{
+		SiteDialGuard: true,
+		Proxy: func(*http.Request) (*url.URL, error) {
+			calls++
+			return nil, nil
+		},
+	})
+	for _, target := range []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"https://METADATA.GOOGLE.INTERNAL./computeMetadata/v1/",
+		"http://[::ffff:169.254.169.254]/",
+	} {
+		req, err := http.NewRequest(http.MethodGet, target, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Host = "allowed.test.invalid" // The URL, not the Host header, owns the destination.
+		proxyURL, err := transport.Proxy(req)
+		if proxyURL != nil || err == nil || !strings.Contains(err.Error(), "forbidden") {
+			t.Errorf("%s: proxy=%v error=%v, want forbidden target", target, proxyURL, err)
+		}
+	}
+	if calls != 0 {
+		t.Errorf("proxy resolver called %d times for forbidden targets", calls)
+	}
+}
+
+func TestNewTransport_SiteDialGuardPreservesProxyDecision(t *testing.T) {
+	fixed := &url.URL{Scheme: "http", Host: "proxy.test.invalid:3128"}
+	proxyErr := errors.New("proxy selection failed")
+	for _, tc := range []struct {
+		name string
+		url  *url.URL
+		err  error
+	}{
+		{name: "direct"},
+		{name: "proxy", url: fixed},
+		{name: "error", err: proxyErr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "https://proxy-only.test.invalid/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			calls := 0
+			transport := NewTransport(Options{
+				SiteDialGuard: true,
+				Proxy: func(got *http.Request) (*url.URL, error) {
+					calls++
+					if got != req {
+						t.Error("proxy resolver received a different request")
+					}
+					return tc.url, tc.err
+				},
+			})
+			got, err := transport.Proxy(req)
+			if got != tc.url || !errors.Is(err, tc.err) || calls != 1 {
+				t.Errorf("proxy=%v error=%v calls=%d, want %v/%v/1", got, err, calls, tc.url, tc.err)
+			}
+		})
 	}
 }

--- a/platform/newapi_token_key_hydration_test.go
+++ b/platform/newapi_token_key_hydration_test.go
@@ -120,3 +120,134 @@ func TestNewApiAdapter_GetAPITokens_MaskedKeyHydrationFailureIsLoud(t *testing.T
 		t.Fatalf("VerifyToken error = nil, result=%+v; want token hydration failure propagated", result)
 	}
 }
+
+// Deletion must identify the actual owned token, not mistake a masked list key
+// (or a refused key lookup) for proof that the upstream token is absent.
+func TestNewApiAdapter_DeleteAPIToken_ResolvesMaskedIdentityBeforeDeleting(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		cookie     bool
+		list       string
+		batch      string
+		batchCode  int
+		wantError  bool
+		wantDelete int32
+		targetKey  string
+	}{
+		{name: "bare_stored_key", targetKey: "full-relay-key", batch: `{"success":true,"data":{"keys":{"7":"full-relay-key"}}}`, wantDelete: 1},
+		{name: "bearer", batch: `{"success":true,"data":{"keys":{"7":"full-relay-key"}}}`, wantDelete: 1},
+		{name: "cookie", cookie: true, batch: `{"success":true,"data":{"keys":{"7":"full-relay-key"}}}`, wantDelete: 1},
+		{name: "actually_absent", batch: `{"success":true,"data":{"keys":{"7":"another-relay-key"}}}`},
+		{name: "lookup_denied", batchCode: http.StatusForbidden, batch: `{"success":false,"message":"key lookup refused"}`, wantError: true},
+		{name: "lookup_missing_key", batch: `{"success":true,"data":{"keys":{}}}`, wantError: true},
+		{name: "lookup_refused_with_data", batch: `{"success":false,"data":{"keys":{"7":"full-relay-key"}}}`, wantError: true},
+		{name: "unmasked_missing_id", list: `{"success":true,"data":{"items":[{"key":"full-relay-key"}]}}`, wantError: true},
+		{name: "missing_id", list: `{"success":true,"data":{"items":[{"key":"abcd****wxyz"}]}}`, wantError: true},
+		{name: "empty_legacy", list: `{"success":true,"data":[]}`},
+		{name: "empty_v1", list: `{"success":true,"data":{"items":[],"total":0}}`},
+		{name: "listing_malformed", list: `{"success":true}`, wantError: true},
+		{name: "listing_missing_key", list: `{"success":true,"data":[{"id":7}]}`, wantError: true},
+		{name: "listing_refused", list: `{"success":false,"message":"list refused"}`, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var deleted atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if tc.cookie && r.Header.Get("Cookie") == "" {
+					http.Error(w, `{"success":false}`, http.StatusUnauthorized)
+					return
+				}
+				if r.Header.Get("New-Api-User") != "1" {
+					t.Error("listing, key lookup and deletion must keep the owner identity")
+				}
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/api/token/":
+					body := tc.list
+					if body == "" {
+						body = `{"success":true,"data":{"items":[{"id":7,"key":"abcd****wxyz","status":1}]}}`
+					}
+					fmt.Fprint(w, body)
+				case r.Method == http.MethodPost && r.URL.Path == "/api/token/batch/keys":
+					var body struct {
+						IDs []int `json:"ids"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil || len(body.IDs) != 1 || body.IDs[0] != 7 {
+						t.Errorf("unexpected key lookup IDs: %v, error: %v", body.IDs, err)
+					}
+					if tc.batchCode != 0 {
+						w.WriteHeader(tc.batchCode)
+					}
+					fmt.Fprint(w, tc.batch)
+				case r.Method == http.MethodDelete && r.URL.Path == "/api/token/7":
+					deleted.Add(1)
+					fmt.Fprint(w, `{"success":true}`)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			uid := 1
+			target := tc.targetKey
+			if target == "" {
+				target = "sk-full-relay-key"
+			}
+			err := newApiAdapterUnderTest().DeleteAPIToken(ctx, srv.URL, "dashboard-pat", target, &uid, nil)
+			if (err != nil) != tc.wantError {
+				t.Fatalf("error = %v, wantError = %v", err, tc.wantError)
+			}
+			if got := deleted.Load(); got != tc.wantDelete {
+				t.Fatalf("DELETE count = %d, want %d", got, tc.wantDelete)
+			}
+		})
+	}
+}
+
+func TestNewApiAdapter_DeleteAPIToken_PartialPageCannotProveAbsence(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		count, total int
+		present      bool
+	}{
+		{"reported_more", 1, 2, false},
+		{"capped_page", UpstreamTokenListPageLimit, 0, false},
+		{"target_on_full_page", UpstreamTokenListPageLimit, UpstreamTokenListPageLimit + 1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var deleted atomic.Int32
+			items := make([]map[string]interface{}, tc.count)
+			for i := range items {
+				items[i] = map[string]interface{}{"id": i + 1, "key": fmt.Sprintf("other-%d", i), "status": 1}
+			}
+			if tc.present {
+				items[0]["key"] = "target-key"
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == http.MethodGet && r.URL.Path == "/api/token/" {
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "data": map[string]interface{}{"items": items, "total": tc.total}})
+					return
+				}
+				if r.Method == http.MethodDelete && r.URL.Path == "/api/token/1" {
+					deleted.Add(1)
+					fmt.Fprint(w, `{"success":true}`)
+					return
+				}
+				http.NotFound(w, r)
+			}))
+			t.Cleanup(srv.Close)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			uid := 1
+			err := newApiAdapterUnderTest().DeleteAPIToken(ctx, srv.URL, "dashboard-pat", "target-key", &uid, nil)
+			if tc.present {
+				if err != nil || deleted.Load() != 1 {
+					t.Fatalf("present target: error=%v deletes=%d", err, deleted.Load())
+				}
+			} else if err == nil || deleted.Load() != 0 {
+				t.Fatalf("partial absence: error=%v deletes=%d, want failure without deletion", err, deleted.Load())
+			}
+		})
+	}
+}

--- a/platform/newapi_tokens.go
+++ b/platform/newapi_tokens.go
@@ -103,9 +103,8 @@ func (n *NewApiAdapter) getAPITokensByCookie(ctx context.Context, baseURL, token
 	return nil, nil
 }
 
-// normalizeListedTokens resolves New API v1's masked list keys through its
-// ownership-checked batch key endpoint before returning them to account-token
-// sync. A masked display value is never a usable routing credential.
+// normalizeListedTokens resolves New API v1's masked display keys before
+// returning routing credentials. The same hydration owns deletion identity.
 func (n *NewApiAdapter) normalizeListedTokens(
 	ctx context.Context,
 	baseURL string,
@@ -113,6 +112,21 @@ func (n *NewApiAdapter) normalizeListedTokens(
 	headers map[string]string,
 	proxy *ProxyConfig,
 ) ([]ApiTokenInfo, error) {
+	if err := n.hydrateListedTokenKeys(ctx, baseURL, items, headers, proxy); err != nil {
+		return nil, err
+	}
+	return normalizeTokenItems(items), nil
+}
+
+// hydrateListedTokenKeys replaces masked keys in the owned list using the
+// ownership-checked batch endpoint. An unresolved key is not proof of absence.
+func (n *NewApiAdapter) hydrateListedTokenKeys(
+	ctx context.Context,
+	baseURL string,
+	items []map[string]interface{},
+	headers map[string]string,
+	proxy *ProxyConfig,
+) error {
 	maskedIDs := make([]int, 0)
 	for _, item := range items {
 		key, _ := getString(item, "key")
@@ -121,12 +135,12 @@ func (n *NewApiAdapter) normalizeListedTokens(
 		}
 		id, ok := getFloat(item, "id")
 		if !ok || id <= 0 {
-			return nil, fmt.Errorf("New API returned a masked token key without a usable token id")
+			return fmt.Errorf("New API returned a masked token key without a usable token id")
 		}
 		maskedIDs = append(maskedIDs, int(id))
 	}
 	if len(maskedIDs) == 0 {
-		return normalizeTokenItems(items), nil
+		return nil
 	}
 
 	resp, err := fetchJSON(
@@ -138,15 +152,18 @@ func (n *NewApiAdapter) normalizeListedTokens(
 		proxy,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("fetch full New API token keys: %w", err)
+		return fmt.Errorf("fetch full New API token keys: %w", err)
+	}
+	if success, present := getBool(resp, "success"); present && !success {
+		return fmt.Errorf("fetch full New API token keys: upstream refused the lookup")
 	}
 	data, ok := getMap(resp, "data")
 	if !ok {
-		return nil, fmt.Errorf("fetch full New API token keys: response has no data")
+		return fmt.Errorf("fetch full New API token keys: response has no data")
 	}
 	keys, ok := getMap(data, "keys")
 	if !ok {
-		return nil, fmt.Errorf("fetch full New API token keys: response has no keys")
+		return fmt.Errorf("fetch full New API token keys: response has no keys")
 	}
 	for _, item := range items {
 		key, _ := getString(item, "key")
@@ -157,11 +174,60 @@ func (n *NewApiAdapter) normalizeListedTokens(
 		fullKey, _ := getString(keys, fmt.Sprintf("%d", int(id)))
 		fullKey = strings.TrimSpace(fullKey)
 		if fullKey == "" || strings.Contains(fullKey, "*") {
-			return nil, fmt.Errorf("fetch full New API token keys: token %d is missing", int(id))
+			return fmt.Errorf("fetch full New API token keys: token %d is missing", int(id))
 		}
 		item["key"] = fullKey
 	}
-	return normalizeTokenItems(items), nil
+	return nil
+}
+
+func (n *NewApiAdapter) listedTokenIDForDelete(ctx context.Context, baseURL string, response map[string]interface{}, headers map[string]string, targetKey string, proxy *ProxyConfig) (*int, error) {
+	if success, present := getBool(response, "success"); present && !success {
+		return nil, fmt.Errorf("upstream token listing was refused")
+	}
+	items := parseTokenItemsFromMap(response)
+	if len(items) == 0 {
+		data, _ := getMap(response, "data")
+		var emptyList bool
+		for _, value := range []interface{}{response["data"], response["items"], response["list"], data["items"], data["data"], data["list"]} {
+			if entries, ok := value.([]interface{}); ok && len(entries) == 0 {
+				emptyList = true
+			}
+		}
+		if !emptyList {
+			return nil, fmt.Errorf("upstream token listing contains no supported token collection")
+		}
+	}
+	if err := n.hydrateListedTokenKeys(ctx, baseURL, items, headers, proxy); err != nil {
+		return nil, err
+	}
+	// New API stores bare keys but presents them with an optional sk- prefix.
+	// Compare the credential identity, not that display prefix.
+	targetKey = strings.TrimPrefix(targetKey, "sk-")
+	for _, item := range items {
+		key, ok := getString(item, "key")
+		if !ok || strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("upstream token listing contains an unresolved key")
+		}
+		if strings.TrimPrefix(normalizeTokenKeyForCompare(key), "sk-") == targetKey {
+			id := getIntPtr(item, "id")
+			if id == nil || *id <= 0 {
+				return nil, fmt.Errorf("matching upstream token has no usable id")
+			}
+			return id, nil
+		}
+	}
+	// A capped first page cannot prove that an unmatched token is absent.
+	total, _ := getFloat(response, "total")
+	if data, ok := getMap(response, "data"); ok {
+		if nestedTotal, present := getFloat(data, "total"); present {
+			total = nestedTotal
+		}
+	}
+	if len(items) >= UpstreamTokenListPageLimit || total > float64(len(items)) {
+		return nil, fmt.Errorf("upstream token listing may be truncated; cannot confirm token absence")
+	}
+	return nil, nil
 }
 
 func (n *NewApiAdapter) CreateAPIToken(ctx context.Context, baseURL, accessToken string, platformUserId *int, options *CreateAPITokenOptions, proxy *ProxyConfig) (bool, error) {
@@ -253,9 +319,13 @@ func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 	if err != nil {
 		reason = err.Error()
 	} else {
-		listed = true
-		items := parseTokenItemsFromMap(resp)
-		tokenID = pickTokenID(items, targetKey)
+		var resolveErr error
+		tokenID, resolveErr = n.listedTokenIDForDelete(ctx, baseURL, resp, n.authHeaders(accessToken, resolvedUserID), targetKey, proxy)
+		if resolveErr != nil {
+			reason = resolveErr.Error()
+		} else {
+			listed = true
+		}
 	}
 
 	if tokenID != nil {
@@ -288,9 +358,13 @@ func (n *NewApiAdapter) DeleteAPIToken(ctx context.Context, baseURL, accessToken
 			if err != nil {
 				reason = err.Error()
 			} else {
-				listed = true
-				items := parseTokenItemsFromMap(resp)
-				tokenID = pickTokenID(items, targetKey)
+				var resolveErr error
+				tokenID, resolveErr = n.listedTokenIDForDelete(ctx, baseURL, resp, headers, targetKey, proxy)
+				if resolveErr != nil {
+					reason = resolveErr.Error()
+				} else {
+					listed = true
+				}
 			}
 		}
 

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -57,10 +57,9 @@ const defaultStreamResponseHeaderTimeout = 30 * time.Second
 func NewStreamTransport() *http.Transport {
 	return httpclient.NewTransport(httpclient.Options{
 		ResponseHeaderTimeout: defaultStreamResponseHeaderTimeout,
-		// Data-plane dial guard: site URLs are operator input, and a hostname
-		// that resolves to a cloud metadata / link-local address must not be
-		// dialled even if it passed URL-level validation earlier (DNS
-		// rebinding). Private ranges stay allowed for self-hosted upstreams.
+		// Keep explicitly forbidden site URLs out of proxies; direct dials
+		// also validate and pin DNS answers through the shared site guard.
+		// Private ranges stay allowed for self-hosted upstreams.
 		SiteDialGuard: true,
 	})
 }

--- a/proxy/executor_ssrf_test.go
+++ b/proxy/executor_ssrf_test.go
@@ -1,40 +1,200 @@
 package proxy
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 )
 
-// The executor dials operator-configured site URLs, so its transports carry the
-// shared site dial guard. A hostname/IP that resolves into the cloud metadata
-// range must be refused before any connection attempt, even though loopback and
-// RFC1918 upstreams stay reachable for self-hosted deployments.
 func TestRuntimeExecutor_RefusesMetadataTarget(t *testing.T) {
-	executor := NewRuntimeExecutor(2 * time.Second)
-	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil)
-	if err != nil {
-		t.Fatalf("build request: %v", err)
-	}
-	resp, err := executor.Do(req)
-	if err == nil {
-		resp.Body.Close()
-		t.Fatal("expected the dial guard to refuse the metadata address")
-	}
-	if !strings.Contains(err.Error(), "forbidden") {
-		t.Errorf("expected a forbidden-target error, got %v", err)
-	}
+	testExecutorMetadataGuard(t, func() *http.Client {
+		return NewRuntimeExecutor(3 * time.Second).client
+	})
+}
+
+func TestRuntimeExecutor_StreamRefusesMetadataTarget(t *testing.T) {
+	testExecutorMetadataGuard(t, func() *http.Client {
+		client := NewRuntimeExecutor(3 * time.Second).streamClient
+		client.Timeout = 3 * time.Second
+		return client
+	})
 }
 
 func TestNewStreamTransport_RefusesMetadataTarget(t *testing.T) {
-	client := &http.Client{Transport: NewStreamTransport(), Timeout: 2 * time.Second}
-	resp, err := client.Get("http://metadata.google.internal/computeMetadata/v1/")
-	if err == nil {
+	testExecutorMetadataGuard(t, func() *http.Client {
+		return &http.Client{Transport: NewStreamTransport(), Timeout: 3 * time.Second}
+	})
+}
+
+// Use a fresh process for each environment: net/http caches ProxyFromEnvironment
+// on first use. Never inherit a real proxy or forward a metadata probe outside
+// this fixture, including when the guard is removed to prove these tests fail.
+func testExecutorMetadataGuard(t *testing.T, newClient func() *http.Client) {
+	t.Helper()
+	const childEnv = "METAPI_TEST_EXECUTOR_PROXY_SCHEME"
+	proxyScheme := os.Getenv(childEnv)
+	if proxyScheme == "" {
+		testName := t.Name()
+		for _, scheme := range []string{"http", "https"} {
+			t.Run(scheme, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^"+regexp.QuoteMeta(testName)+"$", "-test.v", "-test.timeout=25s")
+				cmd.Env = append(os.Environ(), childEnv+"="+scheme)
+				output, err := cmd.CombinedOutput()
+				t.Logf("%s", output)
+				if err != nil {
+					t.Fatalf("isolated %s proxy test: %v", scheme, err)
+				}
+			})
+		}
+		return
+	}
+	if proxyScheme != "http" && proxyScheme != "https" {
+		t.Fatalf("unexpected proxy scheme %q", proxyScheme)
+	}
+
+	const allowedHost = "upstream.test.invalid"
+	const allowedBody = "response from loopback origin"
+	var originRequests, proxyHTTP, proxyCONNECT, unexpectedTargets atomic.Int32
+	originHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		originRequests.Add(1)
+		_, _ = io.WriteString(w, allowedBody)
+	})
+	origin := httptest.NewServer(originHandler)
+	t.Cleanup(origin.Close)
+	tlsOrigin := httptest.NewTLSServer(originHandler)
+	t.Cleanup(tlsOrigin.Close)
+
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forward := httputil.NewSingleHostReverseProxy(originURL)
+	forwardTransport := httpclient.NewTransport(httpclient.Options{Proxy: httpclient.NoProxy})
+	t.Cleanup(forwardTransport.CloseIdleConnections)
+	forward.Transport = forwardTransport
+	proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect && r.Host == allowedHost+":443" {
+			proxyCONNECT.Add(1)
+			// Tunnel only to this fixture's TLS origin, never r.Host.
+			upstream, err := net.DialTimeout("tcp", tlsOrigin.Listener.Addr().String(), 3*time.Second)
+			if err != nil {
+				t.Errorf("connect to loopback TLS origin: %v", err)
+				http.Error(w, "fixture dial failed", http.StatusBadGateway)
+				return
+			}
+			defer upstream.Close()
+			conn, buffered, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack proxy connection: %v", err)
+				return
+			}
+			defer conn.Close()
+			if _, err := io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+				t.Errorf("write CONNECT response: %v", err)
+				return
+			}
+			done := make(chan struct{})
+			go func() {
+				_, _ = io.Copy(upstream, buffered)
+				_ = upstream.Close()
+				close(done)
+			}()
+			_, _ = io.Copy(conn, upstream)
+			_ = conn.Close()
+			<-done
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Scheme == "http" && r.URL.Host == allowedHost {
+			proxyHTTP.Add(1)
+			forward.ServeHTTP(w, r)
+			return
+		}
+		unexpectedTargets.Add(1)
+		// Deliberately not a forbidden-target error: reaching the proxy is a
+		// guard failure, not successful enforcement by this safety net.
+		http.Error(w, "unexpected fixture target", http.StatusBadGateway)
+	}))
+	if proxyScheme == "https" {
+		proxyServer.StartTLS()
+	} else {
+		proxyServer.Start()
+	}
+	t.Cleanup(proxyServer.Close)
+
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		t.Setenv(key, proxyServer.URL)
+	}
+	for _, key := range []string{"NO_PROXY", "no_proxy", "ALL_PROXY", "all_proxy", "REQUEST_METHOD"} {
+		t.Setenv(key, "")
+	}
+	client := newClient()
+	t.Cleanup(client.CloseIdleConnections)
+	transport := client.Transport.(*http.Transport)
+	transport.TLSClientConfig = tlsOrigin.Client().Transport.(*http.Transport).TLSClientConfig.Clone()
+	// Both TLS fixtures use httptest's loopback certificate. Trust it while
+	// keeping the synthetic origin hostname unresolvable outside the proxy.
+	transport.TLSClientConfig.ServerName = "127.0.0.1"
+
+	for _, target := range []string{
+		"http://" + allowedHost + "/allowed",
+		"https://" + allowedHost + "/allowed",
+		origin.URL + "/direct",
+	} {
+		resp, err := client.Get(target)
+		if err != nil {
+			t.Fatalf("allowed target %s: %v", target, err)
+		}
+		body, readErr := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		t.Fatal("expected the dial guard to refuse the metadata hostname")
+		if readErr != nil || resp.StatusCode != http.StatusOK || string(body) != allowedBody {
+			t.Fatalf("allowed target %s: status=%d body=%q error=%v", target, resp.StatusCode, body, readErr)
+		}
 	}
-	if !strings.Contains(err.Error(), "forbidden") {
-		t.Errorf("expected a forbidden-target error, got %v", err)
+	if proxyHTTP.Load() != 1 || proxyCONNECT.Load() != 1 || originRequests.Load() != 3 {
+		t.Fatalf("allowed routing: HTTP=%d CONNECT=%d origins=%d, want 1/1/3", proxyHTTP.Load(), proxyCONNECT.Load(), originRequests.Load())
 	}
+
+	for _, scheme := range []string{"http", "https"} {
+		for _, host := range []string{
+			"169.254.169.254",
+			"metadata.google.internal",
+			"METADATA.GOOGLE.INTERNAL.",
+			"metadata",
+			"instance-data",
+			"100.100.100.200",
+			"[fd00:ec2::254]",
+			"[::ffff:169.254.169.254]",
+		} {
+			t.Run(scheme+"/"+host, func(t *testing.T) {
+				resp, err := client.Get(fmt.Sprintf("%s://%s/latest/meta-data/", scheme, host))
+				if err == nil {
+					resp.Body.Close()
+					t.Fatal("expected a forbidden-target error before contacting the proxy")
+				}
+				if !strings.Contains(err.Error(), "forbidden") {
+					t.Errorf("expected a forbidden-target error, got %v", err)
+				}
+			})
+		}
+	}
+	if got := unexpectedTargets.Load(); got != 0 {
+		t.Errorf("proxy received %d forbidden requests, want zero", got)
+	}
+	t.Logf("loopback fixture: HTTP=%d CONNECT=%d origins=%d forbidden requests received=%d", proxyHTTP.Load(), proxyCONNECT.Load(), originRequests.Load(), unexpectedTargets.Load())
 }

--- a/scripts/e2e/test_verify_real_relay.py
+++ b/scripts/e2e/test_verify_real_relay.py
@@ -177,6 +177,16 @@ def pack(events):
                    for event, data in events).encode("utf-8")
 
 
+def has_tool_result(protocol, body):
+    if protocol == "responses":
+        return any(item.get("type") == "function_call_output" for item in body["input"])
+    if protocol == "chat":
+        return any(item.get("role") == "tool" for item in body["messages"])
+    return any(isinstance(message.get("content"), list) and
+               any(part.get("type") == "tool_result" for part in message["content"])
+               for message in body["messages"])
+
+
 class ValidatorTests(unittest.TestCase):
     def test_all_normal_json_fixtures(self):
         for protocol in relay.PROTOCOLS:
@@ -735,6 +745,78 @@ class ValidatorTests(unittest.TestCase):
                         relay.validate_sse(protocol, pack(stream_events(protocol)))
 
 
+    def test_chat_tool_stream_empty_continuation_fields_preserve_identity(self):
+        expected_id = document("chat", tool=True)["choices"][0]["message"]["tool_calls"][0]["id"]
+        for placeholder in ("", None):
+            with self.subTest(placeholder=placeholder):
+                events = tool_stream_events("chat")
+                for _, obj in events[3:5]:
+                    call = obj["choices"][0]["delta"]["tool_calls"][0]
+                    call["id"] = placeholder
+                    call["function"]["name"] = placeholder
+                result = relay.validate_sse("chat", pack(events), tool=True, expected_value=VALUE)
+                self.assertEqual(result["_call"]["id"], expected_id)
+                self.assertEqual(result["_call"]["name"], TOOL_NAME)
+                self.assertEqual(result["_call"]["arguments"], {"value": VALUE})
+                changed = copy.deepcopy(events)
+                changed[3][1]["choices"][0]["delta"]["tool_calls"][0]["id"] = "another-call"
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse("chat", pack(changed), tool=True, expected_value=VALUE)
+                missing = copy.deepcopy(events)
+                first = missing[2][1]["choices"][0]["delta"]["tool_calls"][0]
+                first["id"] = placeholder
+                first["function"]["name"] = placeholder
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse("chat", pack(missing), tool=True, expected_value=VALUE)
+
+    def test_responses_raw_reasoning_parts_replay_without_becoming_output(self):
+        hidden = "Reasoning is not the answer: " + RECEIPT
+        reasoning = {"id": "rs_fixture", "type": "reasoning", "summary": [],
+                     "content": [{"type": "reasoning_text", "text": hidden}], "status": "completed"}
+        base = {"output_index": 0, "content_index": 0, "item_id": "rs_fixture"}
+        reasoning_events = [
+            ("response.output_item.added", {"type": "response.output_item.added", "output_index": 0,
+                 "item": dict(reasoning, content=[], status="in_progress")}),
+            ("response.content_part.added", dict(base, type="response.content_part.added",
+                 part={"type": "reasoning_text", "text": ""})),
+            ("response.reasoning_text.delta", dict(base, type="response.reasoning_text.delta", delta=hidden)),
+            ("response.reasoning_text.done", dict(base, type="response.reasoning_text.done", text=hidden)),
+            ("response.content_part.done", dict(base, type="response.content_part.done",
+                 part={"type": "reasoning_text", "text": hidden})),
+            ("response.output_item.done", {"type": "response.output_item.done", "output_index": 0, "item": reasoning}),
+        ]
+        for tool in (False, True):
+            with self.subTest(tool=tool):
+                events = tool_stream_events("responses") if tool else stream_events("responses")
+                for _, obj in events:
+                    if "output_index" in obj:
+                        obj["output_index"] += 1
+                output = events[-1][1]["response"]["output"]
+                if tool:
+                    output[0] = copy.deepcopy(reasoning)
+                else:
+                    output.insert(0, copy.deepcopy(reasoning))
+                events[1:1] = copy.deepcopy(reasoning_events)
+                result = relay.validate_sse("responses", pack(events), tool=tool, expected_value=VALUE)
+                self.assertNotIn(RECEIPT, result["_text"])
+                if tool:
+                    original = relay.request_body("responses", MODEL, 256, stream=True, tool_value=VALUE)
+                    replay = relay.followup_body("responses", original, result, "visible-receipt")
+                    self.assertIn(reasoning, replay["input"])
+                else:
+                    self.assertEqual(result["_text"], TEXT)
+                malformed = copy.deepcopy(events)
+                malformed[2][1]["part"]["type"] = "unsupported_private_part"
+                with self.assertRaises(relay.CheckFailed):
+                    relay.validate_sse("responses", pack(malformed), tool=tool, expected_value=VALUE)
+        only_reasoning = stream_events("responses")[:1] + copy.deepcopy(reasoning_events)
+        final = document("responses")
+        final["output"] = [reasoning]
+        only_reasoning.append(("response.completed", {"type": "response.completed", "response": final}))
+        with self.assertRaises(relay.CheckFailed):
+            relay.validate_sse("responses", pack(only_reasoning))
+
+
 class TransportAndCliValidatorTests(unittest.TestCase):
     def client(self):
         return relay.CurlClient("http://127.0.0.1:12345/v1", KEY, 10, dict(ENV))
@@ -799,12 +881,12 @@ class TransportAndCliValidatorTests(unittest.TestCase):
     def good_post(client, protocol, body):
         client.request_count += 1
         if body["stream"]:
-            if body.get("tool_choice") in ("none", {"type": "none"}):
+            if has_tool_result(protocol, body):
                 return 200, "text/event-stream", pack(stream_events(protocol, text=RECEIPT))
             if "tools" in body:
                 return 200, "text/event-stream", pack(tool_stream_events(protocol))
             return 200, "text/event-stream", pack(stream_events(protocol))
-        if body.get("tool_choice") in ("none", {"type": "none"}):
+        if has_tool_result(protocol, body):
             doc = document(protocol, text=RECEIPT)
         else:
             doc = document(protocol, tool="tools" in body)
@@ -827,6 +909,85 @@ class TransportAndCliValidatorTests(unittest.TestCase):
                 self.assertEqual(row["followup"]["status"], "pass")
         for private in (KEY, TEXT, VALUE, RECEIPT, "Preserve this reasoning"):
             self.assertNotIn(private, raw)
+
+    def test_default_and_explicit_forced_tool_policy_are_identical(self):
+        requests = []
+        def post(client, protocol, body):
+            requests.append((protocol, copy.deepcopy(body)))
+            return self.good_post(client, protocol, body)
+        default_code, default_report, _ = self.run_cli([], post)
+        default_requests = requests[:]
+        requests.clear()
+        forced_code, forced_report, _ = self.run_cli(["--tool-choice", "forced"], post)
+        self.assertEqual((default_code, forced_code), (0, 0))
+        self.assertEqual(default_report["toolChoice"], "forced")
+        self.assertEqual(forced_report, default_report)
+        self.assertEqual(requests, default_requests)
+        for protocol, body in requests:
+            if has_tool_result(protocol, body):
+                self.assertEqual(body["tool_choice"], {"type": "none"} if protocol == "messages" else "none")
+            elif "tools" in body:
+                expected = {"chat": {"type": "function", "function": {"name": TOOL_NAME}},
+                            "responses": {"type": "function", "name": TOOL_NAME},
+                            "messages": {"type": "tool", "name": TOOL_NAME, "disable_parallel_tool_use": True}}
+                self.assertEqual(body["tool_choice"], expected[protocol])
+            else:
+                self.assertNotIn("tool_choice", body)
+
+    def test_auto_policy_keeps_bounded_requests_and_auto_on_both_tool_legs(self):
+        for tool_stream in (False, True):
+            with self.subTest(tool_stream=tool_stream):
+                requests = []
+                def post(client, protocol, body):
+                    requests.append((protocol, copy.deepcopy(body)))
+                    return self.good_post(client, protocol, body)
+                argv = ["--tool-choice", "auto"] + (["--tool-stream"] if tool_stream else [])
+                code, report, raw = self.run_cli(argv, post)
+                self.assertEqual(code, 0)
+                self.assertEqual(report["toolChoice"], "auto")
+                self.assertEqual(report["requestCount"], 18 if tool_stream else 12)
+                self.assertEqual(report["requestLimit"], report["requestCount"])
+                self.assertEqual(len(report["results"]), 12 if tool_stream else 9)
+                for protocol, body in requests:
+                    if "tools" in body:
+                        expected = {"type": "auto", "disable_parallel_tool_use": True} if protocol == "messages" else "auto"
+                        self.assertEqual(body["tool_choice"], expected)
+                        self.assertEqual(len(body["tools"]), 1)
+                    else:
+                        self.assertNotIn("tool_choice", body)
+                self.assertEqual(sum(has_tool_result(protocol, body) for protocol, body in requests),
+                                 6 if tool_stream else 3)
+                for private in (KEY, TEXT, VALUE, RECEIPT, "Preserve this reasoning"):
+                    self.assertNotIn(private, raw)
+
+    def test_auto_still_requires_exact_tool_arguments_and_visible_result_receipt(self):
+        for protocol in relay.PROTOCOLS:
+            for failure in ("missing_call", "wrong_arguments", "missing_receipt"):
+                with self.subTest(protocol=protocol, failure=failure):
+                    def post(client, kind, body):
+                        if "tools" in body:
+                            result = has_tool_result(kind, body)
+                            if (not result and failure == "missing_call") or (result and failure == "missing_receipt"):
+                                client.request_count += 1
+                                if body["stream"]:
+                                    return 200, "text/event-stream", pack(stream_events(kind))
+                                return 200, "application/json", encode(document(kind))
+                            if not result and failure == "wrong_arguments":
+                                status, mime, raw = self.good_post(client, kind, body)
+                                wrong = "x" * len(VALUE)
+                                if body["stream"]:
+                                    raw = pack(tool_stream_events(kind, value=wrong))
+                                return status, mime, raw.replace(VALUE.encode(), wrong.encode())
+                        return self.good_post(client, kind, body)
+                    code, report, _ = self.run_cli(["--protocol", protocol, "--tool-stream", "--tool-choice", "auto"], post)
+                    self.assertEqual(code, 1)
+                    rows = [row for row in report["results"] if row["scenario"] in ("tool_roundtrip", "tool_stream")]
+                    self.assertEqual(len(rows), 2)
+                    self.assertTrue(all(row["status"] == "fail" for row in rows))
+                    if failure == "missing_receipt":
+                        self.assertTrue(all(row["followup"]["error"] == "followup_did_not_use_tool_result" for row in rows))
+                    else:
+                        self.assertTrue(all(row["followup"]["status"] == "not_run" for row in rows))
 
     def test_failed_responses_report_bounded_terminal_signals_not_payloads(self):
         def limited(client, protocol, body):
@@ -893,7 +1054,7 @@ class TransportAndCliValidatorTests(unittest.TestCase):
         def post(client, protocol, body):
             if body["stream"]:
                 client.request_count += 1
-                if body.get("tool_choice") in ("none", {"type": "none"}):
+                if has_tool_result(protocol, body):
                     return 200, "text/event-stream", pack(stream_events(protocol))
                 if "tools" in body:
                     return 200, "text/event-stream", pack(tool_stream_events(protocol))
@@ -922,7 +1083,7 @@ class TransportAndCliValidatorTests(unittest.TestCase):
 
     def test_followup_requires_receipt_not_just_any_text(self):
         def post(client, protocol, body):
-            if body.get("tool_choice") in ("none", {"type": "none"}):
+            if has_tool_result(protocol, body):
                 client.request_count += 1
                 return 200, "application/json", encode(document(protocol))
             return self.good_post(client, protocol, body)
@@ -955,7 +1116,9 @@ class TransportAndCliValidatorTests(unittest.TestCase):
 
     def test_invalid_environment_or_limits_make_no_requests(self):
         cases = [([], {}), (["--timeout", "0"], ENV), (["--max-tokens", "999999"], ENV),
-                 (["--protocol", "wrong"], ENV), ([], dict(ENV, RELAY_BASE_URL="http://user:password@example.invalid")),
+                 (["--protocol", "wrong"], ENV), (["--tool-choice", "required"], ENV),
+                 # Deliberately invalid credentials at a reserved example host, not a live secret.
+                 ([], dict(ENV, RELAY_BASE_URL="http://user:password@example.invalid")),  # leak-guard-allow:LG-F4C6A155
                  ([], dict(ENV, RELAY_API_KEY="bad\nheader")), ([], dict(ENV, RELAY_BASE_URL="http://host:bad"))]
         for argv, env in cases:
             with self.subTest(argv=argv, keys=list(env)):

--- a/scripts/e2e/verify-real-relay.py
+++ b/scripts/e2e/verify-real-relay.py
@@ -315,7 +315,10 @@ def validate_sse(protocol, raw, *, tool=False, expected_value=None):
                             tool_calls[index] = entry
                         if item.get("type") not in (None, "function"):
                             require(False, "unexpected_tool_type")
-                        if "id" in item:
+                        # Native relays may retain empty/null identity fields
+                        # on argument-only chunks. They are no update, not a new
+                        # identity; checked_call still requires the assembled ID.
+                        if item.get("id") not in (None, ""):
                             value = identifier(item["id"])
                             require(entry["id"] is None or entry["id"] == value, "stream_tool_identity_changed")
                             entry["id"] = value
@@ -323,9 +326,9 @@ def validate_sse(protocol, raw, *, tool=False, expected_value=None):
                         if function is not None:
                             no_error(function)
                             require(isinstance(function, dict), "invalid_tool_function")
-                            if "name" in function:
+                            if function.get("name") is not None:
                                 value = function["name"]
-                                require(isinstance(value, str) and value, "invalid_tool_name")
+                                require(isinstance(value, str), "invalid_tool_name")
                                 entry["name"] += value
                             if "arguments" in function:
                                 value = function["arguments"]
@@ -448,11 +451,17 @@ def validate_sse(protocol, raw, *, tool=False, expected_value=None):
             elif kind in ("response.content_part.added", "response.content_part.done"):
                 part = obj.get("part")
                 no_error(part)
-                require(part.get("type") == "output_text", "unexpected_content_type")
+                require(part.get("type") in ("output_text", "reasoning_text"), "unexpected_content_type")
+                if part["type"] == "reasoning_text":
+                    require(isinstance(part.get("text"), str), "invalid_reasoning_text")
+            elif kind in ("response.reasoning_text.delta", "response.reasoning_text.done"):
+                # Reasoning is replayed from the completed response document,
+                # never counted as visible answer text or a tool-result receipt.
+                field = "delta" if kind.endswith(".delta") else "text"
+                require(isinstance(obj.get(field), str), "invalid_reasoning_text")
             else:
                 require(kind in ("response.reasoning_summary_part.added", "response.reasoning_summary_part.done",
-                                 "response.reasoning_summary_text.delta", "response.reasoning_summary_text.done",
-                                 "response.reasoning_text.delta", "response.reasoning_text.done"),
+                                 "response.reasoning_summary_text.delta", "response.reasoning_summary_text.done"),
                         "unexpected_sse_event")
         elif protocol == "messages":
             require(not finished, "event_after_completion")
@@ -594,7 +603,7 @@ def validate_http(protocol, reply, *, stream=False, tool=False, expected_value=N
             "expected_json_content_type")
     return validate_json(protocol, body, tool=tool, expected_value=expected_value)
 
-def request_body(protocol, model, max_tokens, *, stream=False, tool_value=None):
+def request_body(protocol, model, max_tokens, *, stream=False, tool_value=None, tool_choice="forced"):
     prompt = "Reply with one short sentence confirming the relay works."
     schema = {"type": "object", "properties": {"value": {"type": "string"}},
               "required": ["value"], "additionalProperties": False}
@@ -609,7 +618,8 @@ def request_body(protocol, model, max_tokens, *, stream=False, tool_value=None):
         body.update(input=[message], max_output_tokens=max_tokens, store=False)
         if tool_value is not None:
             body.update(tools=[dict(type="function", **function)],
-                        tool_choice={"type": "function", "name": TOOL_NAME}, parallel_tool_calls=False)
+                        tool_choice="auto" if tool_choice == "auto" else {"type": "function", "name": TOOL_NAME},
+                        parallel_tool_calls=False)
     else:
         body.update(messages=[message], max_tokens=max_tokens)
         if protocol == "chat":
@@ -618,12 +628,13 @@ def request_body(protocol, model, max_tokens, *, stream=False, tool_value=None):
                 body["stream_options"] = {"include_usage": True}
             if tool_value is not None:
                 body.update(tools=[{"type": "function", "function": function}],
-                            tool_choice={"type": "function", "function": {"name": TOOL_NAME}},
+                            tool_choice="auto" if tool_choice == "auto" else {"type": "function", "function": {"name": TOOL_NAME}},
                             parallel_tool_calls=False)
         elif protocol == "messages":
             if tool_value is not None:
                 body.update(tools=[{"name": TOOL_NAME, "description": function["description"], "input_schema": schema}],
-                            tool_choice={"type": "tool", "name": TOOL_NAME, "disable_parallel_tool_use": True})
+                            tool_choice=({"type": "auto", "disable_parallel_tool_use": True} if tool_choice == "auto" else
+                                         {"type": "tool", "name": TOOL_NAME, "disable_parallel_tool_use": True}))
         else:
             raise CheckFailed("invalid_protocol")
     return body
@@ -633,21 +644,24 @@ def followup_body(protocol, original, validated, receipt):
     call, doc = validated["_call"], validated["_document"]
     output = json.dumps({"value": call["arguments"]["value"], "receipt": receipt})
     body = dict(original)
+    choice = original.get("tool_choice")
+    automatic = choice == "auto" or isinstance(choice, dict) and choice.get("type") == "auto"
     if protocol == "chat":
         # Keep reasoning_content when supplied; thinking-capable models need it on replay.
         body["messages"] = original["messages"] + [doc["choices"][0]["message"],
                                                     {"role": "tool", "tool_call_id": call["id"], "content": output}]
-        body["tool_choice"] = "none"
     elif protocol == "responses":
         # Stateless replay, including reasoning items, avoids previous_response_id storage dependencies.
         body["input"] = original["input"] + doc["output"] + [
             {"type": "function_call_output", "call_id": call["id"], "output": output}]
-        body["tool_choice"] = "none"
     else:
         body["messages"] = original["messages"] + [
             {"role": "assistant", "content": doc["content"]},
             {"role": "user", "content": [{"type": "tool_result", "tool_use_id": call["id"], "content": output}]}]
-        body["tool_choice"] = {"type": "none"}
+    # Do not force "none" for thinking models tested with the explicit auto policy.
+    # The validator still rejects a followup that calls a tool instead of using the receipt.
+    if not automatic:
+        body["tool_choice"] = {"type": "none"} if protocol == "messages" else "none"
     return body
 
 
@@ -760,7 +774,7 @@ def observed_response_signals(reply):
     return {"finishReasons": reasons[:20], "finishReasonCount": len(reasons), "toolCallsPresent": tools}
 
 
-def run_protocol(client, protocol, model, max_tokens, tool_stream):
+def run_protocol(client, protocol, model, max_tokens, tool_stream, tool_choice="forced"):
     results = []
     scenarios = ("nonstream", "stream", "tool_roundtrip") + (("tool_stream",) if tool_stream else ())
     for scenario in scenarios:
@@ -773,7 +787,7 @@ def run_protocol(client, protocol, model, max_tokens, tool_stream):
             row["followup"] = {"status": "not_run"}
         reply = None
         try:
-            body = request_body(protocol, model, max_tokens, stream=stream, tool_value=tool_value)
+            body = request_body(protocol, model, max_tokens, stream=stream, tool_value=tool_value, tool_choice=tool_choice)
             reply = client.post(protocol, body)
             row["httpStatus"] = reply[0]
             validated = validate_http(protocol, reply, stream=stream, tool=tool_value is not None,
@@ -824,11 +838,14 @@ def main(argv=None, environment=None):
         parser.add_argument("--max-tokens", type=int, default=256, metavar="TOKENS", help="per POST, 64..4096 (default: 256)")
         parser.add_argument("--tool-stream", action="store_true",
                             help="also verify streaming echo-tool calls and result followups (2 extra POSTs per protocol)")
+        parser.add_argument("--tool-choice", choices=("forced", "auto"), default="forced",
+                            help="tool selection policy; auto still requires the exact tool/result roundtrip (default: forced)")
         args = parser.parse_args(argv)
         require(5 <= args.timeout <= 300 and 64 <= args.max_tokens <= 4096, "invalid_limits")
         report["maxTokensPerRequest"] = args.max_tokens
         report["perRequestTimeoutSeconds"] = args.timeout
         report["toolStream"] = args.tool_stream
+        report["toolChoice"] = args.tool_choice
         base, model = environment.get("RELAY_BASE_URL", ""), environment.get("RELAY_MODEL", "")
         require(bool(base and key and model), "missing_relay_environment")
         require(len(key) <= 4096 and all(33 <= ord(c) <= 126 for c in key), "invalid_api_key_format")
@@ -845,7 +862,7 @@ def main(argv=None, environment=None):
         report["requestLimit"] = len(selected) * (6 if args.tool_stream else 4)
         client = CurlClient(base, key, args.timeout, environment)
         for protocol in selected:
-            report["results"].extend(run_protocol(client, protocol, model, args.max_tokens, args.tool_stream))
+            report["results"].extend(run_protocol(client, protocol, model, args.max_tokens, args.tool_stream, args.tool_choice))
         report["requestCount"] = client.request_count
         passed = bool(report["results"]) and all(row["status"] == "pass" for row in report["results"])
         report["status"] = "pass" if passed else "fail"


### PR DESCRIPTION
## Summary
- Add explicit `--tool-choice auto` acceptance without weakening exact tool/argument/result validation or changing the default forced policy. Accept legal empty Chat identity continuations and replay raw Responses reasoning without treating it as visible output.
- Return the existing masked projection for token metadata updates. Resolve New API masked/bare token identities through the ownership-checked key endpoint before deletion; refused, unresolved, malformed, or potentially truncated listings cannot silently remove a local record.
- Reject explicitly forbidden origin hosts before HTTP(S) proxy selection. Preserve legitimate proxy forwarding, HTTPS CONNECT, direct private-network access, and the existing DNS-pinned dial guard.
- Make `.local/` isolation repository-owned, normalize Windows PG gate path keys, and clarify local development, artifact identity, public/private documentation and distinct acceptance evidence.

## Verification
- The installed pre-push hook ran in full on the exact final commit: frontend tests/typecheck/lint/format/knip/build, server build, vet, and the complete Linux/WSL race suite. No checks were omitted. Source transport was handled separately after a workstation Git HTTPS failure.
- Server build, vet, and complete PostgreSQL suite passed against all 1,905 hash-matched tracked source files plus verified static assets. The dedicated temporary database was removed. Local golangci-lint passed.
- 59 offline relay-validator tests passed. Four validator ablations fail as intended and restore byte-identically.
- Controlled HTTP/HTTPS proxy negative controls: removing the fix lets forbidden requests reach only the synthetic proxy; restoring it blocks them before proxy selection. Allowed HTTP forwarding and HTTPS CONNECT still work. No real metadata service is used by these probes.
- Token metadata/deletion regressions fail with the pre-fix implementation via a Go compilation overlay and pass with the fix, without overwriting the working source. Complete affected packages passed.
- The final binary passed real-provider acceptance through a dedicated persistent New API instance: 12 protocol scenarios / 18 requests, including JSON, SSE and complete streamed/non-streamed tool-result receipts. Both real downstream CLI clients also executed one bounded tool and returned its unpredictable receipt.
- Real management acceptance completed across two rate-limit windows: 11 core steps plus 7 credential/disabled-account/proxy-only steps. This verifies ordinary-user creation, reusable password login, finite upstream token creation, masked metadata update, local-only rename/default semantics, deletion read back on both sides, PAT model discovery, exact fresh check-in reward, no duplicate reward, upstream-disabled skip, revoked PAT failure, redacted rebind, restored balance/check-in, disabled-account skip, and honest API-key-only behavior.
- The initial combined management burst hit the upstream's default sensitive-operation 429 limit. That failed report is retained; only the remaining cases ran after the natural window reset. The limit was not raised or disabled. All owned test accounts/tokens were removed and original settings/account identities were preserved.
- CI/CD run 34136793203 completed successfully on this head.

## Scope
No production deployment, release, upstream rate-limit relaxation, hidden forced-to-auto rewrite, or speculative full upstream-management parity claim. Runtime endpoints, credentials and raw acceptance evidence remain private.