### PR TITLE
fix(web): finish composite-control accessible names (#1300)

### DIFF
--- a/web/scripts/check-form-control.mjs
+++ b/web/scripts/check-form-control.mjs
@@ -41,23 +41,13 @@ const ISSUE = 'https://github.com/DeliciousBuding/metapi-go/issues/1300'
 const REFERENCE_IMPL = 'src/features/sites/components/custom-headers-field.tsx'
 
 // --- exceptions registry -----------------------------------------------------
-// Composites that currently swallow FormControl's injected props. Each needs a
-// design decision rather than a mechanical fix: a group of controls has no
-// single labelable element, so the correct remedy is role="group" +
-// aria-labelledby, not forwarding one id onto an arbitrary inner input. Delete
-// the entry as soon as the component is fixed — a stale entry fails the gate.
-const EXCEPTIONS = [
-  {
-    component: 'ModelPolicyEditor',
-    reason:
-      'composite policy editor in key-sheet-form. Not a plain drop: it spreads the FormControl-injected id onto its inner add-rule <Input> (...inputProps), so the field-level id names a sub-control instead of the group. Fix = label the group root (role=group + aria-labelledby) AND give the inner Input its own aria-label, i.e. separate the field label from the sub-control label. A redesign, not a forward. #1300.',
-  },
-  {
-    component: 'CredentialRefPicker',
-    reason:
-      'composite credential tree-picker, 2 call sites in key-sheet-form. Takes the whole props object but never spreads it, and renders three root states (loading / error / list) that each need role=group + aria-labelledby. Needs an async-query test harness. #1300.',
-  },
-]
+// Empty as of #1300: every composite FormControl child now forwards the
+// injected id / aria-describedby / aria-invalid onto a role="group" root named
+// by aria-labelledby -> the FormLabel id (`formLabelIdFor`), instead of
+// dropping them or mis-routing them onto an inner sub-control. Re-add an entry
+// ONLY for a genuinely-deferred composite, with a reason and an issue link — a
+// stale entry fails the gate, so this registry cannot rot.
+const EXCEPTIONS = []
 
 // `<FormControl>` and its child may be separated by whitespace and JSX comments.
 const RAW_RES = /<FormControl>/g

--- a/web/src/features/settings/sections/downstream/components/__tests__/credential-ref-picker.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/credential-ref-picker.test.tsx
@@ -147,3 +147,36 @@ describe('CredentialRefPicker', () => {
     ).toHaveAttribute('type', 'checkbox')
   })
 })
+
+describe('CredentialRefPicker accessible name (#1300)', () => {
+  it('forwards the injected id onto a role=group named by the label', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0 } },
+    })
+    render(
+      (
+        <QueryClientProvider client={queryClient}>
+          <CredentialRefPicker
+            value={[]}
+            onChange={vi.fn()}
+            id='cred-1'
+            aria-describedby='desc-1'
+            aria-invalid={false}
+          />
+        </QueryClientProvider>
+      ) as ReactElement
+    )
+
+    // Resolved (list) root: the site expander only renders once the async
+    // site/account/token queries settle (all three roots carry the group role).
+    await screen.findByRole('button', { name: 'Toggle accounts of Alpha' })
+
+    const group = screen.getByTestId('credential-ref-picker')
+    expect(group).toHaveAttribute('role', 'group')
+    expect(group).toHaveAttribute('id', 'cred-1')
+    expect(group).toHaveAttribute('aria-describedby', 'desc-1')
+    expect(group).toHaveAttribute('aria-invalid', 'false')
+    // formLabelIdFor('cred-1') === 'cred-1-label' — the id FormLabel renders.
+    expect(group).toHaveAttribute('aria-labelledby', 'cred-1-label')
+  })
+})

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
@@ -391,7 +391,9 @@ describe('KeySheetForm — create mode', () => {
       target: { value: 'sk-pattern-key' },
     })
 
-    const modelRuleInput = screen.getByLabelText('Model access')
+    // #1300: the field id now names the group, not this sub-control. The
+    // add-rule input carries its own aria-label ("Model rule").
+    const modelRuleInput = screen.getByLabelText('Model rule')
     fireEvent.change(modelRuleInput, { target: { value: 'gpt-5.5' } })
     fireEvent.click(screen.getByRole('option', { name: '+ gpt-5.5' }))
 
@@ -640,5 +642,25 @@ describe('KeyModelPolicyCell — fail-closed summaries', () => {
     expect(screen.getByText('All models')).toBeInTheDocument()
     expect(screen.getByText('2 rules')).toBeInTheDocument()
     expect(screen.getByText('2 route grants')).toBeInTheDocument()
+  })
+})
+
+describe('ModelPolicyEditor accessible name (#1300)', () => {
+  it('names the group via its label and gives the add-rule input its own name', () => {
+    renderKeySheetForm({ editingKey: null })
+
+    // The field is a group named "Model access". Before #1300 the FormControl id
+    // was spread onto the inner add-rule <Input>, so the field-level name landed
+    // on a sub-control and the group itself had none.
+    const group = screen.getByRole('group', { name: 'Model access' })
+    expect(group).toHaveAttribute('aria-invalid', 'false')
+
+    // The add-rule input is a sub-control with its OWN accessible name and must
+    // not carry the field-level id (that id belongs to the group).
+    const input = screen.getByLabelText('Model rule')
+    expect(group).toContainElement(input)
+    const groupId = group.getAttribute('id')
+    expect(groupId).toBeTruthy()
+    expect(input).not.toHaveAttribute('id', groupId ?? '')
   })
 })

--- a/web/src/features/settings/sections/downstream/components/credential-ref-picker.tsx
+++ b/web/src/features/settings/sections/downstream/components/credential-ref-picker.tsx
@@ -11,11 +11,12 @@
 // fleets.
 
 import { ChevronRight, X } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ComponentProps } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { formLabelIdFor } from '@/components/ui/form'
 import { Spinner } from '@/components/ui/spinner'
 import {
   useAccounts,
@@ -36,7 +37,7 @@ import {
 type CredentialRefPickerProps = {
   value: CredentialRef[]
   onChange: (refs: CredentialRef[]) => void
-}
+} & Omit<ComponentProps<'div'>, 'onChange'>
 
 /** Machine-readable description for refs whose upstream object is gone. */
 function describeUnresolvedRef(ref: CredentialRef): string {
@@ -46,15 +47,23 @@ function describeUnresolvedRef(ref: CredentialRef): string {
     : base
 }
 
-export function CredentialRefPicker(props: CredentialRefPickerProps) {
+export function CredentialRefPicker({
+  value,
+  onChange,
+  ...props
+}: CredentialRefPickerProps) {
   const { t } = useTranslation()
+  // Composite control with three root states (loading / error / list); each is a
+  // group named via aria-labelledby -> the FormLabel id, and each forwards the
+  // FormControl-injected id / aria-describedby / aria-invalid (#1300).
+  const labelId = props.id ? formLabelIdFor(props.id) : undefined
   const sitesQuery = useSites()
   const accountsQuery = useAccounts()
   const tokensQuery = useAllAccountTokens()
 
   const selectedKeys = useMemo(
-    () => new Set(props.value.map(credentialRefKey)),
-    [props.value]
+    () => new Set(value.map(credentialRefKey)),
+    [value]
   )
 
   // Sites (and token lists) holding a selection start expanded so edit mode
@@ -62,14 +71,14 @@ export function CredentialRefPicker(props: CredentialRefPickerProps) {
   // remounts per sheet open, so a stale expansion set never leaks across
   // keys.
   const [expandedSiteIds, setExpandedSiteIds] = useState<Set<number>>(
-    () => new Set(props.value.map((ref) => ref.siteId))
+    () => new Set(value.map((ref) => ref.siteId))
   )
   const [expandedTokenAccounts, setExpandedTokenAccounts] = useState<
     Set<number>
   >(
     () =>
       new Set(
-        props.value
+        value
           .filter((ref) => ref.kind === 'account_token')
           .map((ref) => ref.accountId)
       )
@@ -127,9 +136,9 @@ export function CredentialRefPicker(props: CredentialRefPickerProps) {
 
   function toggleRef(ref: CredentialRef, checked: boolean) {
     const key = credentialRefKey(ref)
-    const next = props.value.filter((item) => credentialRefKey(item) !== key)
+    const next = value.filter((item) => credentialRefKey(item) !== key)
     if (checked) next.push(ref)
-    props.onChange(serializeCredentialRefs(next))
+    onChange(serializeCredentialRefs(next))
   }
 
   if (
@@ -141,6 +150,9 @@ export function CredentialRefPicker(props: CredentialRefPickerProps) {
       <div
         data-testid='credential-ref-picker'
         className='text-muted-foreground flex items-center gap-2 rounded-md border p-3 text-sm'
+        role='group'
+        aria-labelledby={labelId}
+        {...props}
       >
         <Spinner />
         {t('settings.downstream.keys.credentials.loading')}
@@ -153,6 +165,9 @@ export function CredentialRefPicker(props: CredentialRefPickerProps) {
       <div
         data-testid='credential-ref-picker'
         className='text-destructive rounded-md border p-3 text-xs'
+        role='group'
+        aria-labelledby={labelId}
+        {...props}
       >
         {t('settings.downstream.keys.credentials.loadFailed')}
       </div>
@@ -170,7 +185,7 @@ export function CredentialRefPicker(props: CredentialRefPickerProps) {
   const knownTokenIds = new Set(
     (tokensQuery.data ?? []).map((token) => token.id)
   )
-  const unresolvedRefs = props.value.filter((ref) => {
+  const unresolvedRefs = value.filter((ref) => {
     if (!knownSiteIds.has(ref.siteId)) return true
     if (!knownAccountIds.has(ref.accountId)) return true
     return ref.kind === 'account_token' && !knownTokenIds.has(ref.tokenId)
@@ -265,9 +280,7 @@ export function CredentialRefPicker(props: CredentialRefPickerProps) {
   function renderSite(site: Site) {
     const siteAccounts = accountsBySite.get(site.id) ?? []
     const expanded = expandedSiteIds.has(site.id)
-    const selectedCount = props.value.filter(
-      (ref) => ref.siteId === site.id
-    ).length
+    const selectedCount = value.filter((ref) => ref.siteId === site.id).length
 
     return (
       <div key={site.id} className='border-border border-b last:border-b-0'>
@@ -315,6 +328,9 @@ export function CredentialRefPicker(props: CredentialRefPickerProps) {
     <div
       data-testid='credential-ref-picker'
       className='border-border max-h-56 overflow-y-auto rounded-md border'
+      role='group'
+      aria-labelledby={labelId}
+      {...props}
     >
       {sites.length === 0 ? (
         <p className='text-muted-foreground p-2 text-xs'>

--- a/web/src/features/settings/sections/downstream/components/key-sheet-form.tsx
+++ b/web/src/features/settings/sections/downstream/components/key-sheet-form.tsx
@@ -58,19 +58,21 @@ type ModelPolicyEditorProps = {
   onChange: (rules: string[]) => void
   candidateModels?: string[]
   routeGrantCount?: number
-} & Omit<
-  ComponentProps<typeof Input>,
-  'value' | 'defaultValue' | 'onChange' | 'onKeyDown'
->
+} & Omit<ComponentProps<'div'>, 'onChange'>
 
 function ModelPolicyEditor({
   value,
   onChange,
   candidateModels = [],
   routeGrantCount = 0,
-  ...inputProps
+  ...props
 }: ModelPolicyEditorProps) {
   const { t } = useTranslation()
+  // Composite control: the field is a group (summary + rules + add-rule input +
+  // suggestions). The FormControl-injected id / aria-* belong on the group root,
+  // named via aria-labelledby -> the FormLabel id; the inner add-rule <Input> is
+  // a sub-control and gets its OWN aria-label, never the field-level id (#1300).
+  const labelId = props.id ? formLabelIdFor(props.id) : undefined
   const [pendingRule, setPendingRule] = useState('')
   const rules = normalizeModelRules(value)
   const normalizedPendingRule = pendingRule.trim()
@@ -118,7 +120,12 @@ function ModelPolicyEditor({
   }
 
   return (
-    <div className='space-y-2'>
+    <div
+      className='space-y-2'
+      role='group'
+      aria-labelledby={labelId}
+      {...props}
+    >
       <div className='flex flex-wrap items-center gap-2'>
         <Badge variant={summaryVariant} data-testid='model-policy-form-summary'>
           {summary}
@@ -168,7 +175,9 @@ function ModelPolicyEditor({
 
       <div className='flex gap-2'>
         <Input
-          {...inputProps}
+          aria-label={t('settings.downstream.keys.models.inputAria', {
+            defaultValue: 'Model rule',
+          })}
           value={pendingRule}
           onChange={(event) => setPendingRule(event.target.value)}
           onKeyDown={(event) => {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1376,6 +1376,7 @@
             "fieldLabel": "Model access",
             "hint": "Empty denies all. Add exact names, glob patterns (*), or re: regex rules. All models requires an explicit *.",
             "inputPlaceholder": "gpt-4o, gpt-*, or re:^claude-",
+            "inputAria": "Model rule",
             "suggestions": "Matching models",
             "allowAll": "Allow all",
             "denyAll": "Deny all",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1376,6 +1376,7 @@
             "fieldLabel": "模型授权",
             "hint": "留空即拒绝所有模型。可添加精确名称、通配符（*）或 re: 正则规则；授权全部模型需显式添加 *。",
             "inputPlaceholder": "gpt-4o、gpt-* 或 re:^claude-",
+            "inputAria": "模型规则",
             "suggestions": "匹配的模型",
             "allowAll": "全部允许",
             "denyAll": "全部拒绝",


### PR DESCRIPTION
Completes #1300. #1303 fixed three composite `FormControl` children; this finishes the last two and empties the gate's exception registry.

## ModelPolicyEditor (redesign, not a forward)

It spread the `FormControl`-injected id onto its inner add-rule `<Input>` (`...inputProps`), so the field-level name **"Model access"** landed on a *sub-control* and the group itself had none. Now:
- the injected `id` / `aria-describedby` / `aria-invalid` go on the `role="group"` root, named by `aria-labelledby -> formLabelIdFor(id)`;
- the add-rule `<Input>` gets its **own** `aria-label` (new bilingual key `settings.downstream.keys.models.inputAria` = "Model rule" / "模型规则").
- The existing `keys-section` test that typed into `getByLabelText('Model access')` was relying on the mislabeled sub-control — retargeted to `'Model rule'`.

## CredentialRefPicker

Took the whole `props` object but never spread it, and renders **three** root states (loading / error / list). Each root now forwards the injected props onto a `role="group"` node named via `aria-labelledby`.

## Gate

`check-form-control` registry is now **empty (0 exceptions)**: all 140 `<FormControl>` sites classified, 10 forwarding composites, 0 unclassified. (The gate proved itself mid-change: naming the rest param `groupAttrs` instead of `props` made it fail until renamed.)

## Gates (local, 2C/4G)

- `vitest run`: **258 files / 1677 tests** pass (baseline 1675 + the 2 new a11y tests). `lint` (incl. gate) / `format:check` / `knip` / `routes:verify` RC=0.
- **Mutation-proven red, then `sha256sum -c` byte-identical restore:** (1) re-spread `{...props}` onto ModelPolicyEditor's inner Input → test fails `expect(input).not.toHaveAttribute('id', '<formItemId>')`; (2) drop `{...props}` from CredentialRefPicker's resolved root → test fails `toHaveAttribute('id','cred-1')`.
- **Typecheck honesty:** `tsgo -b tsconfig.app.json --force` **OOM-SIGKILLed three times** on this box (~1 GB RSS, fresh dmesg) even under `GOMEMLIMIT=1100MiB`/`768MiB` — unlike #1303 it would not fit this run. Per the documented 2C/4G exception I did **not** change code for it and did **not** treat it as passed; the type-sensitive changes (`Omit<ComponentProps<'div'>,'onChange'>` intersections, the `props` destructure/rename) were manually reviewed, and **CI `frontend` (full `tsgo -b` on a large runner) is the authoritative typecheck — will not merge until it is green.**
- leak-guard `master..HEAD` RC=0. Pushed `--no-verify` (hook's `tsgo -b` OOMs; frontend-only change so the Go race is N/A).

Closes #1300