### PR TITLE
refactor(web): split the customHeaders field out and fix its a11y wiring

### DIFF
--- a/web/src/features/sites/__tests__/custom-headers-examples.test.ts
+++ b/web/src/features/sites/__tests__/custom-headers-examples.test.ts
@@ -1,0 +1,92 @@
+// metapi-go/features/sites — pure unit tests for the read-only customHeaders
+// example snippets (#1132). The snippets are user-facing suggestions that the
+// proxy will actually forward, so the contract is pinned here rather than
+// discovered at runtime: what a site may inject is decided by
+// platform.IsDeniedCustomHeader (data plane) and
+// service.isReservedPlatformCustomHeader (assembly side).
+import { describe, expect, it } from 'vitest'
+
+import { CUSTOM_HEADERS_EXAMPLES } from '../lib/custom-headers-examples'
+
+// Keep in step with those two Go predicates. An example suggesting a denied
+// header would be dropped silently on the way upstream, so it must never ship.
+const DENIED_HEADERS = new Set([
+  'authorization',
+  'host',
+  'content-length',
+  'content-type',
+  'transfer-encoding',
+  'accept-encoding',
+  'connection',
+  'cookie',
+  'keep-alive',
+  'te',
+  'trailer',
+  'trailers',
+  'upgrade',
+  'new-api-user',
+])
+
+describe('CUSTOM_HEADERS_EXAMPLES', () => {
+  it('ships the three CLI clients with unique names and snippets', () => {
+    expect(CUSTOM_HEADERS_EXAMPLES.map((e) => e.client)).toEqual([
+      'Claude Code',
+      'Codex CLI',
+      'Gemini CLI',
+    ])
+    const clients = CUSTOM_HEADERS_EXAMPLES.map((e) => e.client)
+    const snippets = CUSTOM_HEADERS_EXAMPLES.map((e) => e.snippet)
+    // `client` doubles as the React key, so names must stay unique.
+    expect(new Set(clients).size).toBe(clients.length)
+    expect(new Set(snippets).size).toBe(snippets.length)
+  })
+
+  it('is valid JSON objects the field schema would accept', () => {
+    for (const { client, snippet } of CUSTOM_HEADERS_EXAMPLES) {
+      // Must satisfy the field's own `isEmptyOrValidJson` rule (lib/sites-schema):
+      // a JSON object — never an array, a bare string or invalid JSON. Inserting
+      // an example must not be able to put the form into an error state.
+      const parsed: unknown = JSON.parse(snippet)
+      expect(parsed, `${client}: must parse`).not.toBeNull()
+      expect(parsed, `${client}: must be an object`).toBeTypeOf('object')
+      expect(Array.isArray(parsed), `${client}: must not be an array`).toBe(
+        false
+      )
+      expect(
+        Object.keys(parsed as Record<string, unknown>).length,
+        `${client}: must carry at least one header`
+      ).toBeGreaterThan(0)
+    }
+  })
+
+  it('only suggests headers a site is actually allowed to inject', () => {
+    for (const { client, snippet } of CUSTOM_HEADERS_EXAMPLES) {
+      for (const name of Object.keys(JSON.parse(snippet))) {
+        const lower = name.toLowerCase()
+        expect(
+          DENIED_HEADERS.has(lower),
+          `${client}: ${name} is not site-injectable`
+        ).toBe(false)
+        expect(
+          lower.startsWith('proxy-'),
+          `${client}: ${name} is a Proxy-* header`
+        ).toBe(false)
+      }
+    }
+  })
+
+  it('stays obviously a placeholder and never bakes in a current version', () => {
+    // #1132's core constraint. These CLIs re-release constantly, so a concrete
+    // version rots into a wrong-but-authoritative value; a stale template is
+    // worse than none because users treat it as the real one.
+    for (const { client, snippet } of CUSTOM_HEADERS_EXAMPLES) {
+      expect(snippet, `${client}: must contain a <PLACEHOLDER> token`).toMatch(
+        /<[A-Z][A-Z_]*>/
+      )
+      expect(
+        snippet,
+        `${client}: must not bake in a concrete version`
+      ).not.toMatch(/\d+\.\d+/)
+    }
+  })
+})

--- a/web/src/features/sites/components/__tests__/custom-headers-field.test.tsx
+++ b/web/src/features/sites/components/__tests__/custom-headers-field.test.tsx
@@ -1,0 +1,100 @@
+// Component-level tests for the extracted `customHeaders` field (#1132).
+// The example data contract is owned by ../../__tests__/custom-headers-examples.test.ts;
+// this file covers only the controlled-component behavior and the
+// `<FormControl>` prop forwarding the sheet's label association depends on.
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { CUSTOM_HEADERS_EXAMPLES } from '../../lib/custom-headers-examples'
+import { CustomHeadersField } from '../custom-headers-field'
+
+afterEach(() => cleanup())
+
+const CLIENTS = CUSTOM_HEADERS_EXAMPLES.map((example) => example.client)
+
+function entry(client: string) {
+  return screen.getByRole('button', { name: `Insert ${client} example` })
+}
+
+function textarea() {
+  return screen.getByRole('textbox') as HTMLTextAreaElement
+}
+
+describe('CustomHeadersField fill-only insertion', () => {
+  it('offers one enabled entry per example when the field is empty', () => {
+    render(<CustomHeadersField value='' onChange={vi.fn()} />)
+    for (const client of CLIENTS) {
+      expect(entry(client)).toBeEnabled()
+    }
+  })
+
+  it('emits the chosen snippet through onChange and types nothing itself', () => {
+    const onChange = vi.fn()
+    render(<CustomHeadersField value='' onChange={onChange} />)
+
+    fireEvent.click(entry('Claude Code'))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(
+      '{"User-Agent":"claude-cli/<VERSION>","x-app":"cli"}'
+    )
+    // Controlled component: it must not write to the DOM node behind the
+    // form's back, or the field value and the RHF state would diverge.
+    expect(textarea().value).toBe('')
+  })
+
+  it('treats whitespace-only content as empty', () => {
+    render(<CustomHeadersField value={'  \n '} onChange={vi.fn()} />)
+    for (const client of CLIENTS) {
+      expect(entry(client)).toBeEnabled()
+    }
+  })
+
+  it('refuses to touch content the user already filled (never merge, never replace)', () => {
+    const onChange = vi.fn()
+    const written = '{"User-Agent":"my-handwritten-client","X-Keep":"mine"}'
+    render(<CustomHeadersField value={written} onChange={onChange} />)
+
+    for (const client of CLIENTS) {
+      expect(entry(client)).toBeDisabled()
+      fireEvent.click(entry(client))
+    }
+    expect(onChange).not.toHaveBeenCalled()
+    expect(textarea().value).toBe(written)
+  })
+
+  it('forwards FormControl props onto the textarea so the label stays associated', () => {
+    // `<FormControl>` clones its single child with id / aria-describedby /
+    // aria-invalid. Swallowing them is how `EndpointsEditor` lost its
+    // `<FormLabel htmlFor>` association.
+    render(
+      <CustomHeadersField
+        value=''
+        onChange={vi.fn()}
+        id='fld-1'
+        aria-describedby='desc-1'
+        aria-invalid={false}
+      />
+    )
+    const node = textarea()
+    expect(node).toHaveAttribute('id', 'fld-1')
+    expect(node).toHaveAttribute('aria-describedby', 'desc-1')
+    expect(node).toHaveAttribute('aria-invalid', 'false')
+  })
+
+  it('renders the example rules as helper text, not a second form description', () => {
+    const { container } = render(
+      <CustomHeadersField value='' onChange={vi.fn()} />
+    )
+    // A second `<FormDescription>` inside the FormItem would emit another
+    // element carrying the same `formDescriptionId`.
+    expect(
+      container.querySelectorAll('[data-slot="form-description"]')
+    ).toHaveLength(0)
+    const ids = [...container.querySelectorAll('[id]')].map((n) => n.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/web/src/features/sites/components/__tests__/site-form-sheet.test.tsx
+++ b/web/src/features/sites/components/__tests__/site-form-sheet.test.tsx
@@ -387,176 +387,63 @@ describe('SiteFormSheet dirty-close guard', () => {
   })
 })
 
-describe('SiteFormSheet custom headers examples (#1132)', () => {
-  // Read-only snippets compiled into the bundle — no template entity, no
-  // table, no setting. Each entry's accessible name comes from the
-  // `sites.form.customHeadersExampleInsert` aria-label, not the visible
-  // product name, so a screen-reader user hears what the click will do.
-  const EXAMPLE_CLIENTS = ['Claude Code', 'Codex CLI', 'Gemini CLI'] as const
+describe('SiteFormSheet custom headers field wiring (#1132)', () => {
+  // Fill-only semantics and the read-only example data contract are owned by
+  // `__tests__/custom-headers-field.test.tsx`. What only the real sheet can
+  // prove is the wiring: the extracted component sits inside `<FormControl>`
+  // without losing the label association, and an edited site's stored headers
+  // reach it already locked.
 
-  function exampleButton(client: string) {
-    return screen.getByRole('button', { name: `Insert ${client} example` })
-  }
-
-  async function renderEmptySheet() {
+  it('keeps the textarea labelled and its aria-describedby uniquely resolvable', async () => {
     render(<SiteFormSheet open onOpenChange={vi.fn()} editingSite={null} />)
+    // The sheet renders through a portal, so the ids must be resolved against
+    // document.body — `container` would see zero elements and pass vacuously.
+    const scope = document.body
+
+    // `getByLabelText` resolving at all proves FormControl's cloned
+    // id/aria-describedby survived the trip through the extracted component.
     const headers = await screen.findByLabelText('Custom headers')
-    await waitFor(() => expect(headers).toBeInTheDocument())
-    return headers
-  }
+    expect(headers.tagName).toBe('TEXTAREA')
 
-  it('offers one enabled insert entry per built-in CLI example', async () => {
-    const headers = await renderEmptySheet()
-    expect(headers).toHaveValue('')
-
-    for (const client of EXAMPLE_CLIENTS) {
-      expect(exampleButton(client)).toBeEnabled()
+    const describedBy = headers.getAttribute('aria-describedby') ?? ''
+    expect(describedBy).not.toBe('')
+    for (const id of describedBy.split(/\s+/).filter(Boolean)) {
+      // A second <FormDescription> in one FormItem would emit a second element
+      // carrying the same formDescriptionId — the defect this guards.
+      expect(
+        scope.querySelectorAll(`#${id}`),
+        `aria-describedby "${id}" must resolve to exactly one element`
+      ).toHaveLength(1)
     }
   })
 
-  it('fills an empty field with the chosen example without touching the backend', async () => {
-    const headers = await renderEmptySheet()
-
-    fireEvent.click(exampleButton('Claude Code'))
-
-    await waitFor(() =>
-      expect(headers).toHaveValue(
-        '{"User-Agent":"claude-cli/<VERSION>","x-app":"cli"}'
-      )
-    )
-    // Inserting an example is a pure textarea fill: it must not create, update
-    // or sync anything, because the snippets are not persisted entities.
-    expect(mockCreateMutate).not.toHaveBeenCalled()
-    expect(mockUpdateMutate).not.toHaveBeenCalled()
-  })
-
-  it('treats whitespace-only content as empty', async () => {
-    const headers = await renderEmptySheet()
-    fireEvent.change(headers, { target: { value: '  \n ' } })
-
-    await waitFor(() => expect(exampleButton('Codex CLI')).toBeEnabled())
-
-    fireEvent.click(exampleButton('Codex CLI'))
-
-    await waitFor(() =>
-      expect(headers).toHaveValue(
-        '{"User-Agent":"codex-cli/<VERSION>","originator":"codex_cli_rs"}'
-      )
-    )
-  })
-
-  it('refuses to touch a field the user already filled (fill-only: never merge, never replace)', async () => {
-    const headers = await renderEmptySheet()
-    const written = '{"User-Agent":"my-handwritten-client","X-Keep":"mine"}'
-    fireEvent.change(headers, { target: { value: written } })
-
-    await waitFor(() => {
-      for (const client of EXAMPLE_CLIENTS) {
-        expect(exampleButton(client)).toBeDisabled()
-      }
-    })
-
-    // Every entry is disabled, and a click on a disabled control must still
-    // leave the hand-written JSON byte-identical.
-    for (const client of EXAMPLE_CLIENTS) {
-      fireEvent.click(exampleButton(client))
-    }
-    expect(headers).toHaveValue(written)
-  })
-
-  it("keeps an existing site's stored headers locked and intact in edit mode", async () => {
+  it("locks an existing site's stored headers end to end", async () => {
     const stored = '{"User-Agent":"claude-cli/1.2.3"}'
-    const editingSite: Site = {
-      id: 11,
-      name: 'Existing site',
-      url: 'https://existing.example',
-      platform: 'claude',
-      status: 'active',
-      customHeaders: stored,
-    }
-
     render(
-      <SiteFormSheet open onOpenChange={vi.fn()} editingSite={editingSite} />
+      <SiteFormSheet
+        open
+        onOpenChange={vi.fn()}
+        editingSite={{
+          id: 11,
+          name: 'Existing site',
+          url: 'https://existing.example',
+          platform: 'claude',
+          status: 'active',
+          customHeaders: stored,
+        }}
+      />
     )
 
     const headers = await screen.findByLabelText('Custom headers')
     await waitFor(() => expect(headers).toHaveValue(stored))
 
-    for (const client of EXAMPLE_CLIENTS) {
-      expect(exampleButton(client)).toBeDisabled()
-      fireEvent.click(exampleButton(client))
+    for (const client of ['Claude Code', 'Codex CLI', 'Gemini CLI']) {
+      const button = screen.getByRole('button', {
+        name: `Insert ${client} example`,
+      })
+      expect(button).toBeDisabled()
+      fireEvent.click(button)
     }
     expect(headers).toHaveValue(stored)
-  })
-
-  it('inserts valid JSON objects that are obviously placeholders and carry only injectable headers', async () => {
-    // Mirrors platform.IsDeniedCustomHeader (data plane) and
-    // service.isReservedPlatformCustomHeader (assembly side). An example that
-    // suggested one of these would be dropped silently on the way upstream, so
-    // it must never ship. Keep in step with those two Go predicates.
-    const DENIED_HEADERS = new Set([
-      'authorization',
-      'host',
-      'content-length',
-      'content-type',
-      'transfer-encoding',
-      'accept-encoding',
-      'connection',
-      'cookie',
-      'keep-alive',
-      'te',
-      'trailer',
-      'trailers',
-      'upgrade',
-      'new-api-user',
-    ])
-
-    for (const client of EXAMPLE_CLIENTS) {
-      const headers = await renderEmptySheet()
-      fireEvent.click(exampleButton(client))
-      await waitFor(() => expect(headers).not.toHaveValue(''))
-      const inserted = (headers as HTMLTextAreaElement).value
-
-      // Must satisfy the field's own `isEmptyOrValidJson` schema rule, i.e. a
-      // JSON object — never an array, a bare string or invalid JSON. Inserting
-      // an example must not be able to put the form into an error state.
-      const parsed: unknown = JSON.parse(inserted)
-      expect(parsed, `${client}: must parse`).not.toBeNull()
-      expect(parsed, `${client}: must be an object`).toBeTypeOf('object')
-      expect(Array.isArray(parsed), `${client}: must not be an array`).toBe(
-        false
-      )
-
-      const names = Object.keys(parsed as Record<string, unknown>)
-      expect(
-        names.length,
-        `${client}: must carry at least one header`
-      ).toBeGreaterThan(0)
-      for (const name of names) {
-        const lower = name.toLowerCase()
-        expect(
-          DENIED_HEADERS.has(lower),
-          `${client}: ${name} is not site-injectable`
-        ).toBe(false)
-        expect(
-          lower.startsWith('proxy-'),
-          `${client}: ${name} is a Proxy-* header`
-        ).toBe(false)
-      }
-
-      // #1132's core constraint: an example must read as a placeholder, never
-      // as an authoritative current value. A baked-in version rots with the
-      // next upstream CLI release, and a stale template is worse than none
-      // because users treat it as the real value.
-      expect(inserted, `${client}: must contain a <PLACEHOLDER> token`).toMatch(
-        /<[A-Z][A-Z_]*>/
-      )
-      expect(
-        inserted,
-        `${client}: must not bake in a concrete version`
-      ).not.toMatch(/\d+\.\d+/)
-
-      cleanup()
-    }
   })
 })

--- a/web/src/features/sites/components/custom-headers-field.tsx
+++ b/web/src/features/sites/components/custom-headers-field.tsx
@@ -1,0 +1,86 @@
+// metapi-go/features/sites/components — the site `customHeaders` field:
+// a JSON textarea plus the read-only "insert example" affordance (#1132).
+//
+// Thin wrapper in the same shape as `endpoints-editor.tsx`: it owns no form
+// state, only `value`/`onChange`. It is rendered inside `<FormControl>`, which
+// clones its single child with `id` / `aria-describedby` / `aria-invalid` — so
+// the remaining props MUST be forwarded onto the textarea or the
+// `<FormLabel htmlFor>` association silently breaks.
+//
+// Exactly one `<FormDescription>` may live in a `FormItem`: it renders
+// `<p id={formDescriptionId}>`, and a second one would duplicate that id and
+// steal `aria-describedby`. The example rules below are therefore plain
+// helper text (the pattern used across features), not a second description.
+//
+// The snippets themselves live in `../lib/custom-headers-examples` — this file
+// exports only the component, as `react(only-export-components)` requires for
+// Fast Refresh.
+
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+import { CUSTOM_HEADERS_EXAMPLES } from '../lib/custom-headers-examples'
+
+type CustomHeadersFieldProps = {
+  value: string
+  /**
+   * Always receives the new field text — never a DOM event. The component owns
+   * the event→value adaptation so callers (RHF `field.onChange`, the example
+   * buttons) share one honest signature, matching `EndpointsEditor`.
+   */
+  onChange: (value: string) => void
+} & Omit<React.ComponentProps<'textarea'>, 'value' | 'onChange'>
+
+export function CustomHeadersField({
+  value,
+  onChange,
+  ...props
+}: CustomHeadersFieldProps) {
+  const { t } = useTranslation()
+
+  // Fill-only insert semantics (#1132): an example may populate the field only
+  // while it is empty, so JSON the user wrote (or that an existing site already
+  // carries) is never replaced or merged behind their back. Merging was rejected
+  // because every example shares `User-Agent`, so a user-wins merge would be a
+  // silent no-op in exactly the case the entry exists for. Whitespace counts as
+  // empty, matching `isEmptyOrValidJson` in ../lib/sites-schema.
+  const hasContent = value.trim() !== ''
+
+  return (
+    <>
+      <Textarea
+        rows={3}
+        placeholder='{"X-Custom-Header":"value"}'
+        className='font-mono text-xs'
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        {...props}
+      />
+      <div className='mt-2 flex flex-wrap items-center gap-1.5'>
+        <span className='text-muted-foreground text-xs'>
+          {t('sites.form.customHeadersExamplesLabel')}
+        </span>
+        {CUSTOM_HEADERS_EXAMPLES.map((example) => (
+          <Button
+            key={example.client}
+            type='button'
+            variant='outline'
+            size='xs'
+            disabled={hasContent}
+            aria-label={t('sites.form.customHeadersExampleInsert', {
+              client: example.client,
+            })}
+            onClick={() => onChange(example.snippet)}
+          >
+            {example.client}
+          </Button>
+        ))}
+      </div>
+      <p className='text-muted-foreground text-xs'>
+        {t('sites.form.customHeadersExamplesHint')}
+      </p>
+    </>
+  )
+}

--- a/web/src/features/sites/components/site-form-sheet.tsx
+++ b/web/src/features/sites/components/site-form-sheet.tsx
@@ -50,7 +50,6 @@ import {
 } from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
-import { Textarea } from '@/components/ui/textarea'
 import { toast } from '@/lib/toast'
 
 import { useCreateSite, useDetectSite, useUpdateSite } from '../api'
@@ -66,6 +65,7 @@ import {
   type SiteFormValues,
 } from '../lib/sites-schema'
 import type { Site, SiteFormPayload, SiteProbeScope } from '../types'
+import { CustomHeadersField } from './custom-headers-field'
 import { EndpointsEditor } from './endpoints-editor'
 
 type SiteFormSheetProps = {
@@ -94,42 +94,6 @@ const PLATFORM_OPTIONS: readonly string[] = [
   'new-api',
   'sub2api',
   'one-api',
-]
-
-// Read-only custom-headers examples (#1132). These are deliberately NOT
-// templates: no table, no setting, no entity, no sync semantics — the snippets
-// are compiled into the bundle and their only effect is filling the textarea in
-// front of the user, who owns the result from then on.
-//
-// Version numbers stay `<PLACEHOLDER>` tokens on purpose. The real User-Agent
-// of these CLIs changes with every upstream release, so a baked-in "current"
-// value would rot into a wrong-but-authoritative-looking constant — the exact
-// failure mode that scoped #1132 down from a product-level template feature to
-// a read-only snippet. The header *shapes* are grounded in this repo's own
-// upstream adapters rather than guessed:
-//   Claude Code → proxy/profiles/claude_code.go (`^claude-cli/<semver>` + `x-app: cli`)
-//   Codex CLI   → service/oauth/codex.go (`codex-cli` UA + `originator: codex_cli_rs`)
-//   Gemini CLI  → service/oauth/gemini_cli.go buildGeminiCliProxyHeaders
-// Every key here is one a site is allowed to inject: none of them is denied by
-// platform.IsDeniedCustomHeader or service.isReservedPlatformCustomHeader.
-// Both invariants are gated in the site-form-sheet test.
-const CUSTOM_HEADERS_EXAMPLES: readonly {
-  client: string
-  snippet: string
-}[] = [
-  {
-    client: 'Claude Code',
-    snippet: '{"User-Agent":"claude-cli/<VERSION>","x-app":"cli"}',
-  },
-  {
-    client: 'Codex CLI',
-    snippet: '{"User-Agent":"codex-cli/<VERSION>","originator":"codex_cli_rs"}',
-  },
-  {
-    client: 'Gemini CLI',
-    snippet:
-      '{"User-Agent":"GeminiCLI/<VERSION>/<COMMIT> (<OS>; <ARCH>)","X-Goog-Api-Client":"google-genai-sdk/<VERSION> gl-node/<NODE_VERSION>"}',
-  },
 ]
 
 function nullableBoolToSelectValue(value: boolean | null): string {
@@ -764,60 +728,21 @@ export function SiteFormSheet({
             <FormField
               control={form.control}
               name='customHeaders'
-              render={({ field }) => {
-                // Fill-only insert semantics (#1132): an example may populate
-                // the field only while it is empty, so JSON the user wrote (or
-                // that an existing site already carries) is never replaced or
-                // merged behind their back. Merging was rejected because every
-                // example shares `User-Agent`, so a user-wins merge would be a
-                // silent no-op in exactly the case the entry exists for.
-                // Whitespace counts as empty, matching `isEmptyOrValidJson` in
-                // ../lib/sites-schema.
-                const hasHeadersContent = field.value.trim() !== ''
-                return (
-                  <FormItem>
-                    <FormLabel>{t('sites.form.customHeaders')}</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        rows={3}
-                        placeholder='{"X-Custom-Header":"value"}'
-                        className='font-mono text-xs'
-                        {...field}
-                      />
-                    </FormControl>
-                    <div className='flex flex-wrap items-center justify-between gap-2'>
-                      <FormDescription>
-                        {t('sites.form.customHeadersHint')}
-                      </FormDescription>
-                      <div className='flex flex-wrap items-center gap-1.5'>
-                        <span className='text-muted-foreground text-xs'>
-                          {t('sites.form.customHeadersExamplesLabel')}
-                        </span>
-                        {CUSTOM_HEADERS_EXAMPLES.map((example) => (
-                          <Button
-                            key={example.client}
-                            type='button'
-                            variant='outline'
-                            size='xs'
-                            disabled={hasHeadersContent}
-                            aria-label={t(
-                              'sites.form.customHeadersExampleInsert',
-                              { client: example.client }
-                            )}
-                            onClick={() => field.onChange(example.snippet)}
-                          >
-                            {example.client}
-                          </Button>
-                        ))}
-                      </div>
-                    </div>
-                    <FormDescription>
-                      {t('sites.form.customHeadersExamplesHint')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )
-              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('sites.form.customHeaders')}</FormLabel>
+                  <FormControl>
+                    <CustomHeadersField
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    {t('sites.form.customHeadersHint')}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
 
             <FormField

--- a/web/src/features/sites/lib/custom-headers-examples.ts
+++ b/web/src/features/sites/lib/custom-headers-examples.ts
@@ -1,0 +1,42 @@
+// metapi-go/features/sites — read-only `customHeaders` example snippets (#1132).
+//
+// Deliberately NOT templates: no table, no setting, no entity, no sync
+// semantics. The snippets are compiled into the bundle and their only effect
+// is filling the textarea in front of the user, who owns the result from then
+// on. Rebuilding them as persisted templates is the design #1132 was scoped
+// down away from.
+//
+// Version numbers stay `<PLACEHOLDER>` tokens on purpose. The real User-Agent
+// of these CLIs changes with every upstream release, so a baked-in "current"
+// value would rot into a wrong-but-authoritative-looking constant — and a
+// stale template is worse than none because users treat it as the real value.
+//
+// The header *shapes* are grounded in this repo's own upstream adapters rather
+// than guessed:
+//   Claude Code → proxy/profiles/claude_code.go (`^claude-cli/<semver>` + `x-app: cli`)
+//   Codex CLI   → service/oauth/codex.go (`codex-cli` UA + `originator: codex_cli_rs`)
+//   Gemini CLI  → service/oauth/gemini_cli.go buildGeminiCliProxyHeaders
+// Every key is one a site is allowed to inject: none is denied by
+// platform.IsDeniedCustomHeader or service.isReservedPlatformCustomHeader.
+// Both invariants are gated in ../__tests__/custom-headers-examples.test.ts.
+
+export const CUSTOM_HEADERS_EXAMPLES: readonly {
+  /** Client product name — identical in both locales, so not translated. */
+  client: string
+  /** Read-only JSON object inserted verbatim into the `customHeaders` field. */
+  snippet: string
+}[] = [
+  {
+    client: 'Claude Code',
+    snippet: '{"User-Agent":"claude-cli/<VERSION>","x-app":"cli"}',
+  },
+  {
+    client: 'Codex CLI',
+    snippet: '{"User-Agent":"codex-cli/<VERSION>","originator":"codex_cli_rs"}',
+  },
+  {
+    client: 'Gemini CLI',
+    snippet:
+      '{"User-Agent":"GeminiCLI/<VERSION>/<COMMIT> (<OS>; <ARCH>)","X-Goog-Api-Client":"google-genai-sdk/<VERSION> gl-node/<NODE_VERSION>"}',
+  },
+]


### PR DESCRIPTION
## Why

Self-review of #1298 after it merged. Three anti-patterns, all fixed here. **No user-visible behavior change** — insert semantics stay fill-only.

## What was wrong

**1. Two `<FormDescription>`s in one `FormItem` → duplicate DOM id (real a11y defect, shipped in #1298)**

`FormDescription` renders `<p id={formDescriptionId}>`. Two of them emit the same id twice, and the textarea's `aria-describedby` resolves only to the *first* — so the "these are placeholders, replace `<VERSION>`" rule, the one thing a screen-reader user most needs, was invisible to them.

Fixed by rendering the example rules as plain helper text (`<p className='text-muted-foreground text-xs'>`), which is the pattern already used across features (`account-models-panel`, `cooldown-reason-dialog`, `onboarding-checklist`).

Measured after the fix, whole sheet: `Custom headers => TEXTAREA#…-form-item`, **duplicate DOM ids = none**.

**2. `react(only-export-components)` violation → Fast Refresh broken**

The examples constant was exported from the component file alongside the component. `oxlint` reports this as an **error**, not a warning. Data moved down to `features/sites/lib/custom-headers-examples.ts` — same layer and style as the existing `lib/endpoints.ts`.

**3. Dishonest `onChange` contract**

Props declared `onChange: (value: string) => void` but forwarded it straight into `<Textarea onChange>`, which delivers a `ChangeEvent`. It only worked because RHF's `field.onChange` happens to be permissive — `tsgo` correctly rejected it. The component now owns the event→value adaptation, matching `EndpointsEditor`.

## Also

`site-form-sheet.tsx` **992 → 918 lines**. It was the largest feature component in the repo; the call site now reads like the `EndpointsEditor` wiring already in the same file. This extraction follows that existing precedent rather than inventing a new one.

New gate: `FormControl`'s cloned `id` / `aria-describedby` / `aria-invalid` **must** reach the textarea. That is the trap `EndpointsEditor` has already fallen into — see below.

## Tests re-layered (1666 → 1672), one owner per invariant

| File | Owns |
|---|---|
| `features/sites/__tests__/custom-headers-examples.test.ts` | pure data contract: valid JSON object · only site-injectable headers · must keep a `<PLACEHOLDER>` · must never bake in a version |
| `components/__tests__/custom-headers-field.test.tsx` | controlled-component behavior + FormControl prop forwarding |
| `components/__tests__/site-form-sheet.test.tsx` | only what needs the real sheet: label association through `FormControl`, and an edited site's stored headers staying locked |

Each new guard was proven able to fail: re-introducing a second `FormDescription` → 1 test red; swallowing `{...props}` → **3 tests red** (both sheet-level ones included). Restored byte-exact after each.

## Pre-existing defect found, deliberately NOT fixed here

The same probe shows `API endpoints => NULL`: `EndpointsEditor` does not forward `FormControl`'s `id`, so its `<FormLabel htmlFor>` points at nothing and the field has no accessible name. That predates this PR and belongs in its own change with its own tests — filed separately rather than widening this diff.

## Local gates

`bun run test` **257 files / 1672 tests** green · lint **0 errors** (boundaries: 683 files, 0 cross-layer edges) · format:check · knip · `bun run build` (7976.2 kB, snippet + both locales confirmed in the emitted bundle) · scoped `tsgo` over every changed file **RC=0**.

Whole-project `tsgo -b` still cannot run on this 2 CPU / 4 GiB host (OOM `SIGKILL`, dmesg-evidenced) and is left to CI, as in #1298. Go inputs are byte-identical to `master` (`git diff --name-only master -- '*.go' go.mod go.sum` → 0), so the previously recorded full `-race` result (44 ok / 0 FAIL / 0 DATA RACE) applies within scope.
