### PR TITLE
fix(platform): link site notices to the upstream site, not /api/notice

### DIFF
--- a/platform/donehub.go
+++ b/platform/donehub.go
@@ -71,12 +71,12 @@ func (d *DoneHubAdapter) GetSiteAnnouncements(ctx context.Context, baseURL, acce
 		return []SiteAnnouncement{}, nil
 	}
 
+	// SourceURL stays empty; see NewApiAdapter.GetSiteAnnouncements (#1297).
 	return []SiteAnnouncement{{
 		SourceKey:  buildNoticeSourceKey(content),
 		Title:      "Site notice",
 		Content:    content,
 		Level:      "info",
-		SourceURL:  "/api/notice",
 		RawPayload: nil,
 	}}, nil
 }

--- a/platform/donehub_test.go
+++ b/platform/donehub_test.go
@@ -218,6 +218,12 @@ func TestDoneHubAdapter_GetSiteAnnouncementsEnvelope(t *testing.T) {
 			if len(anns) != 1 || anns[0].Content != tt.wantContent {
 				t.Fatalf("announcements = %#v, want one with content %q", anns, tt.wantContent)
 			}
+			// #1297: the scrape endpoint (/api/notice) must not leak out as the
+			// user-facing source URL; an empty source URL resolves to the
+			// trusted site home in the web UI instead of a raw JSON payload.
+			if anns[0].SourceURL != "" {
+				t.Fatalf("SourceURL = %q, want empty", anns[0].SourceURL)
+			}
 		})
 	}
 }

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -1083,12 +1083,16 @@ func (n *NewApiAdapter) GetSiteAnnouncements(ctx context.Context, baseURL, acces
 		return []SiteAnnouncement{}, nil
 	}
 
+	// SourceURL stays empty on purpose. The notice is scraped from the machine
+	// endpoint /api/notice, which serves raw JSON rather than a page a person
+	// can read; emitting it as the source made the web UI's "open upstream"
+	// link land on a JSON payload (#1297). An empty source URL resolves to the
+	// trusted site home, matching the other adapters (e.g. sub2api).
 	return []SiteAnnouncement{{
 		SourceKey: fmt.Sprintf("notice:%x", sha1.Sum([]byte(content))),
 		Title:     "Site notice",
 		Content:   content,
 		Level:     "info",
-		SourceURL: "/api/notice",
 	}}, nil
 }
 

--- a/platform/newapi_test.go
+++ b/platform/newapi_test.go
@@ -282,6 +282,12 @@ func TestNewApiAdapter_GetSiteAnnouncementsEnvelope(t *testing.T) {
 			if len(anns) != 1 || anns[0].Content != tt.wantContent {
 				t.Fatalf("announcements = %#v, want one with content %q", anns, tt.wantContent)
 			}
+			// #1297: the scrape endpoint (/api/notice) must not leak out as the
+			// user-facing source URL; an empty source URL resolves to the
+			// trusted site home in the web UI instead of a raw JSON payload.
+			if anns[0].SourceURL != "" {
+				t.Fatalf("SourceURL = %q, want empty", anns[0].SourceURL)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What

`GetSiteAnnouncements` for the **NewAPI** and **DoneHub** adapters set `SourceURL` to the scrape endpoint `"/api/notice"`. The web UI's `resolveAnnouncementSourceURL` resolves that relative path against the site origin, so the "open upstream" link landed on a **raw JSON payload** (`https://<site>/api/notice`) instead of the actual website.

Fix: leave `SourceURL` empty. An empty source URL resolves to the **trusted site home**, which is what the "open upstream" affordance is for. This also aligns NewAPI/DoneHub with the `sub2api` adapter, which already leaves it empty.

## Why root-cause, not a band-aid

The frontend resolver is correct and intentionally conservative (same-origin-or-home, rejects hostile/cross-origin values). The defect is the backend emitting a *machine scrape endpoint* as a *user-facing source URL* — a category error. Fixing it at the source keeps the resolver's trust model intact and matches the other adapters.

## Scope

- Backend-only: `platform/newapi.go`, `platform/donehub.go` (2 lines removed + explanatory comments).
- No contract change: `sourceUrl` is `omitempty` / `string | null` end-to-end; the resolver already handles empty → site home. No frontend or `docs/api` changes.

## Tests

- Added an assertion to both `GetSiteAnnouncements` envelope tests: a valid notice must carry an **empty** `SourceURL`.
- **Gate proven to gate**: re-adding `SourceURL: "/api/notice"` to `newapi.go` turns the test red (`SourceURL = "/api/notice", want empty`); restored byte-identically (`sha256sum -c` OK) and green again.
- Local: `go build ./cmd/server` ✓ · `go vet ./...` ✓ · `go test ./... -count=1 -race -p 1` ✓ (44 ok / 0 FAIL / 0 DATA RACE). leak-guard `master..HEAD` RC=0.

Closes #1297