### PR TITLE
refactor(web): rewrite the theme providers as metapi-go's own

### DIFF
--- a/web/src/components/theme-customizer.tsx
+++ b/web/src/components/theme-customizer.tsx
@@ -1,9 +1,14 @@
-// metapi-go/components — theme customizer panel
-// (color scheme / preset / font / radius / scale / content-layout).
-// Adapted from newapi's config-drawer (AGPL header stripped): a compact
-// popover for the app header instead of a full sheet. Consumes the
-// ThemeCustomizationProvider axes plus the ThemeProvider color scheme, so the
-// mode can always be returned to "follow system".
+// metapi-go/components — ThemeCustomizer: the appearance popover in the app
+// header (colour scheme / preset / font / radius / scale / content layout).
+//
+// A popover off the header rather than a settings page: these are axes a user
+// tweaks once and forgets, and every tile previews live because the providers
+// write straight to <body> — the swatch, the "Aa" glyph, the corner radius and
+// the font size are the real tokens, not illustrations of them.
+//
+// It owns no appearance state. Colour scheme comes from ThemeProvider, the other
+// four axes plus content layout from ThemeCustomizationProvider, which keeps
+// "follow system" and "reset" reachable from the same control that changes them.
 
 import { Radio as RadioPrimitive } from '@base-ui/react/radio'
 import { Check, Monitor, Moon, Palette, RotateCcw, Sun } from 'lucide-react'

--- a/web/src/context/__tests__/theme-customization-provider.test.tsx
+++ b/web/src/context/__tests__/theme-customization-provider.test.tsx
@@ -1,0 +1,143 @@
+// metapi-go/context — ThemeCustomizationProvider axis contract.
+//
+// Every axis is the same deal: a value validated against an allowlist, read from
+// a year-long cookie on first render, written back on change, mirrored onto one
+// <body> attribute, and forgotten (cookie removed) when it returns to its
+// default. These tests pin that contract per axis, including the two ways an
+// axis legitimately differs — `font` writes the *resolved* face rather than the
+// stored `default`, and `content-layout` always writes, because the stylesheet
+// and the pre-paint bootstrap both address it by value.
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  ThemeCustomizationProvider,
+  useThemeCustomization,
+} from '@/context/theme-customization-provider'
+import { THEME_COOKIE_KEYS } from '@/lib/theme-customization'
+
+function clearCookies() {
+  for (const key of Object.values(THEME_COOKIE_KEYS)) {
+    document.cookie = `${key}=; Max-Age=0; path=/`
+  }
+}
+
+function readCookie(name: string): string | undefined {
+  const [, value] = `; ${document.cookie}`.split(`; ${name}=`)
+  return value?.split(';')[0]
+}
+
+function renderProvider() {
+  return renderHook(() => useThemeCustomization(), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <ThemeCustomizationProvider>{children}</ThemeCustomizationProvider>
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearCookies()
+  for (const attribute of [
+    'data-theme-preset',
+    'data-theme-font',
+    'data-theme-radius',
+    'data-theme-scale',
+    'data-theme-content-layout',
+  ]) {
+    document.body.removeAttribute(attribute)
+  }
+})
+
+afterEach(() => cleanup())
+
+describe('ThemeCustomizationProvider axes', () => {
+  it('mirrors a stored preset onto <body> and drops an unknown one', () => {
+    document.cookie = `${THEME_COOKIE_KEYS.preset}=rose-garden; path=/`
+    const { result, unmount } = renderProvider()
+
+    expect(result.current.customization.preset).toBe('rose-garden')
+    expect(document.body).toHaveAttribute('data-theme-preset', 'rose-garden')
+    unmount()
+
+    // A value outside the allowlist is not a preference, it is corrupt state:
+    // fall back to the default rather than write an attribute CSS cannot match.
+    document.cookie = `${THEME_COOKIE_KEYS.preset}=not-a-preset; path=/`
+    const fallback = renderProvider()
+
+    expect(fallback.result.current.customization.preset).toBe('default')
+    expect(document.body).not.toHaveAttribute('data-theme-preset')
+  })
+
+  it('resolves the stored font preference to the face CSS addresses', () => {
+    const { result } = renderProvider()
+
+    // `default` is a stored preference, not a CSS value: the stylesheet only
+    // knows [data-theme-font='sans'] / 'serif'.
+    expect(result.current.customization.font).toBe('default')
+    expect(document.body).toHaveAttribute('data-theme-font', 'sans')
+
+    act(() => result.current.setFont('serif'))
+    expect(document.body).toHaveAttribute('data-theme-font', 'serif')
+    expect(readCookie(THEME_COOKIE_KEYS.font)).toBe('serif')
+  })
+
+  it('persists a change and forgets the cookie when the axis returns to default', () => {
+    const { result } = renderProvider()
+
+    act(() => result.current.setRadius('lg'))
+    expect(readCookie(THEME_COOKIE_KEYS.radius)).toBe('lg')
+    expect(document.body).toHaveAttribute('data-theme-radius', 'lg')
+
+    act(() => result.current.setRadius('default'))
+    expect(readCookie(THEME_COOKIE_KEYS.radius)).toBeUndefined()
+    expect(document.body).not.toHaveAttribute('data-theme-radius')
+  })
+
+  it('always writes content-layout, including at its default', () => {
+    const { result } = renderProvider()
+
+    expect(document.body).toHaveAttribute('data-theme-content-layout', 'full')
+
+    act(() => result.current.setContentLayout('centered'))
+    expect(document.body).toHaveAttribute(
+      'data-theme-content-layout',
+      'centered'
+    )
+    expect(readCookie(THEME_COOKIE_KEYS.contentLayout)).toBe('centered')
+
+    act(() => result.current.setContentLayout('full'))
+    expect(document.body).toHaveAttribute('data-theme-content-layout', 'full')
+    expect(readCookie(THEME_COOKIE_KEYS.contentLayout)).toBeUndefined()
+  })
+
+  it('resets every axis and clears every cookie at once', () => {
+    const { result } = renderProvider()
+
+    act(() => {
+      result.current.setPreset('ocean-breeze')
+      result.current.setFont('serif')
+      result.current.setRadius('xl')
+      result.current.setScale('lg')
+      result.current.setContentLayout('centered')
+    })
+    expect(result.current.customization).toEqual({
+      preset: 'ocean-breeze',
+      font: 'serif',
+      radius: 'xl',
+      scale: 'lg',
+      contentLayout: 'centered',
+    })
+
+    act(() => result.current.resetCustomization())
+
+    expect(result.current.customization).toEqual(result.current.defaults)
+    for (const key of Object.values(THEME_COOKIE_KEYS)) {
+      expect(readCookie(key), key).toBeUndefined()
+    }
+    expect(document.body).not.toHaveAttribute('data-theme-preset')
+    expect(document.body).toHaveAttribute('data-theme-font', 'sans')
+    expect(document.body).toHaveAttribute('data-theme-content-layout', 'full')
+  })
+})

--- a/web/src/context/theme-customization-provider.tsx
+++ b/web/src/context/theme-customization-provider.tsx
@@ -1,6 +1,19 @@
-// metapi-go/context — theme-customization-provider ported from newapi. AGPL header stripped.
-// 3-axis (preset/radius/scale) + content-layout provider. Mirrors <body> data-* attributes
-// so theme-presets.css can override CSS variables at the right cascade layer.
+// metapi-go/context — ThemeCustomizationProvider: the appearance axes that sit
+// on top of the colour scheme (preset / font / radius / scale) plus the content
+// layout, mirrored onto <body> as data attributes so `styles/theme-presets.css`
+// can override the design tokens at the right point in the cascade.
+//
+// Every axis is the same four things: a value validated against an allowlist,
+// read from a year-long cookie on first render, written back on change, and
+// mirrored onto one <body> attribute. `usePersistedAxis` owns that once, so the
+// provider reads as five declarations plus the one axis that needs something
+// extra — a preset changes `--background`, so `<meta name="theme-color">` has to
+// follow it.
+//
+// Ordering note: `public/theme-init.js` writes the same attributes before React
+// mounts (that is the whole point of cookies over localStorage here), so this
+// provider is *confirming* the pre-paint state, not establishing it. A value the
+// bootstrap does not know is dropped back to the default by the allowlist.
 
 import {
   createContext,
@@ -12,6 +25,7 @@ import {
 } from 'react'
 
 import { getCookie, removeCookie, setCookie } from '@/lib/cookies'
+import { syncThemeColorMeta } from '@/lib/theme-color-meta'
 import {
   CONTENT_LAYOUT_VALUES,
   type ContentLayout,
@@ -31,27 +45,113 @@ import {
 
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365 // 1 year
 
-function readCookie<T extends string>(
-  name: string,
-  allowed: ReadonlySet<T>,
+type Axis<T extends string> = {
+  /** The <body> attribute this axis mirrors onto. */
+  attribute: string
+  /** The cookie the choice persists to. */
+  cookieKey: string
+  default: T
+  values: ReadonlySet<T>
+  /**
+   * Stored preference → what CSS addresses; identity when omitted. Returning
+   * `null` removes the attribute, which is how an axis hands control back to
+   * `theme.css` instead of restating its value from a preset.
+   */
+  toAttribute?: (value: T) => string | null
+}
+
+/**
+ * The three axes `theme-presets.css` overrides: at `default` they write nothing
+ * at all, so the tokens in `theme.css` win rather than a preset restating them.
+ */
+function omitAtDefault(value: string): string | null {
+  return value === 'default' ? null : value
+}
+
+const PRESET_AXIS: Axis<ThemePreset> = {
+  attribute: 'data-theme-preset',
+  cookieKey: THEME_COOKIE_KEYS.preset,
+  default: DEFAULT_THEME_CUSTOMIZATION.preset,
+  values: THEME_PRESET_VALUES,
+  toAttribute: omitAtDefault,
+}
+
+// The font axis has no `default` in CSS: the stylesheet addresses the concrete
+// face, so the preference is resolved on the way out.
+const FONT_AXIS: Axis<ThemeFont> = {
+  attribute: 'data-theme-font',
+  cookieKey: THEME_COOKIE_KEYS.font,
+  default: DEFAULT_THEME_CUSTOMIZATION.font,
+  values: THEME_FONT_VALUES,
+  toAttribute: resolveThemeFont,
+}
+
+const RADIUS_AXIS: Axis<ThemeRadius> = {
+  attribute: 'data-theme-radius',
+  cookieKey: THEME_COOKIE_KEYS.radius,
+  default: DEFAULT_THEME_CUSTOMIZATION.radius,
+  values: THEME_RADIUS_VALUES,
+  toAttribute: omitAtDefault,
+}
+
+const SCALE_AXIS: Axis<ThemeScale> = {
+  attribute: 'data-theme-scale',
+  cookieKey: THEME_COOKIE_KEYS.scale,
+  default: DEFAULT_THEME_CUSTOMIZATION.scale,
+  values: THEME_SCALE_VALUES,
+  toAttribute: omitAtDefault,
+}
+
+// Always written, including `full`: the layout stylesheet and the pre-paint
+// bootstrap both address this attribute by value.
+const CONTENT_LAYOUT_AXIS: Axis<ContentLayout> = {
+  attribute: 'data-theme-content-layout',
+  cookieKey: THEME_COOKIE_KEYS.contentLayout,
+  default: DEFAULT_THEME_CUSTOMIZATION.contentLayout,
+  values: CONTENT_LAYOUT_VALUES,
+}
+
+/** The allowlisted value in `cookieKey`, or `fallback` when absent/unknown. */
+function readAxis<T extends string>(
+  cookieKey: string,
+  values: ReadonlySet<T>,
   fallback: T
 ): T {
-  const value = getCookie(name)
-  return value && allowed.has(value as T) ? (value as T) : fallback
+  const stored = getCookie(cookieKey)
+  return stored && values.has(stored as T) ? (stored as T) : fallback
 }
 
-function applyAttribute(name: string, value: string | null) {
-  if (typeof document === 'undefined') return
-  const body = document.body
-  if (!body) return
-  if (value === null) {
-    body.removeAttribute(name)
-  } else {
-    body.setAttribute(name, value)
-  }
+/**
+ * One persisted appearance axis: cookie-backed state that mirrors itself onto a
+ * <body> attribute, and forgets the cookie when it returns to the default.
+ */
+function usePersistedAxis<T extends string>(
+  axis: Axis<T>
+): [T, (value: T) => void] {
+  const [value, setValue] = useState<T>(() =>
+    readAxis(axis.cookieKey, axis.values, axis.default)
+  )
+
+  useEffect(() => {
+    const written = axis.toAttribute ? axis.toAttribute(value) : value
+
+    if (written === null) document.body.removeAttribute(axis.attribute)
+    else document.body.setAttribute(axis.attribute, written)
+  }, [axis, value])
+
+  const persist = useCallback(
+    (next: T) => {
+      setValue(next)
+      if (next === axis.default) removeCookie(axis.cookieKey)
+      else setCookie(axis.cookieKey, next, COOKIE_MAX_AGE)
+    },
+    [axis]
+  )
+
+  return [value, persist]
 }
 
-type ThemeCustomizationContextType = {
+type ThemeCustomizationContextValue = {
   defaults: ThemeCustomization
   customization: ThemeCustomization
   setPreset: (preset: ThemePreset) => void
@@ -62,9 +162,13 @@ type ThemeCustomizationContextType = {
   resetCustomization: () => void
 }
 
-// Fallback used when a consumer renders outside the provider (e.g. an error
-// route mounted before providers are ready). Permissive to avoid crashing.
-const FALLBACK_CONTEXT: ThemeCustomizationContextType = {
+/**
+ * Seen by a consumer rendered outside a provider (an error boundary mounted
+ * before the provider stack is ready): every axis reads as its default and
+ * writes are ignored, so a stray `useThemeCustomization()` degrades rather than
+ * crashing.
+ */
+const UNMOUNTED: ThemeCustomizationContextValue = {
   defaults: DEFAULT_THEME_CUSTOMIZATION,
   customization: DEFAULT_THEME_CUSTOMIZATION,
   setPreset: () => {},
@@ -76,132 +180,24 @@ const FALLBACK_CONTEXT: ThemeCustomizationContextType = {
 }
 
 const ThemeCustomizationContext =
-  createContext<ThemeCustomizationContextType>(FALLBACK_CONTEXT)
+  createContext<ThemeCustomizationContextValue>(UNMOUNTED)
 
-export function ThemeCustomizationProvider(props: {
+export function ThemeCustomizationProvider({
+  children,
+}: {
   children: React.ReactNode
 }) {
-  const [preset, _setPreset] = useState<ThemePreset>(() =>
-    readCookie<ThemePreset>(
-      THEME_COOKIE_KEYS.preset,
-      THEME_PRESET_VALUES,
-      DEFAULT_THEME_CUSTOMIZATION.preset
-    )
-  )
-  const [font, _setFont] = useState<ThemeFont>(() =>
-    readCookie<ThemeFont>(
-      THEME_COOKIE_KEYS.font,
-      THEME_FONT_VALUES,
-      DEFAULT_THEME_CUSTOMIZATION.font
-    )
-  )
-  const [radius, _setRadius] = useState<ThemeRadius>(() =>
-    readCookie<ThemeRadius>(
-      THEME_COOKIE_KEYS.radius,
-      THEME_RADIUS_VALUES,
-      DEFAULT_THEME_CUSTOMIZATION.radius
-    )
-  )
-  const [scale, _setScale] = useState<ThemeScale>(() =>
-    readCookie<ThemeScale>(
-      THEME_COOKIE_KEYS.scale,
-      THEME_SCALE_VALUES,
-      DEFAULT_THEME_CUSTOMIZATION.scale
-    )
-  )
-  const [contentLayout, _setContentLayout] = useState<ContentLayout>(() =>
-    readCookie<ContentLayout>(
-      THEME_COOKIE_KEYS.contentLayout,
-      CONTENT_LAYOUT_VALUES,
-      DEFAULT_THEME_CUSTOMIZATION.contentLayout
-    )
-  )
+  const [preset, setPreset] = usePersistedAxis(PRESET_AXIS)
+  const [font, setFont] = usePersistedAxis(FONT_AXIS)
+  const [radius, setRadius] = usePersistedAxis(RADIUS_AXIS)
+  const [scale, setScale] = usePersistedAxis(SCALE_AXIS)
+  const [contentLayout, setContentLayout] =
+    usePersistedAxis(CONTENT_LAYOUT_AXIS)
 
+  // A preset redefines --background, so the browser chrome colour has to follow.
   useEffect(() => {
-    applyAttribute(
-      'data-theme-preset',
-      preset === DEFAULT_THEME_CUSTOMIZATION.preset ? null : preset
-    )
+    syncThemeColorMeta()
   }, [preset])
-
-  useEffect(() => {
-    window.requestAnimationFrame(() => {
-      const background = getComputedStyle(document.body)
-        .getPropertyValue('--background')
-        .trim()
-      const themeColor = document.querySelector('meta[name="theme-color"]')
-      if (background) themeColor?.setAttribute('content', background)
-    })
-  }, [preset])
-
-  // Font is resolved before writing the attribute: the persisted preference
-  // may be `default`, but CSS works in terms of the concrete sans/serif choice.
-  useEffect(() => {
-    applyAttribute('data-theme-font', resolveThemeFont(font, preset))
-  }, [font, preset])
-
-  useEffect(() => {
-    applyAttribute(
-      'data-theme-radius',
-      radius === DEFAULT_THEME_CUSTOMIZATION.radius ? null : radius
-    )
-  }, [radius])
-
-  useEffect(() => {
-    applyAttribute(
-      'data-theme-scale',
-      scale === DEFAULT_THEME_CUSTOMIZATION.scale ? null : scale
-    )
-  }, [scale])
-
-  useEffect(() => {
-    applyAttribute('data-theme-content-layout', contentLayout)
-  }, [contentLayout])
-
-  const setPreset = useCallback((value: ThemePreset) => {
-    _setPreset(value)
-    if (value === DEFAULT_THEME_CUSTOMIZATION.preset) {
-      removeCookie(THEME_COOKIE_KEYS.preset)
-    } else {
-      setCookie(THEME_COOKIE_KEYS.preset, value, COOKIE_MAX_AGE)
-    }
-  }, [])
-
-  const setFont = useCallback((value: ThemeFont) => {
-    _setFont(value)
-    if (value === DEFAULT_THEME_CUSTOMIZATION.font) {
-      removeCookie(THEME_COOKIE_KEYS.font)
-    } else {
-      setCookie(THEME_COOKIE_KEYS.font, value, COOKIE_MAX_AGE)
-    }
-  }, [])
-
-  const setRadius = useCallback((value: ThemeRadius) => {
-    _setRadius(value)
-    if (value === DEFAULT_THEME_CUSTOMIZATION.radius) {
-      removeCookie(THEME_COOKIE_KEYS.radius)
-    } else {
-      setCookie(THEME_COOKIE_KEYS.radius, value, COOKIE_MAX_AGE)
-    }
-  }, [])
-
-  const setScale = useCallback((value: ThemeScale) => {
-    _setScale(value)
-    if (value === DEFAULT_THEME_CUSTOMIZATION.scale) {
-      removeCookie(THEME_COOKIE_KEYS.scale)
-    } else {
-      setCookie(THEME_COOKIE_KEYS.scale, value, COOKIE_MAX_AGE)
-    }
-  }, [])
-
-  const setContentLayout = useCallback((value: ContentLayout) => {
-    _setContentLayout(value)
-    if (value === DEFAULT_THEME_CUSTOMIZATION.contentLayout) {
-      removeCookie(THEME_COOKIE_KEYS.contentLayout)
-    } else {
-      setCookie(THEME_COOKIE_KEYS.contentLayout, value, COOKIE_MAX_AGE)
-    }
-  }, [])
 
   const resetCustomization = useCallback(() => {
     setPreset(DEFAULT_THEME_CUSTOMIZATION.preset)
@@ -211,7 +207,7 @@ export function ThemeCustomizationProvider(props: {
     setContentLayout(DEFAULT_THEME_CUSTOMIZATION.contentLayout)
   }, [setPreset, setFont, setRadius, setScale, setContentLayout])
 
-  const value = useMemo<ThemeCustomizationContextType>(
+  const value = useMemo<ThemeCustomizationContextValue>(
     () => ({
       defaults: DEFAULT_THEME_CUSTOMIZATION,
       customization: { preset, font, radius, scale, contentLayout },
@@ -238,13 +234,13 @@ export function ThemeCustomizationProvider(props: {
   )
 
   return (
-    <ThemeCustomizationContext.Provider value={value}>
-      {props.children}
-    </ThemeCustomizationContext.Provider>
+    <ThemeCustomizationContext value={value}>
+      {children}
+    </ThemeCustomizationContext>
   )
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export function useThemeCustomization(): ThemeCustomizationContextType {
+export function useThemeCustomization(): ThemeCustomizationContextValue {
   return useContext(ThemeCustomizationContext)
 }

--- a/web/src/context/theme-provider.tsx
+++ b/web/src/context/theme-provider.tsx
@@ -1,6 +1,19 @@
-// metapi-go/context — theme-provider ported from newapi. AGPL header stripped.
-// Dark mode provider: <html> class switching + cookie persistence + prefers-color-scheme listener.
-// Exports useTheme() — consumed by sonner.tsx and the theme toggle.
+// metapi-go/context — ThemeProvider: the light / dark / system colour scheme.
+//
+// Three jobs, in the order they matter:
+//   1. resolve `system` against `prefers-color-scheme` and keep resolving it —
+//      the media-query listener is what makes "follow system" actually follow;
+//   2. publish the resolved scheme everywhere something reads it: the
+//      `.light` / `.dark` class (Tailwind 4 dark mode is class-based),
+//      `data-theme`, `color-scheme` (native form controls and scrollbars), and
+//      `<meta name="theme-color">` (browser chrome);
+//   3. persist the choice in a year-long cookie, which is what lets
+//      `public/bootstrap.js` paint the right background before the bundle loads.
+//
+// On mount it also strips the bootstrap's inline background from `<html>`: that
+// inline style exists only to win the first paint, and leaving it in place makes
+// overscroll reveal the pre-mount colour instead of the themed body background
+// (which propagates to the canvas).
 
 import {
   createContext,
@@ -12,17 +25,18 @@ import {
 } from 'react'
 
 import { getCookie, removeCookie, setCookie } from '@/lib/cookies'
+import { syncThemeColorMeta } from '@/lib/theme-color-meta'
 
 export type Theme = 'dark' | 'light' | 'system'
 export type ResolvedTheme = Exclude<Theme, 'system'>
 
-const DEFAULT_THEME = 'system'
-// Legacy name, kept deliberately: the theme is client state persisted for a
-// year, so renaming the cookie would silently reset every existing user's
-// choice. Read by `public/bootstrap.js` before the bundle loads.
-const THEME_COOKIE_NAME = 'vite-ui-theme'
+const DEFAULT_THEME: Theme = 'system'
 const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365 // 1 year
 const THEMES = new Set<Theme>(['dark', 'light', 'system'])
+const PREFERS_DARK = '(prefers-color-scheme: dark)'
+// Legacy cookie name, kept deliberately: it is a year of client state, and it is
+// what `public/bootstrap.js` reads before this module exists.
+const THEME_COOKIE_NAME = 'vite-ui-theme'
 
 type ThemeProviderProps = {
   children: React.ReactNode
@@ -30,7 +44,7 @@ type ThemeProviderProps = {
   storageKey?: string
 }
 
-type ThemeProviderState = {
+type ThemeContextValue = {
   defaultTheme: Theme
   resolvedTheme: ResolvedTheme
   theme: Theme
@@ -38,116 +52,95 @@ type ThemeProviderState = {
   resetTheme: () => void
 }
 
-const initialState: ThemeProviderState = {
+/**
+ * Value seen by a consumer rendered outside a provider: reads as the light
+ * default and ignores writes. Not hypothetical — `ui/__tests__/axe-toast`
+ * renders `<Toaster>` standalone, and an error boundary can mount before the
+ * provider stack is ready. A stray `useTheme()` should degrade, not crash.
+ */
+const UNMOUNTED: ThemeContextValue = {
   defaultTheme: DEFAULT_THEME,
   resolvedTheme: 'light',
   theme: DEFAULT_THEME,
-  setTheme: () => null,
-  resetTheme: () => null,
+  setTheme: () => {},
+  resetTheme: () => {},
 }
 
-const ThemeContext = createContext<ThemeProviderState>(initialState)
+const ThemeContext = createContext<ThemeContextValue>(UNMOUNTED)
 
-function getSystemTheme(): ResolvedTheme {
-  if (typeof window === 'undefined') return 'light'
-  return window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? 'dark'
-    : 'light'
+function systemTheme(): ResolvedTheme {
+  return window.matchMedia(PREFERS_DARK).matches ? 'dark' : 'light'
 }
 
-function resolveTheme(theme: Theme): ResolvedTheme {
-  return theme === 'system' ? getSystemTheme() : theme
+function resolve(theme: Theme): ResolvedTheme {
+  return theme === 'system' ? systemTheme() : theme
 }
 
-function getStoredTheme(storageKey: string, fallback: Theme): Theme {
-  const storedTheme = getCookie(storageKey) as Theme | undefined
-  return storedTheme && THEMES.has(storedTheme) ? storedTheme : fallback
+/** The persisted choice, or `fallback` when it is absent or not a known theme. */
+function readStoredTheme(storageKey: string, fallback: Theme): Theme {
+  const stored = getCookie(storageKey) as Theme | undefined
+  return stored && THEMES.has(stored) ? stored : fallback
 }
 
 export function ThemeProvider({
   children,
   defaultTheme = DEFAULT_THEME,
   storageKey = THEME_COOKIE_NAME,
-  ...props
 }: ThemeProviderProps) {
-  const [theme, _setTheme] = useState<Theme>(() =>
-    getStoredTheme(storageKey, defaultTheme)
+  const [theme, setThemeState] = useState<Theme>(() =>
+    readStoredTheme(storageKey, defaultTheme)
   )
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
-    resolveTheme(getStoredTheme(storageKey, defaultTheme))
+    resolve(readStoredTheme(storageKey, defaultTheme))
   )
 
   useEffect(() => {
-    const root = window.document.documentElement
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const root = document.documentElement
+    const prefersDark = window.matchMedia(PREFERS_DARK)
 
-    const applyTheme = () => {
-      const nextResolvedTheme = theme === 'system' ? getSystemTheme() : theme
+    const apply = () => {
+      const next = resolve(theme)
+
       root.classList.remove('light', 'dark')
-      root.classList.add(nextResolvedTheme)
-      root.setAttribute('data-theme', nextResolvedTheme)
-      root.style.colorScheme = nextResolvedTheme
-      window.requestAnimationFrame(() => {
-        const background = getComputedStyle(document.body)
-          .getPropertyValue('--background')
-          .trim()
-        const themeColor = document.querySelector('meta[name="theme-color"]')
-        if (background) themeColor?.setAttribute('content', background)
-      })
-      setResolvedTheme(nextResolvedTheme)
+      root.classList.add(next)
+      root.setAttribute('data-theme', next)
+      root.style.colorScheme = next
+      setResolvedTheme(next)
+      syncThemeColorMeta()
     }
 
-    applyTheme()
+    apply()
 
-    // The index.html FOUC bootstrap paints an inline background on <html> so
-    // the first frame matches the theme before React mounts. Once the
-    // provider owns the document, drop it: the themed body background (which
-    // propagates to the canvas) takes over, so overscroll no longer reveals
-    // the stale pre-mount color.
     root.style.removeProperty('background-color')
     root.style.removeProperty('--bootstrap-background')
 
-    mediaQuery.addEventListener('change', applyTheme)
-
-    return () => mediaQuery.removeEventListener('change', applyTheme)
+    prefersDark.addEventListener('change', apply)
+    return () => prefersDark.removeEventListener('change', apply)
   }, [theme])
 
   const setTheme = useCallback(
-    (theme: Theme) => {
-      setCookie(storageKey, theme, THEME_COOKIE_MAX_AGE)
-      _setTheme(theme)
+    (next: Theme) => {
+      setCookie(storageKey, next, THEME_COOKIE_MAX_AGE)
+      setThemeState(next)
     },
     [storageKey]
   )
 
+  /** Back to following the system, and forget the stored override. */
   const resetTheme = useCallback(() => {
     removeCookie(storageKey)
-    _setTheme(defaultTheme)
+    setThemeState(defaultTheme)
   }, [defaultTheme, storageKey])
 
-  const contextValue = useMemo(
-    () => ({
-      defaultTheme,
-      resolvedTheme,
-      resetTheme,
-      theme,
-      setTheme,
-    }),
-    [defaultTheme, resolvedTheme, resetTheme, theme, setTheme]
+  const value = useMemo<ThemeContextValue>(
+    () => ({ defaultTheme, resolvedTheme, resetTheme, setTheme, theme }),
+    [defaultTheme, resolvedTheme, resetTheme, setTheme, theme]
   )
 
-  return (
-    <ThemeContext value={contextValue} {...props}>
-      {children}
-    </ThemeContext>
-  )
+  return <ThemeContext value={value}>{children}</ThemeContext>
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const useTheme = () => {
-  const context = useContext(ThemeContext)
-
-  if (!context) throw new Error('useTheme must be used within a ThemeProvider')
-
-  return context
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext)
 }

--- a/web/src/lib/theme-color-meta.ts
+++ b/web/src/lib/theme-color-meta.ts
@@ -1,0 +1,24 @@
+// metapi-go/lib — syncThemeColorMeta: keep <meta name="theme-color"> on the
+// resolved --background.
+//
+// index.html ships a static `#ffffff`, which is wrong the moment the user picks
+// dark mode or a colour preset: browsers paint that meta into the address bar,
+// the tab strip and the PWA chrome. Both theme providers therefore re-read the
+// computed `--background` whenever they change the cascade.
+//
+// The read happens in an animation frame because a class or data attribute
+// written in the same tick has not been styled yet — reading synchronously
+// would publish the previous theme's colour.
+
+export function syncThemeColorMeta(): void {
+  window.requestAnimationFrame(() => {
+    const background = getComputedStyle(document.body)
+      .getPropertyValue('--background')
+      .trim()
+    if (!background) return
+
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute('content', background)
+  })
+}

--- a/web/src/lib/theme-customization.ts
+++ b/web/src/lib/theme-customization.ts
@@ -1,7 +1,30 @@
-const PRESET_DEFAULT_FONT: Partial<Record<ThemePreset, ResolvedThemeFont>> = {
-  default: 'sans',
-}
+// metapi-go/lib — the theme customization vocabulary: the axes a user can
+// change, their allowed values, and where each choice is persisted.
+//
+// Lives in `lib/` rather than beside the provider so both the provider and the
+// customizer panel can import it without crossing the React Fast Refresh
+// boundary (`only-export-components`).
+//
+// Two hard constraints on this module:
+//
+//   1. `public/theme-init.js` applies these choices before first paint, so it
+//      carries its own hardcoded copy of the allowlists (it runs before any
+//      bundled module exists and cannot import from here). Two gates fail if the
+//      copies drift — `styles/__tests__/fouc-bootstrap` and
+//      `lib/__tests__/theme-bootstrap-parity` — and both compare **in order**,
+//      so declaration order below is part of the contract, not a style choice.
+//   2. The cookie keys and every `value` string are persisted client state
+//      (one-year cookies). Renaming one silently resets that user's appearance.
+//
+// The preset *palette* — the `swatches` below and the oklch values they preview
+// in `styles/theme-presets.css` — is design data rather than logic, and is the
+// product's visual identity; changing it is a design decision, not a refactor.
 
+/**
+ * The colour presets, in customizer display order. Each entry carries the two
+ * swatches its card previews (the preset's `--primary` and `--secondary` from
+ * `theme-presets.css`).
+ */
 export const THEME_PRESETS = [
   {
     value: 'default',
@@ -9,8 +32,7 @@ export const THEME_PRESETS = [
     swatches: ['oklch(0.72 0.18 250)', 'oklch(0.7 0.12 280)'],
   },
   {
-    // Inspired by Anthropic's brand language: warm cream canvas paired
-    // with clay/coral as the single accent.
+    // Warm cream canvas with clay/coral as the single accent.
     value: 'anthropic',
     name: 'Anthropic',
     swatches: ['oklch(0.984 0.005 95)', 'oklch(0.57 0.15 38)'],
@@ -57,25 +79,19 @@ export const THEME_PRESETS = [
   },
 ] as const
 
-// metapi-go/lib — theme customization constants ported from newapi. AGPL header stripped.
-// Lives in lib/ (not context/) so it can be imported alongside the provider
-// without breaking React Fast Refresh boundaries.
-
 export type ThemePreset = (typeof THEME_PRESETS)[number]['value']
 export type ThemeRadius = 'default' | 'none' | 'sm' | 'md' | 'lg' | 'xl'
 export type ThemeScale = 'default' | 'sm' | 'lg' | 'xl'
 export type ContentLayout = 'full' | 'centered'
 
 /**
- * Font axis for the theme.
+ * The body-font axis.
  *
- * - `default` — resolve at runtime from the active preset
- *   (see PRESET_DEFAULT_FONT). Every shipped preset resolves to sans,
- *   so the out-of-the-box experience is the humanist Public Sans voice;
- *   serif only appears when the user explicitly selects it.
- * - `sans` — humanist sans (Public Sans), the project's UI fallback.
- * - `serif` — editorial serif (Lora + CJK fallbacks), an explicit
- *   opt-in typography.
+ * `default` is what ships and what a reset returns to; it resolves to `sans`
+ * (the humanist Public Sans voice) for every preset, so serif only ever appears
+ * as an explicit user choice. `resolveThemeFont` is the single place that
+ * resolution happens — CSS addresses the concrete face
+ * (`[data-theme-font='sans']` / `='serif'`), never `default`.
  */
 export type ThemeFont = 'default' | 'sans' | 'serif'
 
@@ -98,7 +114,7 @@ export const DEFAULT_THEME_CUSTOMIZATION: ThemeCustomization = {
 }
 
 export const THEME_PRESET_VALUES = new Set(
-  THEME_PRESETS.map((p) => p.value)
+  THEME_PRESETS.map((preset) => preset.value)
 ) as ReadonlySet<ThemePreset>
 
 export const THEME_FONT_VALUES: ReadonlySet<ThemeFont> = new Set([
@@ -128,6 +144,10 @@ export const CONTENT_LAYOUT_VALUES: ReadonlySet<ContentLayout> = new Set([
   'centered',
 ])
 
+/**
+ * Cookie each axis persists to. Read by `public/theme-init.js` before the
+ * bundle loads — the strings are a contract with that script, not free names.
+ */
 export const THEME_COOKIE_KEYS = {
   preset: 'theme_preset',
   font: 'theme_font',
@@ -136,19 +156,7 @@ export const THEME_COOKIE_KEYS = {
   contentLayout: 'theme_content_layout',
 } as const
 
-/**
- * Preset → default font mapping. Every preset resolves to `sans` — the
- * humanist Public Sans voice is the default experience everywhere, and
- * serif is only ever an explicit user choice. The map exists so a future
- * preset could opt into serif (or any other resolved face) by listing it.
- */
-
-export function resolveThemeFont(
-  font: ThemeFont,
-  preset: ThemePreset
-): ResolvedThemeFont {
-  if (font === 'default') {
-    return PRESET_DEFAULT_FONT[preset] ?? 'sans'
-  }
-  return font
+/** The stored font preference as the concrete face CSS addresses. */
+export function resolveThemeFont(font: ThemeFont): ResolvedThemeFont {
+  return font === 'default' ? 'sans' : font
 }


### PR DESCRIPTION
## What

The two appearance providers were the largest near-verbatim modules left outside `components/ui/`. Rewritten. Observable behaviour is unchanged; the duplication inside and between them is gone.

**`lib/theme-color-meta.ts` (new).** Both providers carried the same `requestAnimationFrame` + `getComputedStyle` + `<meta name="theme-color">` write. One helper, two callers.

**`context/theme-customization-provider.tsx`.** Five axes each had their own `useState` + `useEffect` + `setX` triple — ~120 lines of one shape that had already drifted (content-layout writes its attribute at the default value; the other three remove it). `usePersistedAxis` now owns "allowlisted value, cookie-backed, mirrored onto one `<body>` attribute" once, and the provider reads as five axis declarations. The two genuine differences are explicit in the declaration instead of buried in an effect each:

| axis | `toAttribute` |
| --- | --- |
| preset / radius / scale | `omitAtDefault` — at `default` the attribute is removed so `theme.css` wins rather than a preset restating it |
| font | `resolveThemeFont` — CSS addresses the concrete face (`sans`/`serif`), never `default` |
| content-layout | *(none)* — always written, because the stylesheet and the pre-paint bootstrap both address it by value |

**`context/theme-provider.tsx`.** Same behaviour (light/dark class + `data-theme` + `color-scheme` + theme-color meta, the `prefers-color-scheme` listener that makes "follow system" actually follow, the bootstrap inline-style cleanup, the year-long cookie). Dropped the `typeof window` guard (SPA: no SSR, no prerender) and the never-populated `...props` spread onto the context element. The unmounted-provider default stays, and now names the real caller that exercises it (`ui/__tests__/axe-toast` renders `<Toaster>` standalone) instead of a hypothetical one.

**`lib/theme-customization.ts`.** The file header sat at line 60, *below* `THEME_PRESETS`; it is at the top now. `PRESET_DEFAULT_FONT` is gone — a one-entry map whose every other key fell through to the same `'sans'`, kept "so a future preset could opt into serif". `resolveThemeFont(font)` is the whole rule, and it no longer takes a preset it never read. The two constraints that are invisible from the code are documented where they bite: `public/theme-init.js` carries an **ordered** copy of these allowlists (two gates fail on drift), and the cookie keys and value strings are persisted client state.

**`components/theme-customizer.tsx`.** Header describes the component.

## Deliberately untouched

The preset palette data — `THEME_PRESETS` swatches and `styles/theme-presets.css`. That is design data and the product's visual identity, not logic. Changing it is a design decision; this is a refactor.

## Tests

New `context/__tests__/theme-customization-provider.test.tsx` pins the axis contract a rewrite here could silently change: an unknown cookie value falls back instead of reaching CSS, `font` resolves `default` → `sans`, returning to a default removes the cookie (and the attribute, except content-layout), and `resetCustomization` clears all five.

Existing guards: `styles/__tests__/fouc-bootstrap`, `lib/__tests__/theme-bootstrap-parity`, `components/__tests__/theme-customizer`, `context/__tests__/theme-provider`, `layout/components/interface-controls`, `features/auth/sign-in-page*`.

## Gates

- `bun run lint` → oxlint clean, boundaries **685/0**, FormControl **140/0**
- `bun run format:check` · `bun run knip` · `bun run routes:verify` (28/28)
- `bun run vitest run --maxWorkers=1` → **260 files / 1684 tests passed**
- `bun run typecheck` (`tsgo -b`) cannot run on the 2C/4G dev host — OOM-killed (`dmesg`: `total-vm:2384420kB, anon-rss:1114748kB, Out of memory: Killed process … (tsgo)`). CI `frontend` is the typecheck authority.