### PR TITLE
fix(web): give composite form controls an accessible group name (#1300)

### DIFF
--- a/web/scripts/check-form-control.mjs
+++ b/web/scripts/check-form-control.mjs
@@ -48,28 +48,14 @@ const REFERENCE_IMPL = 'src/features/sites/components/custom-headers-field.tsx'
 // the entry as soon as the component is fixed — a stale entry fails the gate.
 const EXCEPTIONS = [
   {
-    component: 'EndpointsEditor',
-    reason:
-      'composite endpoint-row editor; label association empirically broken (queryByLabelText -> null). Fix pattern in #1300.',
-  },
-
-  {
-    component: 'ScheduleEditor',
-    reason:
-      'composite schedule editor, 4 call sites (scheduling-section x3, import-export-section); same mechanism, not individually probed. #1300.',
-  },
-  {
     component: 'ModelPolicyEditor',
-    reason: 'composite policy editor in key-sheet-form; same mechanism. #1300.',
-  },
-  {
-    component: 'SiteScopePicker',
-    reason: 'composite scope picker in key-sheet-form; same mechanism. #1300.',
+    reason:
+      'composite policy editor in key-sheet-form. Not a plain drop: it spreads the FormControl-injected id onto its inner add-rule <Input> (...inputProps), so the field-level id names a sub-control instead of the group. Fix = label the group root (role=group + aria-labelledby) AND give the inner Input its own aria-label, i.e. separate the field label from the sub-control label. A redesign, not a forward. #1300.',
   },
   {
     component: 'CredentialRefPicker',
     reason:
-      'composite credential picker, 2 call sites in key-sheet-form; same mechanism. #1300.',
+      'composite credential tree-picker, 2 call sites in key-sheet-form. Takes the whole props object but never spreads it, and renders three root states (loading / error / list) that each need role=group + aria-labelledby. Needs an async-query test harness. #1300.',
   },
 ]
 

--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -180,6 +180,19 @@ function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
   )
 }
 
+/**
+ * The id `FormLabel` renders, derived from the same `formItemId` that
+ * `FormControl` injects onto its single child. A native control is named by the
+ * `<label htmlFor>`; a *composite* control (a group of inputs with no single
+ * labelable element) instead forwards that injected id onto its `role="group"`
+ * root and points `aria-labelledby` here, so the group gets an accessible name
+ * without reaching back into form context. One owner for the `-label` suffix
+ * convention shared by FormLabel and the composite fields (#1300).
+ */
+function formLabelIdFor(formItemId: string): string {
+  return `${formItemId}-label`
+}
+
 function FormLabel({
   className,
   ...props
@@ -188,6 +201,7 @@ function FormLabel({
 
   return (
     <Label
+      id={formLabelIdFor(formItemId)}
       data-slot='form-label'
       data-error={!!error}
       className={cn('data-[error=true]:text-destructive', className)}
@@ -269,4 +283,5 @@ export {
   FormDescription,
   FormMessage,
   FormField,
+  formLabelIdFor,
 }

--- a/web/src/features/settings/components/__tests__/schedule-editor-a11y.test.tsx
+++ b/web/src/features/settings/components/__tests__/schedule-editor-a11y.test.tsx
@@ -1,0 +1,51 @@
+// Focused a11y test for ScheduleEditor's FormControl prop forwarding (#1300).
+// ScheduleEditor is a composite — a group of selects/inputs with no single
+// labelable element — so it must forward the FormControl-injected
+// id / aria-describedby / aria-invalid onto a role="group" root and name that
+// group via aria-labelledby -> the FormLabel id (`formLabelIdFor`).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ScheduleEditor } from '../schedule-editor'
+
+beforeAll(() => {
+  // base-ui Select needs matchMedia under jsdom.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+afterEach(() => cleanup())
+
+describe('ScheduleEditor accessible name (#1300)', () => {
+  it('forwards the injected id onto a role=group named by the label', () => {
+    render(
+      <ScheduleEditor
+        value={undefined}
+        onChange={vi.fn()}
+        id='fld-1'
+        aria-describedby='desc-1'
+        aria-invalid={false}
+      />
+    )
+    const group = screen.getByRole('group')
+    expect(group).toHaveAttribute('id', 'fld-1')
+    expect(group).toHaveAttribute('aria-describedby', 'desc-1')
+    expect(group).toHaveAttribute('aria-invalid', 'false')
+    // formLabelIdFor('fld-1') === 'fld-1-label' — the id FormLabel renders.
+    expect(group).toHaveAttribute('aria-labelledby', 'fld-1-label')
+  })
+})

--- a/web/src/features/settings/components/schedule-editor.tsx
+++ b/web/src/features/settings/components/schedule-editor.tsx
@@ -6,8 +6,10 @@
 // mode. `window` has no deterministic cron and is only offered when
 // `allowWindow` is set.
 
+import type { ComponentProps } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { formLabelIdFor } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -28,13 +30,14 @@ type ScheduleEditorProps = {
   /** Offer the random-in-window option (checkin only). */
   allowWindow?: boolean
   disabled?: boolean
-}
+} & Omit<ComponentProps<'div'>, 'onChange'>
 
 export function ScheduleEditor({
   value,
   onChange,
   allowWindow,
   disabled,
+  ...props
 }: ScheduleEditorProps) {
   const { t } = useTranslation()
   const kind = value?.kind ?? 'daily'
@@ -79,8 +82,16 @@ export function ScheduleEditor({
     })
   }
 
+  // Composite control: a group of schedule inputs with no single labelable
+  // element. Forward the FormControl-injected id / aria-* onto the root and name
+  // the group via the FormLabel id (#1300).
   return (
-    <div className='space-y-2'>
+    <div
+      className='space-y-2'
+      role='group'
+      aria-labelledby={props.id ? formLabelIdFor(props.id) : undefined}
+      {...props}
+    >
       <div className='flex flex-wrap items-center gap-2'>
         <Select
           value={kind}

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section-site-scope.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section-site-scope.test.tsx
@@ -199,3 +199,24 @@ describe('downstream key site restriction (#1026)', () => {
     expect(payload.allowedSiteIds).toEqual([])
   })
 })
+
+describe('site scope picker accessible name (#1300)', () => {
+  it('names the site-scope group through its label', async () => {
+    renderKeySheetForm(null)
+    await waitFor(() => {
+      expect(screen.getByTestId('site-scope-picker')).toBeInTheDocument()
+    })
+    const group = screen.getByTestId('site-scope-picker')
+    expect(group).toHaveAttribute('role', 'group')
+    const labelId = group.getAttribute('aria-labelledby')
+    expect(labelId).toBeTruthy()
+    // Before #1300 SiteScopePicker dropped the FormControl id entirely, so the
+    // field had no accessible name. The group must now be named by a real,
+    // non-empty label element.
+    const label = labelId ? document.getElementById(labelId) : null
+    // The aria-labelledby target must actually exist (FormLabel renders it) and
+    // carry text, or the group is named by nothing.
+    expect(label).not.toBeNull()
+    expect(label?.textContent?.trim()).not.toBe('')
+  })
+})

--- a/web/src/features/settings/sections/downstream/components/key-sheet-form.tsx
+++ b/web/src/features/settings/sections/downstream/components/key-sheet-form.tsx
@@ -20,6 +20,7 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  formLabelIdFor,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import {
@@ -224,17 +225,28 @@ type SiteScopePickerProps = {
   value: number[]
   onChange: (siteIds: number[]) => void
   sites: Array<{ id: number; name: string }>
-}
+} & Omit<ComponentProps<'div'>, 'onChange'>
 
 // Checkbox list over the upstream sites: empty selection means "no site
 // restriction" (the routing selector treats an empty allow-list as
 // unrestricted), mirroring the model-policy empty-means-deny contrast.
-function SiteScopePicker({ value, onChange, sites }: SiteScopePickerProps) {
+function SiteScopePicker({
+  value,
+  onChange,
+  sites,
+  ...props
+}: SiteScopePickerProps) {
   const selected = new Set(value)
+  // Composite control: a checkbox list with no single labelable element.
+  // Forward the FormControl-injected id / aria-* onto the root and name the
+  // group via the FormLabel id (#1300).
   return (
     <div
       className='border-border max-h-40 space-y-1 overflow-y-auto rounded-md border p-2'
       data-testid='site-scope-picker'
+      role='group'
+      aria-labelledby={props.id ? formLabelIdFor(props.id) : undefined}
+      {...props}
     >
       {sites.length === 0
         ? null

--- a/web/src/features/sites/components/__tests__/site-form-sheet-endpoints.test.tsx
+++ b/web/src/features/sites/components/__tests__/site-form-sheet-endpoints.test.tsx
@@ -413,3 +413,17 @@ describe('SiteFormSheet apiEndpoints validation errors', () => {
     expect(statusText2).not.toContain('Fail')
   })
 })
+
+describe('SiteFormSheet apiEndpoints accessible name (#1300)', () => {
+  it('names the endpoint editor group through its label', async () => {
+    await renderCreateDialog()
+    // Before #1300 EndpointsEditor swallowed the FormControl-injected id, so
+    // <FormLabel htmlFor> pointed at a nonexistent element and the field had no
+    // accessible name (queryByLabelText -> null). A role=group is named by
+    // aria-labelledby -> the FormLabel id; an htmlFor cannot name a
+    // non-labelable div, which is why getByRole(name) is the strict check.
+    const group = screen.getByRole('group', { name: 'API endpoints' })
+    expect(group).toHaveAttribute('aria-invalid', 'false')
+    expect(group.getAttribute('aria-describedby')).toBeTruthy()
+  })
+})

--- a/web/src/features/sites/components/endpoints-editor.tsx
+++ b/web/src/features/sites/components/endpoints-editor.tsx
@@ -16,11 +16,12 @@ import {
   ArrowDown as ArrowDownIcon,
   ArrowUp as ArrowUpIcon,
 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ComponentProps } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { formLabelIdFor } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
@@ -49,7 +50,7 @@ type EndpointsEditorProps = {
    * prop may arrive as null — treat it as no live data.
    */
   liveEndpoints?: SiteApiEndpoint[] | null
-}
+} & Omit<ComponentProps<'div'>, 'onChange'>
 
 function nextRowKey(): string {
   return `row-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
@@ -94,6 +95,7 @@ export function EndpointsEditor({
   value,
   onChange,
   liveEndpoints = [],
+  ...props
 }: EndpointsEditorProps) {
   const { t, i18n } = useTranslation()
   const [rows, setRows] = useState<EndpointRow[]>(() => rowsFromText(value))
@@ -150,9 +152,19 @@ export function EndpointsEditor({
     commit([...rows, { key: nextRowKey(), url: '', enabled: true }])
   }
 
+  // Composite control: a group of endpoint rows with no single labelable
+  // element. Forward the FormControl-injected id / aria-describedby /
+  // aria-invalid onto the root and name the group via the FormLabel id (#1300).
+  const labelId = props.id ? formLabelIdFor(props.id) : undefined
+
   if (advanced) {
     return (
-      <div className='space-y-2'>
+      <div
+        className='space-y-2'
+        role='group'
+        aria-labelledby={labelId}
+        {...props}
+      >
         <Textarea
           aria-label={t('sites.form.apiEndpointsTextareaLabel')}
           rows={6}
@@ -187,7 +199,12 @@ export function EndpointsEditor({
   }
 
   return (
-    <div className='space-y-2'>
+    <div
+      className='space-y-2'
+      role='group'
+      aria-labelledby={labelId}
+      {...props}
+    >
       {parseBlocked ? (
         <div className='bg-destructive/10 text-destructive-soft-fg rounded-md border p-3 text-xs'>
           {t('sites.form.apiEndpointsParseBlocked')}


### PR DESCRIPTION
## What

Fixes the proven instance of #1300 and the two other composite controls that share the exact mechanism.

`<FormControl>` clones its single child with `id` / `aria-describedby` / `aria-invalid`, and `<FormLabel htmlFor>` points at that id. **EndpointsEditor**, **ScheduleEditor** and **SiteScopePicker** dropped those props, so the label pointed at a nonexistent element and the field had **no accessible name** (`queryByLabelText('API endpoints') -> null`). It failed silently: no type error, no runtime error, and the `a11y` CI job stayed green (it scans authenticated routes, not dialog/sheet internals).

## Why a group, not prop-forwarding onto an inner input

A composite has no single labelable element. Forwarding the field id onto an inner input would *mislabel a sub-control* (that is exactly ModelPolicyEditor's bug, left for a follow-up). The correct ARIA shape is a **group**:

- `ui/form.tsx`: `FormLabel` now renders `id={formLabelIdFor(formItemId)}` — one owner for the `-label` suffix convention (new `formLabelIdFor` helper, exported).
- each composite forwards the injected props onto a `role="group"` root named by `aria-labelledby -> formLabelIdFor(id)`. An `htmlFor` cannot name a non-labelable `div`, which is why `aria-labelledby` is the real fix.

## Scope

- Frontend-only (8 files). `form.tsx` change is **additive** (a label id) — verified across the full suite that every existing form is unaffected.
- **Deferred (still registered gate exceptions, reclassified in #1300):** `ModelPolicyEditor` (spreads the field id onto its inner add-rule `<Input>` → needs the group labelled *and* the inner input given its own `aria-label` — a redesign) and `CredentialRefPicker` (async; three root states each need the group treatment + an async-query harness). #1300 stays open for these two.

## Gates (local, 2C/4G)

- `check-form-control` gate: 140 sites classified, **0 unclassified**, exceptions 5 → **2/2 matched** (the three fixed entries deleted; a stale entry fails the gate).
- `tsgo -b tsconfig.app.json --force`: **RC=0** full app typecheck — `tsgo -b` OOM-SIGKILLs at default heap on this box (fresh dmesg `anon-rss:1232696kB`), so run under `GOMEMLIMIT=1100MiB GOMAXPROCS=1`; **proved real** by injecting `const n: number = "<string>"` → `TS2322`, then restoring.
- `vitest run`: **258 files / 1675 tests** pass (baseline 257/1672 → +1 file, +3 tests, reconciles). `lint` (oxlint+boundaries+gate) / `format:check` / `knip` / `routes:verify` all RC=0.
- **Mutation-proven red, then `sha256sum -c` byte-identical restore:** (1) remove the `FormLabel` id → EndpointsEditor `getByRole('group',{name:'API endpoints'})` and SiteScopePicker label-exists both fail (`Unable to find ... role "group" and name "API endpoints"`); (2) remove `role='group'` from ScheduleEditor → its test fails.
- leak-guard `master..HEAD` RC=0.

## Tests added

- EndpointsEditor: `getByRole('group', { name: 'API endpoints' })` resolves in the real sheet (was null).
- SiteScopePicker: the group's `aria-labelledby` target exists and is non-empty.
- ScheduleEditor: forwards id/aria-describedby/aria-invalid onto a `role=group` named via `formLabelIdFor`.

Progress on #1300 (3 of 5 composites + the shared `formLabelIdFor` infra); does not close it.