### PR TITLE
refactor(web): clean-room icon-badge as metapi-original ui

### DIFF
--- a/web/src/components/ui/icon-badge.tsx
+++ b/web/src/components/ui/icon-badge.tsx
@@ -1,9 +1,11 @@
-// metapi-go/ui — icon badge (soft solid-tone chip for stat cards / headers).
+// metapi-go/ui — IconBadge: a soft solid-tone icon chip for stat cards and
+// section headers.
 //
-// Conceptually borrowed from newapi's icon-badge (quantumnous, AGPL) and
-// trimmed to the metapi-go semantic tokens. Solid soft fills only —
-// DESIGN.md §1 forbids gradients. Tones map 1:1 onto the OKLCH status tokens
-// declared in styles/theme.css, so every tone stays theme- and preset-aware.
+// Tones map 1:1 onto the OKLCH status tokens declared in styles/theme.css
+// (DESIGN.md §2.4 status semantics), so every tone stays theme- and
+// preset-aware. Solid soft fills only — DESIGN.md §1 forbids gradients. The
+// icon is decorative by default (aria-hidden); the surrounding label carries
+// the meaning.
 
 import { cva, type VariantProps } from 'class-variance-authority'
 import type { ReactNode } from 'react'
@@ -47,16 +49,19 @@ type IconBadgeProps = {
   decorative?: boolean
 }
 
-export function IconBadge(props: IconBadgeProps) {
+export function IconBadge({
+  children,
+  tone,
+  size,
+  className,
+  decorative = true,
+}: IconBadgeProps) {
   return (
     <span
-      className={cn(
-        iconBadgeVariants({ tone: props.tone, size: props.size }),
-        props.className
-      )}
-      aria-hidden={props.decorative ?? true}
+      className={cn(iconBadgeVariants({ tone, size }), className)}
+      aria-hidden={decorative}
     >
-      {props.children}
+      {children}
     </span>
   )
 }


### PR DESCRIPTION
## What

First **genuine rewrite** of the ui provenance work (vs. batches 1–4b, which re-attributed shadcn-derived primitives or rewrote stack-assembly components). `IconBadge` is a soft solid-tone icon chip whose tones are metapi-go's own OKLCH status tokens (DESIGN.md §2.4); a soft-fill chip is a generic UI pattern, so it is rewritten in the metapi-go house idiom from its spec.

## Appearance / API byte-preserved

- The `cva` tone/size class strings are **identical** (verified by `diff` against the prior file) → no visual change.
- Prop types unchanged (`IconBadgeTone` / `IconBadgeSize` / `IconBadgeProps`).
- `aria-hidden` still defaults to decorative — destructuring `decorative = true` is equivalent to the prior `props.decorative ?? true`.
- Only changes: metapi-original header, destructured params (matching `count-up` / `section-skeleton`), formatting.

## Gates (local, 2C/4G)

- `lint` (oxlint + boundaries + FormControl gate): **RC=0** — 140 sites / 0 exceptions
- `format:check` **RC=0** (727) · `knip` **RC=0** · `routes:verify` **RC=0**
- scoped `vitest` (`src/components/ui` + `src/features/dashboard`, 32 files): pass
- leak-guard `master..HEAD`: **RC=0**
- `visual-regression` + `a11y` + full vitest + `tsgo -b` typecheck run in CI (cva classes identical → no visual change expected).
