### PR TITLE
docs: correct public-doc tone (fix internal/ mischaracterization, drop process jargon)

### DIFF
--- a/docs/internal/design/DESIGN.md
+++ b/docs/internal/design/DESIGN.md
@@ -170,7 +170,7 @@ Every destructive action maps to exactly one tier; never hand-roll a variant:
 
 ### 4.2 Settings page skeleton（设置页骨架）
 
-- 单 h1 在 `SettingsPage` 页头，文案来自 section meta 的 i18n 键；侧栏树是唯一导航面（wave 8 lane C 之后无页内面包屑/侧栏）。
+- 单 h1 在 `SettingsPage` 页头，文案来自 section meta 的 i18n 键；侧栏树是唯一导航面（无页内面包屑或二级侧栏）。
 - `SettingsSectionCard` **无 `actions` 时不渲染 CardHeader**——同一组 title/description i18n 键已在页头渲染，卡头再渲染就是逐字重复。带 header actions（测试/保存/批量按钮）的卡保留卡头（按钮需要宿主），但**单卡 section 传 `hideHeaderCopy`**：页头同题文案已在页面顶层，h2 重复无辨识价值；h2 只保留给多内容页内需区分的卡片。
 - 危险/前置警告信息放卡内正文顶部 banner（`border-warning/40 bg-warning/5` + `TriangleAlert`），不藏在 description 里（参考：数据迁移节的 wipe/重启警告）。
 

--- a/docs/internal/responses-websocket-residual.md
+++ b/docs/internal/responses-websocket-residual.md
@@ -1,4 +1,4 @@
-# Responses WebSocket — C3 residual
+# Responses WebSocket — single-instance residual
 
 **Status**: present (single-instance honesty)
 
@@ -11,7 +11,7 @@ residual Codex upstream `wss` transport:
 - Dial / empty-event failure falls back to the HTTP SSE bridge — no fake
   terminal frames
 - **Process-local sticky only**: the transport is single-instance honest;
-  there is no cluster-wide sticky session claim (no `STICKY-B`). Multi-instance
+  there is no cluster-wide sticky-session claim. Multi-instance
   deployments require load-balancer pinning or a single instance.
 
 Forbidden always: hijack-silent-close and inventing terminal frames for failed

--- a/handler/proxy/responses_ws.go
+++ b/handler/proxy/responses_ws.go
@@ -39,7 +39,7 @@ import (
 // - Codex upstream wss runtime (codex_ws_runtime.go) + session response id store
 // - Capability probe: platform=codex + CodexUpstreamWebsocketEnabled + extraConfig
 // - Dial / empty-event failure → HTTP SSE bridge fallback (no fake terminals)
-// - Process-local sticky only (single-instance honesty; no STICKY-B)
+// - Process-local sticky only (single-instance honest; no cluster-wide sticky-session claim)
 
 // Forbidden always: Hijack-silent-close · invent terminal frames for failed bridges.
 const (

--- a/llms.txt
+++ b/llms.txt
@@ -8,8 +8,9 @@
 
 This repository is docs-as-code: every page below is plain markdown at the
 given raw URL and mirrors the in-repo file. User-facing docs live in `docs/`;
-maintainer process docs live in `docs/internal/` and are intentionally not
-indexed here.
+contributor design notes live in `docs/internal/` and are intentionally not
+indexed here. Maintainer process and history live outside this repository
+(GitHub issues for open work, `CHANGELOG.md` for the version narrative).
 
 ## Start here
 


### PR DESCRIPTION
## What

Public-documentation tone/coherence pass — no behavior change.

- **`llms.txt`** described `docs/internal/` as "maintainer process docs", which contradicted `docs/README.md` (maintainer process/history live **outside** this repo) and the actual content (contributor **design notes**: design system, backend philosophy, frontend layering contract, git workflow). Corrected the description and stated where process docs actually live.
- **`DESIGN.md`**: dropped a `wave 8 lane C` internal process reference — the design fact ("the sidebar tree is the only navigation surface; no in-page breadcrumbs or secondary sidebar") now stands on its own.
- **`responses-websocket-residual.md`** + the matching `responses_ws.go` comment: replaced the opaque `C3 residual` / `STICKY-B` shorthand with plain language. The functional status id `c3_codex_upstream_wss` is unchanged.

## Why

`docs/internal/` is publicly tracked contributor/architecture documentation that the code references as its design SSOT (e.g. `check-boundaries.mjs`, `ResponsesWebsocketResidualDoc`, several `web/src` comments). It is not maintainer process material — the docs should describe it accurately and read cleanly for external contributors.

## Gates

- `go test ./docs -run TestPublicMarkdownHygiene` (the `docs-hygiene` CI check): **ok**
- `go test ./handler/proxy -run 'Responses|Residual'`: **ok**
- `go vet ./handler/proxy`: **RC=0** · `gofmt -l`: clean · leak-guard: **RC=0**
- Full Go race + frontend suites run in CI (changes are doc text + one Go comment).
