### PR TITLE
docs: clarify admin probe and downstream budget contracts

### DIFF
--- a/docs/api/accounts.md
+++ b/docs/api/accounts.md
@@ -19,9 +19,10 @@ filter and create form keep working without a second full-fleet request.
 
 **Body** (create, optional): `proxyUrl` — per-account egress proxy stored in `extraConfig.proxyUrl`; accepted schemes are `http://`, `https://`, `socks5://`, `socks5h://` (SOCKS5 runs natively on Go's `net/http` transport). Invalid schemes return `400`.
 
-### GET /api/accounts/:id, PUT /api/accounts/:id, DELETE /api/accounts/:id
+### PUT /api/accounts/:id, DELETE /api/accounts/:id
 
-Get, update, delete an account.
+Update or delete an account. This build does not expose `GET /api/accounts/:id`;
+read account rows from `GET /api/accounts`, including its paginated form.
 
 **`proxyUrl` update semantics**: field omitted → keep the stored proxy; present with a value → replace (same scheme validation as create); present empty (`""`) → delete `extraConfig.proxyUrl`.
 
@@ -49,6 +50,12 @@ failure is explicit. `skipModelFetch: true` performs no model probe and returns
 ### POST /api/accounts/login
 
 Log in against the site with username/password and create the account — or update the existing one for `(siteId, username)` — with the session token and an encrypted `autoRelogin` credential (`extraConfig.credentialMode = session`).
+
+For a modern NewAPI dashboard login, Metapi exchanges the short-lived session
+credential for a durable personal access token (PAT), then revokes the temporary
+login session. If that exchange cannot complete, binding fails rather than
+storing a session that will soon expire. The PAT is a management credential for
+check-in and balance operations; a relay API key is a separate credential.
 
 **Body**: `{ "siteId": 3, "username": "me@example.com", "password": "..." }` — `siteId`/`username`/`password` are required; unsupported platforms are 400, failed logins are 401 with the platform message.
 **Response** (200): `{ "success": true, "account": { "id": 12, "siteId": 3, "username": "me@example.com", "accessToken": "sk-...", "apiToken": null, "balance": 9.5, "status": "active", "isPinned": false, "sortOrder": 1, "checkinEnabled": true, "extraConfig": "{}", "createdAt": "...", "updatedAt": "..." }, "apiTokenFound": false, "tokenCount": 1, "reusedAccount": false }`

--- a/docs/api/downstream-keys.md
+++ b/docs/api/downstream-keys.md
@@ -22,12 +22,15 @@ Usage trend data for a specific key.
 
 ### POST /api/downstream-keys
 
-Create a new downstream API key.
+Create a new downstream API key. Both `name` and `key` are required. The server
+does not generate the key for this endpoint; supply a cryptographically random
+secret beginning with `sk-` (the admin UI generates one before submission).
 
 **Body**:
 ```json
 {
   "name": "My Key",
+  "key": "${DOWNSTREAM_API_KEY}",
   "groupName": "production",
   "tags": "tag1,tag2",
   "supportedModels": ["gpt-4o", "claude-sonnet-4-20250514"],
@@ -48,6 +51,24 @@ Create a new downstream API key.
 ```
 
 Routing-policy fields (`excludedSiteIds`, `excludedCredentialRefs`, `allowedSiteIds`, `allowedCredentialRefs`, `siteWeightMultipliers`, `keyWeight`) are accepted on both create and update; their full contract is documented under **Credential & site scope** below.
+
+### Usage limits are not a prepaid billing ledger
+
+- `maxRequests` is an atomic admission counter. RPM/TPM-denied requests do not
+  consume it, but an admitted request can still fail later; it is not a count of
+  successful model completions.
+- `maxCost` rejects subsequent requests once stored `usedCost` reaches the
+  threshold. Successful proxy requests add their **estimated** cost after
+  completion. No money is reserved for in-flight requests, so overlapping
+  requests or a single completion can exceed the threshold. It is not a strict
+  spending guarantee.
+- Failed attempts may retain reported usage and an estimate in proxy logs, but
+  currently do not increase the key's `usedCost`.
+- Proxy cost estimates use the recorded pricing-source/fallback calculation.
+  They are not the upstream wallet debit or an authoritative customer invoice;
+  do not require monetary amounts at different relay layers to match.
+- For `maxCost` and `maxRequests`, omitted, `null`, zero, or an empty string
+  clears the corresponding limit.
 
 ### Credential & site scope (downstream keys)
 

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -36,11 +36,20 @@ Available token candidates for route configuration.
 
 ### POST /api/models/check/:accountId
 
-Check model availability for a specific account. Returns `{ "success": true, "models": [...] }`.
+Refresh model discovery for one account. The response includes `success`,
+`refresh` (including `status`, `modelCount`, and `models`), `rebuild`, and
+`tokenBackfilled`. A discovered model is not proof of successful inference.
 
 ### POST /api/models/probe
 
-Trigger a model probe. Body: `{ "models": ["gpt-4o"], "wait": false }`. Returns 202 with probe job.
+Trigger a **scheduler-wide** model probe. The handler does not consume a request
+body: `models`, `accountId`, and `wait` do not narrow or wait for this operation.
+The 202 response (`queued`, `jobId`, `status: "pending"`) acknowledges the trigger,
+not successful inference or completion. Inspect the resulting probe history.
+
+For a bounded operator test, use `POST /api/models/verify-batch` with explicit
+`accountId`, `models`, and `limit`. That endpoint targets existing route channels;
+`probed: 0` is not successful inference coverage.
 
 ### POST /api/models/verify-batch, GET /api/models/verify-history
 


### PR DESCRIPTION
## Summary

- Correct the account read contract: this build exposes the account list, not `GET /api/accounts/:id`; describe durable NewAPI PAT promotion separately from relay keys.
- Correct the model-discovery response and make the scheduler-wide scope of `/api/models/probe` explicit. Its request body does not filter or wait; point bounded verification to `verify-batch`.
- Document the required caller-generated downstream key and distinguish atomic request admission, estimated post-completion cost limits, and an authoritative prepaid billing ledger.

These are documentation corrections to current behavior, not implementation of new endpoints or billing features.

## Validation

- Cross-checked the current route registrars and handlers.
- `go test ./docs -count=1` passed.
- Full installed pre-push passed: frontend tests, typecheck, lint, format, knip, build; Go build, vet, and complete WSL race suite.
- No `--no-verify` or gate exemption. A secret-shaped example placeholder was rejected before push; it was replaced with an environment-variable placeholder and the normal gate was rerun.