### PR TITLE
fix(store): reconcile legacy PostgreSQL id sequences on upgrade

### DIFF
--- a/handler/admin/settings_backup.go
+++ b/handler/admin/settings_backup.go
@@ -545,6 +545,7 @@ func validateBackupImportTableKeys(tables map[string]json.RawMessage, fromExport
 type backupImportConn interface {
 	DriverName() string
 	Queryx(query string, args ...any) (*sqlx.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
 	Exec(query string, args ...any) (sql.Result, error)
 }
 

--- a/handler/admin/settings_backup_pg_test.go
+++ b/handler/admin/settings_backup_pg_test.go
@@ -55,8 +55,16 @@ func TestBackupImportResyncsPostgresSequences(t *testing.T) {
 			site(3, "restored-c", "http://127.0.0.1:3012", "openai") +
 			"]"),
 	}
-	if _, err := importBackupTablesWithConn(db.DB, payload); err != nil {
+	tx, err := db.Beginx()
+	if err != nil {
+		t.Fatalf("begin import tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := importBackupTablesWithConn(tx, payload); err != nil {
 		t.Fatalf("import: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit import tx: %v", err)
 	}
 
 	// The ordinary write path supplies no id, so PostgreSQL asks the sequence.

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -78,6 +78,12 @@ func AutoMigrate(db *DB) error {
 			"dialect", dialect, "elapsed_ms", elapsed.Milliseconds())
 	}
 
+	if isPG(dialect) {
+		if err := reconcilePGIDSequences(db); err != nil {
+			return err
+		}
+	}
+
 	slog.Info("store: auto-migration complete", "dialect", dialect)
 	return nil
 }

--- a/store/sequences.go
+++ b/store/sequences.go
@@ -6,24 +6,30 @@ import (
 	"fmt"
 )
 
-// sequenceExecer is the slice of a transaction or connection that a sequence
-// resync needs. Both *sqlx.Tx (the SQLite→PostgreSQL migrator) and the backup
-// import's conn satisfy it, so this SQL has one owner instead of two copies that
-// can drift apart the next time a table is added.
+// sequenceExecer is the transaction-scoped executor used by sequence repair.
+// Callers must keep the transaction open until this function returns so the
+// advisory lock and per-table locks cover the read/repair/commit sequence.
+// The SQLite→PostgreSQL migrator and backup import both pass their open tx.
 type sequenceExecer interface {
+	QueryRow(query string, args ...any) *sql.Row
 	Exec(query string, args ...any) (sql.Result, error)
 }
 
-// ResyncPGIDSequences advances every serial id sequence past the largest id now
-// stored, for the tables that have one.
+const sequenceResyncAdvisoryLockKey = "metapi:resync-pg-id-sequences"
+
+// ResyncPGIDSequences advances every serial id sequence that is behind the
+// largest id now stored, for the tables that have one. It never rewinds a
+// sequence that is already ahead of MAX(id), including watermarks left by
+// deleted rows or allocated ids.
 //
 // Bulk writers that insert explicit ids leave PostgreSQL's sequences behind: the
-// migrator copying a SQLite database over, and a backup import restoring rows
-// with the ids they were exported with. The next ordinary INSERT then asks the
-// sequence for a value the restore just occupied and fails with a duplicate key —
-// a deployment in that state works until its first write, which is the worst
-// moment to discover it, and the error names a constraint rather than a sequence
-// so nothing points back here.
+// migrator copying a SQLite database over, a backup import restoring rows with
+// the ids they were exported with, and legacy databases whose sequence was
+// already below an occupied id before this repair existed. The next ordinary
+// INSERT then asks the sequence for a value the restore just occupied and fails
+// with a duplicate key — a deployment in that state works until its first write,
+// which is the worst moment to discover it, and the error names a constraint
+// rather than a sequence so nothing points back here.
 //
 // SQLite needs no help: AUTOINCREMENT updates sqlite_sequence on an explicit
 // insert, and a plain INTEGER PRIMARY KEY derives max+1 by itself.
@@ -35,19 +41,103 @@ type sequenceExecer interface {
 // Failures are collected and returned together rather than aborting on the first,
 // so a caller running against a possibly-incomplete schema can report every table
 // it could not resync. The migrator warns and continues, because its target may
-// not have run every migration; a backup import treats the same error as fatal,
-// because there the schema was just migrated and a silently un-advanced sequence
-// is exactly the bug this prevents.
+// not have run every migration; a backup import and AutoMigrate treat the same
+// error as fatal, because there the schema was just migrated and a silently
+// un-advanced sequence is exactly the bug this prevents.
 func ResyncPGIDSequences(exec sequenceExecer) error {
+	// Serialize repair runs across concurrent transactions. The lock is
+	// transaction-scoped, so it is released on commit or rollback.
+	if _, err := exec.Exec(`SELECT pg_advisory_xact_lock(hashtext($1::text))`, sequenceResyncAdvisoryLockKey); err != nil {
+		return fmt.Errorf("acquire PostgreSQL sequence resync lock: %w", err)
+	}
+
 	var errs []error
 	for _, table := range sequenceTableNames() {
-		query := fmt.Sprintf(
-			`SELECT setval(pg_get_serial_sequence('%s', 'id'), COALESCE((SELECT MAX("id") FROM "%s"), 1), TRUE)`,
-			table, table,
+		quotedTable := quoteIdentPG(table)
+		// Probe without a table lock first. AutoMigrate runs on every startup
+		// and most databases need no repair; locking every table would turn a
+		// healthy boot into a fleet-wide write barrier.
+		probeSQL := fmt.Sprintf(
+			`SELECT COALESCE(MAX("id"), 0), COALESCE(pg_sequence_last_value(pg_get_serial_sequence('%s', 'id')::regclass), 0), pg_get_serial_sequence('%s', 'id') FROM %s`,
+			table, table, quotedTable,
 		)
-		if _, err := exec.Exec(query); err != nil {
+		var maxID, sequenceLast int64
+		var sequenceName sql.NullString
+		if err := exec.QueryRow(probeSQL).Scan(&maxID, &sequenceLast, &sequenceName); err != nil {
+			errs = append(errs, fmt.Errorf("table %s: probe: %w", table, err))
+			continue
+		}
+		if !sequenceName.Valid {
+			errs = append(errs, fmt.Errorf("table %s: no serial id sequence", table))
+			continue
+		}
+		if maxID == 0 || sequenceLast >= maxID {
+			continue
+		}
+
+		// SHARE ROW EXCLUSIVE conflicts with ordinary INSERT/UPDATE/DELETE.
+		// The caller's transaction holds it until commit, so the MAX(id) read
+		// and setval cannot race an ordinary writer. The anonymous block
+		// re-reads the sequence state, so a concurrent repair is harmless.
+		lockSQL := fmt.Sprintf(`LOCK TABLE %s IN SHARE ROW EXCLUSIVE MODE`, quotedTable)
+		if _, err := exec.Exec(lockSQL); err != nil {
+			errs = append(errs, fmt.Errorf("table %s: lock: %w", table, err))
+			continue
+		}
+		if _, err := exec.Exec(pgSequenceRepairSQL(table)); err != nil {
 			errs = append(errs, fmt.Errorf("table %s: %w", table, err))
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// pgSequenceRepairSQL repairs one table's serial sequence without ever moving
+// it backwards. PostgreSQL's pg_sequence_last_value() is NULL until a sequence
+// has been called, so reading the sequence relation directly is required to
+// preserve a setval(..., false) watermark. The anonymous block runs under the
+// caller's table lock and transaction-scoped advisory lock.
+func pgSequenceRepairSQL(table string) string {
+	quotedTable := quoteIdentPG(table)
+	return fmt.Sprintf(`
+DO $metapi_sequence_resync$
+DECLARE
+	seq regclass;
+	last_value bigint;
+	is_called boolean;
+	max_id bigint;
+BEGIN
+	seq := pg_get_serial_sequence('%s', 'id')::regclass;
+	IF seq IS NULL THEN
+		RAISE EXCEPTION 'no serial id sequence for table %s';
+	END IF;
+	EXECUTE 'SELECT last_value, is_called FROM ' || seq::text INTO last_value, is_called;
+	SELECT COALESCE(MAX("id"), 0) INTO max_id FROM %s;
+	IF max_id > 0 THEN
+		IF last_value < max_id THEN
+			PERFORM setval(seq, max_id, true);
+		ELSIF last_value = max_id AND NOT is_called THEN
+			PERFORM setval(seq, last_value, true);
+		END IF;
+	END IF;
+END
+$metapi_sequence_resync$`, table, table, quotedTable)
+}
+
+// reconcilePGIDSequences is the AutoMigrate entry point. It runs the shared
+// repair in one transaction so the advisory lock and table locks are held until
+// every sequence has been checked.
+func reconcilePGIDSequences(db *DB) error {
+	tx, err := db.Beginx()
+	if err != nil {
+		return fmt.Errorf("store: begin PostgreSQL sequence reconciliation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := ResyncPGIDSequences(tx); err != nil {
+		return fmt.Errorf("store: reconcile PostgreSQL id sequences: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: commit PostgreSQL sequence reconciliation: %w", err)
+	}
+	return nil
 }

--- a/store/sequences_upgrade_test.go
+++ b/store/sequences_upgrade_test.go
@@ -1,0 +1,153 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
+)
+
+const sequenceUpgradeTestTimestamp = "2026-09-09T00:00:00Z"
+
+func seedExplicitSiteID(t *testing.T, db *DB, id int64) {
+	t.Helper()
+	if _, err := db.Exec(db.Rebind(`INSERT INTO sites (id, name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`),
+		id, "legacy-site-"+idString(id), "https://legacy-"+idString(id)+".example", "openai", "active",
+		sequenceUpgradeTestTimestamp, sequenceUpgradeTestTimestamp); err != nil {
+		t.Fatalf("seed explicit site id %d: %v", id, err)
+	}
+}
+
+func setSiteSequence(t *testing.T, db *DB, value int64, called bool) {
+	t.Helper()
+	if _, err := db.Exec(`SELECT setval(pg_get_serial_sequence('sites', 'id'), $1, $2)`, value, called); err != nil {
+		t.Fatalf("set sites sequence to %d (called=%t): %v", value, called, err)
+	}
+}
+
+func insertSiteWithoutID(t *testing.T, db *DB) int64 {
+	t.Helper()
+	var id int64
+	if err := db.QueryRow(db.Rebind(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?) RETURNING id`),
+		"post-upgrade", "https://post-upgrade.example", "openai", "active",
+		sequenceUpgradeTestTimestamp, sequenceUpgradeTestTimestamp).Scan(&id); err != nil {
+		t.Fatalf("insert without id after AutoMigrate: %v", err)
+	}
+	return id
+}
+
+func idString(id int64) string {
+	if id == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for id > 0 {
+		i--
+		buf[i] = byte('0' + id%10)
+		id /= 10
+	}
+	return string(buf[i:])
+}
+
+// TestAutoMigrateAdvancesLegacyPostgresSequence is the upgrade-path regression:
+// a database restored or imported with explicit ids can leave the serial
+// sequence below MAX(id). AutoMigrate must repair that before the next ordinary
+// INSERT; without the repair this test gets an id below the occupied range.
+func TestAutoMigrateAdvancesLegacyPostgresSequence(t *testing.T) {
+	db := openTestPG(t)
+	pgtest.Reset(t, db.DB)
+
+	seedExplicitSiteID(t, db, 10)
+	setSiteSequence(t, db, 1, true)
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate upgrade: %v", err)
+	}
+
+	id := insertSiteWithoutID(t, db)
+	if id <= 10 {
+		t.Fatalf("insert after upgrade got id %d, want > occupied id 10", id)
+	}
+}
+
+// TestAutoMigrateDoesNotRewindPostgresSequenceAheadOfRows pins the other side of
+// the repair: a sequence may be ahead of MAX(id) because rows were deleted or
+// ids were allocated. AutoMigrate must leave that watermark in place.
+func TestAutoMigrateDoesNotRewindPostgresSequenceAheadOfRows(t *testing.T) {
+	db := openTestPG(t)
+	pgtest.Reset(t, db.DB)
+
+	seedExplicitSiteID(t, db, 10)
+	setSiteSequence(t, db, 100, true)
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate upgrade: %v", err)
+	}
+
+	var sequence int64
+	if err := db.QueryRow(`SELECT pg_sequence_last_value(pg_get_serial_sequence('sites', 'id')::regclass)`).Scan(&sequence); err != nil {
+		t.Fatalf("read sites sequence after AutoMigrate: %v", err)
+	}
+	if sequence != 100 {
+		t.Fatalf("sequence last_value = %d after AutoMigrate, want the existing watermark 100", sequence)
+	}
+
+	id := insertSiteWithoutID(t, db)
+	if id <= sequence {
+		t.Fatalf("insert after upgrade got id %d, want > sequence watermark %d", id, sequence)
+	}
+}
+
+// TestAutoMigrateMarksPostgresSequenceCalledAtMax covers the boundary where the
+// sequence value equals MAX(id) but is_called=false. The next value would be
+// the occupied id unless AutoMigrate marks the sequence as called.
+func TestAutoMigrateMarksPostgresSequenceCalledAtMax(t *testing.T) {
+	db := openTestPG(t)
+	pgtest.Reset(t, db.DB)
+
+	seedExplicitSiteID(t, db, 10)
+	setSiteSequence(t, db, 10, false)
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate upgrade: %v", err)
+	}
+
+	id := insertSiteWithoutID(t, db)
+	if id <= 10 {
+		t.Fatalf("insert after upgrade got id %d, want > occupied id 10", id)
+	}
+}
+
+// TestAutoMigratePreservesSQLiteSequenceBehavior verifies the PG repair is not
+// applied to SQLite, whose AUTOINCREMENT bookkeeping already advances on
+// explicit-id inserts.
+func TestAutoMigratePreservesSQLiteSequenceBehavior(t *testing.T) {
+	db := openTestSQLite(t)
+
+	if _, err := db.Exec(`INSERT INTO sites (id, name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		10, "legacy-site-sqlite", "https://legacy-sqlite.example", "openai", "active",
+		sequenceUpgradeTestTimestamp, sequenceUpgradeTestTimestamp); err != nil {
+		t.Fatalf("seed explicit SQLite site id 10: %v", err)
+	}
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate SQLite upgrade: %v", err)
+	}
+
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		"post-upgrade-sqlite", "https://post-upgrade-sqlite.example", "openai", "active",
+		sequenceUpgradeTestTimestamp, sequenceUpgradeTestTimestamp)
+	if err != nil {
+		t.Fatalf("insert without id after SQLite AutoMigrate: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("read SQLite insert id: %v", err)
+	}
+	if id <= 10 {
+		t.Fatalf("SQLite insert after upgrade got id %d, want > occupied id 10", id)
+	}
+}


### PR DESCRIPTION
## Summary

- `AutoMigrate` now reconciles serial ID sequences on PostgreSQL startup, covering legacy databases whose sequence is behind `MAX(id)` before the next ordinary insert collides.
- The shared sequence repair never rewinds a sequence ahead of `MAX(id)`, serializes concurrent repairs with a transaction-scoped advisory lock, and takes a table lock only when a repair is actually needed.
- Added PostgreSQL upgrade regressions for behind, ahead, and `is_called=false` states, plus SQLite behavior coverage.

## Verification

- Negative control on the pre-fix commit: the regression returned `id=2` while explicit historical ID `10` was occupied.
- Isolated Linux PostgreSQL test node:
  - `go test ./... -count=1 -race -p 1 -timeout=30m` → exit 0
  - `go build ./cmd/server` and `go vet ./...` passed
  - `go test ./store -count=1 -p 1` passed
  - backup import PostgreSQL integration regression passed
  - frontend `bun run test`: 255 files / 1660 tests passed
  - frontend lint, format check, and knip passed
  - `golangci-lint v1.64.8` passed with single concurrency
- Frontend `typecheck` / `build:check` could not complete on the 2C/4 GiB isolated node because the native `tsgo` process was OOM-killed (`SIGKILL`); GitHub CI will run that gate on its larger runner. No TypeScript source changed in this PR.

Fixes #1292