### PR TITLE
refactor(web): make the navigation layer metapi-go's own

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -4,7 +4,7 @@
 
 本文档定义 metapi-go 前端项目的开发规范与最佳实践，供开发与 AI 助手共同遵循。具体依赖与脚本以 `package.json` 为准。
 
-metapi-go 是 Meta-layer management and unified proxy for AI API aggregation platforms 的 Go 重写，前端为 React SPA，预构建产物经 `web/embed.go` 的 `go:embed dist` 打包进 Go 单二进制（生产镜像不含 node/bun）。前端采用与 newapi 同类的 React 技术栈；迁移必须保留后端 API 契约（camelCase 字段、env var 名）与 DB（SQLite/PG dual dialect）。
+metapi-go 是 Meta-layer management and unified proxy for AI API aggregation platforms 的 Go 重写，前端为 React SPA，预构建产物经 `web/embed.go` 的 `go:embed dist` 打包进 Go 单二进制（生产镜像不含 node/bun）。重写的兼容性目标是 metapi 的 TypeScript 版：后端 API 契约（camelCase 字段、env var 名）与 DB（SQLite/PG dual dialect）必须保持不变。
 
 ---
 
@@ -74,7 +74,7 @@ src/
 ├── routes/                # TanStack Router 文件路由
 ├── styles/                # theme.css + theme-presets.css + index.css
 ├── i18n/                  # config.ts + languages.ts + locales/{en,zh-CN}.json
-├── hooks/                 # use-media-query / use-mobile / use-sidebar-data / use-sidebar-view
+├── hooks/                 # use-media-query / use-mobile / use-search-actions / use-sidebar-view
 ├── context/               # theme / theme-customization / font / direction providers
 ├── stores/                # auth-store
 ├── config/                # fonts.ts

--- a/web/src/components/layout/components/app-sidebar.tsx
+++ b/web/src/components/layout/components/app-sidebar.tsx
@@ -1,7 +1,5 @@
-// metapi-go/layout — app-sidebar adapted from newapi. AGPL header stripped.
-// Dropped LayoutProvider dependency (not in scope for skeleton); sidebar variant
-// and collapsible mode are hardcoded to sensible defaults. View resolution and
-// per-view header remain via useSidebarView + sidebar-view-registry.
+// metapi-go/layout — AppSidebar: the navigation shell, and the mount point for
+// the drill-in view swap.
 
 import { Cancel01Icon } from '@hugeicons/core-free-icons'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -21,47 +19,20 @@ import { metapiIdentity } from '@/lib/identity-branding'
 import { NavGroup } from './nav-group'
 import { SidebarViewHeader } from './sidebar-view-header'
 
-// Skeleton defaults — newapi reads these from LayoutProvider (cookie-backed).
-// metapi will wire a layout provider in a later phase; for now these match
-// the newapi defaults (variant=inset, collapsible=icon).
+// Fixed chrome, not user-configurable: `inset` gives the content panel its own
+// card inside the sidebar frame, and `icon` collapses the rail to icons rather
+// than hiding it, so the entries stay one click away on a narrow desktop.
 const SIDEBAR_VARIANT = 'inset' as const
 const SIDEBAR_COLLAPSIBLE = 'icon' as const
 
 /**
- * Application sidebar.
- *
- * Adopts the Vercel / Cloudflare "drill-in" pattern: the URL drives
- * which sidebar *view* is rendered. Clicking a top-level entry like
- * `Settings` swaps the sidebar to a contextual workspace — with a
- * `← Back to Home` affordance — instead of stacking the sub-navigation
- * inside the root tree.
- *
- * Architecture:
- *   - View resolution: {@link useSidebarView}
- *   - View registry: layout/lib/sidebar-view-registry.ts
- *   - Per-view header: {@link SidebarViewHeader}
- *
- * Adding a new nested view only requires registering a SidebarView
- * in the registry; this component requires no changes.
- *
- * Animation: the view swap uses the `.sidebar-view-enter` CSS keyframe
- * (defined in styles/index.css) instead of `motion`/`framer-motion`. The
- * `key={key}` prop forces React to remount the container on every view
- * change, which re-triggers the CSS enter animation. This removed the
- * `motion` package (~78 kB gz) from the eager authenticated chunk; the
- * animation only fires on view switches (never on initial page render —
- * matching the previous `AnimatePresence initial={false}`), and
- * `prefers-reduced-motion` users see no animation.
- */
-/**
- * Mobile-only drawer header: brand row + an explicit close button.
+ * Mobile-only drawer header: brand row plus an explicit close button.
  *
  * The sheet template's own close button is hidden on the mobile sidebar
- * (`[&>button]:hidden` in ui/sidebar.tsx) and the drawer previously opened
- * straight into the first group label with no way to tell where the close
- * affordance was. This header lives inside a wrapper div, so the `> button`
- * selector never hits it. It is rendered only on mobile (desktop keeps its
- * icon-collapsed rail + trigger).
+ * (`[&>button]:hidden` in ui/sidebar.tsx), so without this the drawer would
+ * open straight into a group label with no visible way out. It sits inside a
+ * wrapper div so that `> button` selector cannot reach it, and renders only on
+ * mobile — desktop keeps the icon-collapsed rail and its trigger.
  */
 function SidebarMobileHeader() {
   const { setOpenMobile } = useSidebar()
@@ -90,6 +61,22 @@ function SidebarMobileHeader() {
   )
 }
 
+/**
+ * The application sidebar.
+ *
+ * The URL decides which *view* is shown (Vercel / Cloudflare drill-in): entering
+ * Settings swaps the whole sidebar for a contextual workspace with a back
+ * affordance, rather than stacking a second tree inside the root one. Three
+ * pieces own that, and this component only composes them —
+ * {@link useSidebarView} resolves the view, `layout/lib/sidebar-view-registry`
+ * holds the registrations, {@link SidebarViewHeader} renders the back row. A new
+ * workspace is therefore a registry entry, not a change here.
+ *
+ * The swap animates with the `.sidebar-view-enter` keyframe (styles/index.css)
+ * rather than a motion library: `key={key}` remounts the container, which
+ * re-triggers the enter animation on a view change only — never on first render —
+ * and `prefers-reduced-motion` suppresses it.
+ */
 export function AppSidebar() {
   const { key, view, navGroups } = useSidebarView()
   const { isMobile } = useSidebar()
@@ -100,9 +87,8 @@ export function AppSidebar() {
       {view && <SidebarViewHeader view={view} />}
 
       <SidebarContent className='py-2'>
-        {/* `key` remounts the subtree on every view switch so the CSS
-         * enter animation re-runs. Plain <div> replaces the old
-         * <AnimatePresence><motion.div> pair. */}
+        {/* `key` remounts the subtree on a view switch so the CSS enter
+         * animation re-runs. */}
         <div key={key} className='sidebar-view-enter flex flex-col'>
           {navGroups.map((props) => (
             <NavGroup key={props.id || props.title} {...props} />

--- a/web/src/components/layout/components/authenticated-layout.tsx
+++ b/web/src/components/layout/components/authenticated-layout.tsx
@@ -1,9 +1,15 @@
-// metapi-go/layout — authenticated-layout adapted from newapi. AGPL header stripped.
-// SidebarProvider + SkipToMain + AppHeader + flex row (AppSidebar + SidebarInset).
-// Uses <Outlet /> from TanStack Router so matched child routes (/dashboard/*, /sites,
-// /accounts, /settings/*, ...) render inside SidebarInset. Also owns the global
-// search palette state and mounts SearchModal here (inside the router, since
-// result clicks navigate).
+// metapi-go/layout — AuthenticatedLayout: the shell every signed-in route
+// renders inside.
+//
+// SidebarProvider → SkipToMain → AppHeader → (AppSidebar | SidebarInset), with
+// TanStack's <Outlet /> putting the matched child route (/dashboard/*, /sites,
+// /accounts, /settings/*, …) into the inset panel.
+//
+// Two things live here rather than in a page because they are shell-wide:
+//   - the sidebar's initial open state, read from the `sidebar_state` cookie the
+//     SidebarProvider itself persists, so a reload keeps the rail collapsed;
+//   - the command palette's open state. SearchModal is mounted inside the router
+//     on purpose — picking a result navigates.
 
 import { Outlet } from '@tanstack/react-router'
 import * as React from 'react'

--- a/web/src/components/layout/components/nav-group.tsx
+++ b/web/src/components/layout/components/nav-group.tsx
@@ -1,6 +1,13 @@
-// metapi-go/layout — nav-group ported from newapi. AGPL header stripped.
-// Dropped ChatPresetsItem handling (metapi has no chat). Renders NavLink and
-// NavCollapsible items, with a collapsed-state dropdown for desktop icon mode.
+// metapi-go/layout — NavGroup: one labelled section of the sidebar.
+//
+// Renders both shapes of `NavItem` (see ../types): a leaf becomes a link, a
+// branch becomes a Collapsible whose open state follows the URL, so the group
+// containing the current page is already expanded on arrival. On the desktop
+// icon-collapsed rail there is no room for a nested tree, so a branch renders as
+// a dropdown instead — same entries, different container.
+//
+// Active state comes from `checkIsActive` (../lib/url-utils), which is the one
+// place that decides what a URL selects.
 
 import { Link, useLocation, type LinkProps } from '@tanstack/react-router'
 import { ChevronRight } from 'lucide-react'
@@ -42,10 +49,6 @@ import type {
   NavGroup as NavGroupProps,
 } from '../types'
 
-/**
- * Sidebar navigation group component
- * Renders a group of navigation items, supporting regular links and collapsible submenus
- */
 export function NavGroup({ title, items }: NavGroupProps) {
   const { state, isMobile } = useSidebar()
   const href = useLocation({ select: (location) => location.href })

--- a/web/src/components/layout/components/sidebar-view-header.tsx
+++ b/web/src/components/layout/components/sidebar-view-header.tsx
@@ -1,6 +1,10 @@
-// metapi-go/layout — sidebar-view-header ported from newapi. AGPL header stripped.
-// Renders the back affordance for a nested drill-in sidebar view.
-// Labels are i18n keys resolved via t() at render time.
+// metapi-go/layout — SidebarViewHeader: the back affordance of a drill-in
+// sidebar view.
+//
+// Deliberately just a back link, with no title row: the workspace is already
+// named by the group labels underneath it, so a second copy of the name is noise.
+// The link also dismisses the mobile drawer, because on a phone the sidebar *is*
+// an overlay — navigating without closing it would leave the new page covered.
 
 import { Link } from '@tanstack/react-router'
 import { ChevronLeft } from 'lucide-react'
@@ -13,43 +17,29 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from '@/components/ui/sidebar'
-import { cn } from '@/lib/utils'
 
 import type { SidebarView } from '../types'
 
-type SidebarViewHeaderProps = {
-  view: SidebarView
-}
-
-/**
- * Header for a nested sidebar view (Vercel / Cloudflare drill-in pattern).
- *
- * Renders only the back affordance — workspace context is conveyed by
- * the nav groups below, not a redundant title row.
- */
-export function SidebarViewHeader(props: SidebarViewHeaderProps) {
+export function SidebarViewHeader({ view }: { view: SidebarView }) {
   const { setOpenMobile } = useSidebar()
   const { t } = useTranslation()
+  // Resolved once: the same label is the visible text and the collapsed-rail
+  // tooltip, and the two must not drift.
+  const parentLabel = t(view.parent.label)
 
   return (
     <SidebarHeader className='border-sidebar-border border-b px-2 py-2'>
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton
-            tooltip={t(props.view.parent.label)}
-            className={cn(
-              'text-muted-foreground hover:text-foreground',
-              'gap-1.5 font-medium'
-            )}
+            tooltip={parentLabel}
+            className='text-muted-foreground hover:text-foreground gap-1.5 font-medium'
             render={
-              <Link
-                to={props.view.parent.to}
-                onClick={() => setOpenMobile(false)}
-              />
+              <Link to={view.parent.to} onClick={() => setOpenMobile(false)} />
             }
           >
             <ChevronLeft className='size-4 shrink-0' />
-            <span className='truncate'>{t(props.view.parent.label)}</span>
+            <span className='truncate'>{parentLabel}</span>
           </SidebarMenuButton>
         </SidebarMenuItem>
       </SidebarMenu>

--- a/web/src/components/layout/config/root-navigation.ts
+++ b/web/src/components/layout/config/root-navigation.ts
@@ -1,7 +1,15 @@
-// metapi-go/hooks — use-sidebar-data adapted from newapi per plan.md §5.5.4.
-// 4 collapsible groups (Console / Configuration / Models / System) with lucide icons.
-// No NavChatPresets (metapi has no chat). No requiredRole (metapi is fully open).
-// Titles are i18n keys resolved via t() at render time (nav-group.tsx).
+// metapi-go/layout — the root navigation set: what the sidebar shows when the
+// URL matches no drill-in view.
+//
+// Four collapsible groups (Console / Configuration / Models / System). Every
+// `title` is an i18n key resolved with t() by `nav-group.tsx`, so this module
+// stays pure data and can be read outside React — the command palette does
+// exactly that to index navigation alongside its other sources.
+//
+// Static by design: it lives beside `system-settings.config.ts` (the Settings
+// view's equivalent) rather than in `hooks/`, because there is nothing to
+// observe. Both callers get the same object reference, so identity comparisons
+// downstream stay cheap.
 
 import {
   Activity,
@@ -23,17 +31,7 @@ import {
 
 import type { SidebarData } from '@/components/layout/types'
 
-/**
- * Root navigation groups for the metapi sidebar.
- *
- * Shown when the URL does not match any nested sidebar view registered in
- * components/layout/lib/sidebar-view-registry.ts (currently just Settings).
- * Grouped into 4 collapsible sections per the rewrite IA redesign.
- */
-// Module-level constant: the nav groups are fully static, so returning the
-// same object reference every call keeps `useSidebarView`'s `useMemo` from
-// re-running on every render (a fresh object literal would defeat it).
-const SIDEBAR_DATA: SidebarData = {
+export const ROOT_NAVIGATION: SidebarData = {
   navGroups: [
     {
       id: 'console',
@@ -143,8 +141,4 @@ const SIDEBAR_DATA: SidebarData = {
       ],
     },
   ],
-}
-
-export function useSidebarData(): SidebarData {
-  return SIDEBAR_DATA
 }

--- a/web/src/components/layout/config/system-settings.config.ts
+++ b/web/src/components/layout/config/system-settings.config.ts
@@ -1,17 +1,19 @@
-// metapi-go/layout — system-settings.config adapted from newapi per plan.md §5.5.2.
-// metapi Settings is a 5-subarea drill-in workspace (general / downstream / models /
-// content / system-info). The 7-section newapi registry is collapsed to metapi's 5.
-// Titles are i18n keys resolved via t() at render time (nav-group.tsx /
-// sidebar-view-header.tsx).
+// metapi-go/layout — the Settings drill-in view: its back target and its
+// navigation groups.
 //
-// IA restructure (wave 8 lane C): the 5 subareas render as NavCollapsible
-// nested-tree entries whose sub-items are the subarea's sections (from the
-// shared section-registry manifest). Together with the removed in-page
-// settings sidebar, breadcrumbs and overview section lists, the sidebar tree
-// is now the single navigation surface for the Settings workspace — aligned
-// with the newapi "System Administration" drill-in view. The active subarea
-// auto-expands (activePrefix + checkIsActive) and the active section is
-// highlighted with aria-current.
+// Settings is five subareas (general / downstream / models / content /
+// system-info), each rendered as a `NavCollapsible` whose sub-items are that
+// subarea's sections, read from the shared section-registry manifest so a
+// section added by a feature appears in the sidebar without an edit here.
+//
+// This sidebar tree is the *only* navigation surface for the workspace — there
+// is no in-page section list, breadcrumb trail or overview index to keep in
+// sync. That is why the active subarea auto-expands (`activePrefix` +
+// `checkIsActive`) and the active section carries `aria-current`: losing the
+// highlight would leave the user with no way to tell where they are.
+//
+// Titles are i18n keys resolved with t() at render time (nav-group.tsx /
+// sidebar-view-header.tsx).
 
 import { LayoutGrid } from 'lucide-react'
 

--- a/web/src/components/layout/lib/sidebar-view-registry.ts
+++ b/web/src/components/layout/lib/sidebar-view-registry.ts
@@ -1,33 +1,29 @@
-// metapi-go/layout — sidebar-view-registry ported from newapi. AGPL header stripped.
-// Resolves the active nested drill-in view for a given pathname.
+// metapi-go/layout — the registry of drill-in sidebar views, and the pathname
+// lookup that picks one.
 //
-// S5 boundary inversion: the shell owns this registry. Feature-owned views
-// register through `registerSidebarView` from the authenticated route's
-// composition root (routes/_authenticated/route.tsx) instead of the shell
-// importing features (components ↛ features, see
-// docs/internal/web-package-boundaries.md).
+// The shell owns this module and features push into it, never the reverse: a
+// feature-owned view registers through `registerSidebarView` from the
+// authenticated route's composition root (routes/_authenticated/route.tsx),
+// which keeps `components/ ↛ features/` intact (see
+// docs/internal/web-package-boundaries.md). The inversion is what lets a
+// workspace live in its own feature folder and still replace the sidebar.
 
 import { SYSTEM_SETTINGS_VIEW } from '../config/system-settings.config'
 import type { SidebarView } from '../types'
 
 /**
- * Registered nested sidebar views.
- *
- * Each entry describes a contextual sidebar that replaces the root
- * navigation when the user enters that workspace (Vercel-style
- * "drill-in" pattern).
- *
- * Match priority is array order; the first matching `pathPattern` wins.
- * The settings view is layout-owned and registered statically; feature
- * views are appended by the composition root before first render.
+ * Registered views, in match order: the first `pathPattern` that tests true
+ * wins, so a narrower pattern must be registered before a broader one.
+ * Settings is layout-owned and therefore static; feature views are appended by
+ * the composition root before first render.
  */
 const SIDEBAR_VIEWS: SidebarView[] = [SYSTEM_SETTINGS_VIEW]
 
 /**
- * Register a drill-in view owned outside the layout shell.
+ * Register a view owned outside the layout shell.
  *
- * Idempotent per view id: re-registering the same id replaces the entry
- * (keeps HMR re-evaluation from duplicating views).
+ * Idempotent per `id` — re-registering replaces the entry, so a dev-server
+ * module re-evaluation cannot leave the same workspace in the list twice.
  */
 export function registerSidebarView(view: SidebarView): void {
   const existingIndex = SIDEBAR_VIEWS.findIndex((entry) => entry.id === view.id)
@@ -38,12 +34,7 @@ export function registerSidebarView(view: SidebarView): void {
   SIDEBAR_VIEWS.push(view)
 }
 
-/**
- * Resolve the active nested view for the given path.
- *
- * @returns Matching SidebarView, or `null` when the root
- *          navigation should be displayed.
- */
+/** The view for `pathname`, or null when the root navigation applies. */
 export function resolveSidebarView(pathname: string): SidebarView | null {
   return SIDEBAR_VIEWS.find((view) => view.pathPattern.test(pathname)) ?? null
 }

--- a/web/src/components/layout/lib/url-utils.ts
+++ b/web/src/components/layout/lib/url-utils.ts
@@ -1,114 +1,108 @@
-// metapi-go/layout — url-utils ported from newapi. AGPL header stripped.
-// checkIsActive drives sidebar active-state highlighting.
+// metapi-go/layout — checkIsActive: which sidebar entry the current URL selects.
+//
+// The sidebar is the only navigation surface for the Settings workspace, so this
+// has to be right for the three ways an entry can declare itself active, and
+// each exists for a reason:
+//
+//   `url`          the entry's own target;
+//   `activeUrls`   extra URLs that also select it (a section index that has to
+//                  light up for its default section);
+//   `activePrefix` a whole subtree (a settings subarea stays active for every
+//                  section URL beneath it).
+//
+// Query and hash are stripped before comparing pathnames, so `/models#top` still
+// highlights `/models`. A declared URL that *does* carry a query only matches an
+// href carrying the same one — that is what keeps `/observability` and
+// `/observability?section=traffic` two distinct entries instead of one stealing
+// the other's highlight.
 
 import type { LinkProps } from '@tanstack/react-router'
 
-import type { NavItem, NavCollapsible } from '../types'
+import type { NavCollapsible, NavItem } from '../types'
+
+type NavUrl = LinkProps['to'] | (string & {})
 
 /**
- * Convert LinkProps['to'] to string
- * Handles both string URLs and object URLs (e.g., { pathname, search })
+ * A declared nav URL as a comparable string. TanStack's `to` is either a string
+ * or a `{ pathname, search }` object; anything else yields null, i.e. "never
+ * active", rather than throwing on a malformed entry.
  */
-function urlToString(url: LinkProps['to'] | (string & {})): string | null {
-  if (typeof url === 'string') {
-    return url
-  }
-  if (url && typeof url === 'object' && !Array.isArray(url)) {
-    const urlObj = url as Record<string, unknown>
-    const pathname = typeof urlObj.pathname === 'string' ? urlObj.pathname : ''
-    const search = typeof urlObj.search === 'string' ? urlObj.search : ''
-    return pathname + search
-  }
-  return null
+function urlToString(url: NavUrl): string | null {
+  if (typeof url === 'string') return url
+  if (!url || typeof url !== 'object' || Array.isArray(url)) return null
+
+  const { pathname, search } = url as Record<string, unknown>
+  const path = typeof pathname === 'string' ? pathname : ''
+  const query = typeof search === 'string' ? search : ''
+  return path + query
 }
 
-/**
- * Strip both the query string and the hash fragment from a URL, leaving only
- * the pathname. The active-state comparison should ignore transient query /
- * hash state so `/models#top` still highlights the `/models` nav item.
- */
+/** Pathname only: query and hash are transient state, not identity. */
 function stripQueryAndHash(url: string): string {
   return url.split('?')[0].split('#')[0]
 }
 
+/** Does the declared URL `candidate` select the current `href`? */
+function selects(href: string, hrefPath: string, candidate: string): boolean {
+  if (href === candidate) return true
+  // A candidate that pins a query is exact-match-only: matching it on pathname
+  // alone would claim every sibling section that shares its path.
+  return !candidate.includes('?') && stripQueryAndHash(candidate) === hrefPath
+}
+
+/** Trailing slashes normalised, except that `/` itself stays `/`. */
+function withoutTrailingSlash(path: string): string {
+  return path.length > 1 ? path.replace(/\/+$/, '') : path
+}
+
 /**
- * Check if a navigation item is active for the current href.
- * @param href - Current URL (may include query string + hash fragment)
- * @param item - Navigation item
+ * Subtree match for `activePrefix`. The `prefix + '/'` form is what stops
+ * `/settings/basic` from leaking onto `/settings/basics`.
  */
+function matchesPrefix(hrefPath: string, activePrefix: string): boolean {
+  const prefix = withoutTrailingSlash(activePrefix.split('?')[0])
+  const path = withoutTrailingSlash(hrefPath)
+
+  return path === prefix || path.startsWith(`${prefix}/`)
+}
+
 export function checkIsActive(href: string, item: NavItem): boolean {
   const hrefPath = stripQueryAndHash(href)
 
-  // Active URLs are query-aware: an entry matches the *bare* path only when
-  // the current href itself carries no query, so `/observability` highlights
-  // the default-section item without also matching `/observability?section=…`
-  // variants (which belong to their exact-match entries).
   if (
     item.activeUrls?.some((url) => {
-      const activeUrl = urlToString(url)
-      if (!activeUrl) return false
+      const declared = urlToString(url)
+      // Query-aware in the opposite direction from `selects`: a bare-path entry
+      // matches only while the href itself carries no query, so `/observability`
+      // highlights the default-section item without also claiming the
+      // `?section=…` variants that belong to their own entries.
       return (
-        activeUrl === href || (activeUrl === hrefPath && !href.includes('?'))
+        declared !== null &&
+        (declared === href || (declared === hrefPath && !href.includes('?')))
       )
     })
   ) {
     return true
   }
 
-  // Prefix match for drill-in items (e.g. a settings subarea stays active for
-  // any of its section URLs: /settings/basic matches /settings/basic/*).
-  if (item.activePrefix) {
-    const prefix = item.activePrefix.split('?')[0]
-    const cleanPrefix = prefix.length > 1 ? prefix.replace(/\/+$/, '') : prefix
-    const cleanHref =
-      hrefPath.length > 1 ? hrefPath.replace(/\/+$/, '') : hrefPath
-    if (cleanHref === cleanPrefix || cleanHref.startsWith(`${cleanPrefix}/`)) {
-      return true
-    }
+  if (item.activePrefix && matchesPrefix(hrefPath, item.activePrefix)) {
+    return true
   }
 
-  // For collapsible items (NavCollapsible), check sub-items first
+  // A branch is active when any child is, so the group stays open and highlighted
+  // while the user is somewhere inside it.
   if ('items' in item && item.items) {
-    const collapsibleItem = item as NavCollapsible
-    const items = collapsibleItem.items
-
-    // Check if any sub-item matches
+    const branch = item as NavCollapsible
     if (
-      items.some((i) => {
-        if (!i?.url) return false
-        const subItemUrl = urlToString(i.url)
-        if (!subItemUrl) return false
-        if (href === subItemUrl) return true
-        const subItemUrlPath = stripQueryAndHash(subItemUrl)
-        const subItemUrlHasQuery = subItemUrl.includes('?')
-        if (subItemUrlPath === hrefPath) {
-          if (!subItemUrlHasQuery) return true
-          if (subItemUrlHasQuery && href === subItemUrl) return true
-        }
-        return false
+      branch.items.some((child) => {
+        const declared = child?.url ? urlToString(child.url) : null
+        return declared !== null && selects(href, hrefPath, declared)
       })
     ) {
       return true
     }
   }
 
-  // For regular link items, check the item's URL
-  if (!item.url) return false
-
-  const itemUrl = urlToString(item.url)
-  if (!itemUrl) return false
-
-  // Exact match
-  if (href === itemUrl) return true
-
-  const itemUrlPath = stripQueryAndHash(itemUrl)
-  const itemUrlHasQuery = itemUrl.includes('?')
-
-  // If both URLs have the same base path
-  if (hrefPath === itemUrlPath) {
-    if (!itemUrlHasQuery) return true
-    if (itemUrlHasQuery && href === itemUrl) return true
-  }
-
-  return false
+  const declared = item.url ? urlToString(item.url) : null
+  return declared !== null && selects(href, hrefPath, declared)
 }

--- a/web/src/components/layout/search-modal.tsx
+++ b/web/src/components/layout/search-modal.tsx
@@ -41,6 +41,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
+import { ROOT_NAVIGATION } from '@/components/layout/config/root-navigation'
 import {
   Command,
   CommandDialog,
@@ -51,7 +52,6 @@ import {
 } from '@/components/ui/command'
 import { Spinner } from '@/components/ui/spinner'
 import { useSearchActions } from '@/hooks/use-search-actions'
-import { useSidebarData } from '@/hooks/use-sidebar-data'
 import {
   searchApi,
   type SearchAccount,
@@ -120,7 +120,6 @@ function firstNonEmpty(
 export function SearchModal(props: SearchModalProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const sidebarData = useSidebarData()
 
   const [query, setQuery] = React.useState('')
   const [results, setResults] = React.useState<SearchResponse | null>(null)
@@ -350,9 +349,10 @@ export function SearchModal(props: SearchModalProps) {
 
   // ---- Local navigation layer --------------------------------------------
 
+  // ROOT_NAVIGATION is a module constant, so there is nothing to recompute on.
   const pageEntries = React.useMemo(
-    () => pageEntriesFromNavGroups(sidebarData.navGroups),
-    [sidebarData]
+    () => pageEntriesFromNavGroups(ROOT_NAVIGATION.navGroups),
+    []
   )
   const settingsEntries = React.useMemo(() => getSettingsNavEntries(), [])
 

--- a/web/src/components/layout/types.ts
+++ b/web/src/components/layout/types.ts
@@ -1,13 +1,20 @@
-// metapi-go/layout — navigation types adapted from newapi. AGPL header stripped.
-// Dropped NavChatPresets (metapi has no chat) and requiredRole (metapi is fully open;
-// route-level guards enforce access). getNavGroups takes no TFunction — i18n lands in
-// phase 2, so nav builders return plain strings for now.
+// metapi-go/layout — the navigation model: what a sidebar entry can be, and how
+// a URL picks one.
+//
+// Two ideas carry the whole shell. A `NavItem` is either a leaf (`url`) or a
+// branch (`items`), made mutually exclusive with `?: never` so a malformed
+// entry is a type error rather than a runtime surprise. A `SidebarView` is a
+// whole navigation set bound to a path pattern, which is what lets a workspace
+// like Settings replace the root sidebar instead of nesting inside it.
+//
+// Every `title` / `badge` / `label` string in this model is an **i18n key**,
+// resolved with `t()` at render time by `nav-group.tsx` and
+// `sidebar-view-header.tsx` — the builders here stay pure data so they can be
+// constructed outside React.
 
 import type { LinkProps } from '@tanstack/react-router'
 
-/**
- * Base navigation item type
- */
+/** Fields every navigation entry carries, leaf or branch. */
 type BaseNavItem = {
   title: string
   /** Optional i18n key of a small badge rendered beside the title (resolved via t()). */
@@ -21,83 +28,64 @@ type BaseNavItem = {
   activeOptions?: LinkProps['activeOptions']
 }
 
-/**
- * Navigation link type - single link item
- */
+/** A leaf entry: navigates somewhere, has no children. */
 export type NavLink = BaseNavItem & {
   url: LinkProps['to'] | (string & {})
   items?: never
 }
 
-/**
- * Navigation collapsible type - collapsible navigation with sub-items
- */
+/** A branch entry: expands to sub-items, navigates nowhere itself. */
 export type NavCollapsible = BaseNavItem & {
   items: (BaseNavItem & { url: LinkProps['to'] | (string & {}) })[]
   url?: never
 }
 
-/**
- * Navigation item union type
- */
 export type NavItem = NavCollapsible | NavLink
 
-/**
- * Navigation group type - a group of navigation items in sidebar
- */
+/** A labelled section of the sidebar. */
 export type NavGroup = {
   id?: string
   title: string
   items: NavItem[]
 }
 
-/**
- * Root sidebar data type
- *
- * Used by the default (top-level) sidebar view that lists primary
- * application navigation (console / configuration / models / system).
- */
+/** The root navigation set: console / configuration / models / system. */
 export type SidebarData = {
   navGroups: NavGroup[]
 }
 
-/**
- * Back-navigation descriptor for a nested sidebar view
- */
+/** Where a nested view's back affordance goes, and what it says. */
 type SidebarViewParent = {
-  /** Destination URL for the back button */
   to: LinkProps['to'] | (string & {})
-  /** Visible label, e.g. "Back to Home" */
+  /** i18n key, e.g. `nav.backToHome`. */
   label: string
 }
 
 /**
- * Nested sidebar view configuration
- *
- * A nested view replaces the root navigation when the user enters a
- * dedicated workspace (e.g. Settings). Models the Vercel / Cloudflare
- * "drill-in" sidebar UX: clicking a top-level entry swaps the sidebar
- * to a contextual view with a "Back" affordance.
+ * A drill-in workspace that replaces the root navigation while its path
+ * pattern matches — the Vercel / Cloudflare sidebar pattern: entering Settings
+ * swaps the whole sidebar for a contextual one with a back affordance, rather
+ * than nesting a second tree inside the first.
  */
 export type SidebarView = {
-  /** Stable identifier (also drives transition animation keys) */
+  /** Stable identifier; also the animation key when the sidebar swaps views. */
   id: string
-  /** Path matcher that activates this view */
+  /** Activates this view when it matches the current pathname. */
   pathPattern: RegExp
-  /** Back-navigation descriptor; required for nested views */
   parent: SidebarViewParent
-  /** Nav group builder, called per render */
+  /** Called per render, so a view can reflect live manifests. */
   getNavGroups: () => NavGroup[]
 }
 
 /**
- * Resolved sidebar view returned by useSidebarView()
+ * What `useSidebarView()` resolves for the current location.
  *
- * - `view === null`: root navigation (default sidebar)
- * - `view !== null`: nested workspace view (renders header + back button)
+ * `view === null` means the root navigation and no header; a non-null `view`
+ * means a drill-in workspace, which renders its back affordance above
+ * `navGroups`.
  */
 export type ResolvedSidebarView = {
-  /** Animation/identity key — falls back to a sentinel for the root view */
+  /** Animation / identity key; a sentinel for the root view. */
   key: string
   view: SidebarView | null
   navGroups: NavGroup[]

--- a/web/src/features/dashboard/components/dashboard-page.tsx
+++ b/web/src/features/dashboard/components/dashboard-page.tsx
@@ -8,9 +8,9 @@
 // pattern. When `onSectionChange` is omitted the tabs render read-only
 // (useful for embeds / tests).
 //
-// Phase 3: lift shared section state here (chart preferences, time-range
-// filters) once the traffic / models sections grow their own filter controls,
-// mirroring newapi's dashboard/index.tsx parent-owned state.
+// The page owns no section state: each section fetches and holds its own, and
+// the only cross-section state today (the active tab) lives in the URL, which is
+// what makes a dashboard deep link reproducible.
 
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/features/settings/components/settings-page.tsx
+++ b/web/src/features/settings/components/settings-page.tsx
@@ -13,8 +13,9 @@
 // navigation surface, so the page header only needs the section title.
 // Section cards carry their own h2 title + description.
 //
-// Phase 3 will extend this to fetch the runtime-settings map and pass it into
-// each section's `build` (mirroring newapi's SettingsPage + useSystemOptions).
+// Runtime settings are not fetched here: each section takes a `serverValues`
+// snapshot of its own slice (see ../hooks/use-settings-form), so opening one
+// subarea does not pay for the others.
 
 import { Suspense } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/web/src/features/settings/hooks/use-settings-form.ts
+++ b/web/src/features/settings/hooks/use-settings-form.ts
@@ -1,9 +1,11 @@
 // metapi-go/features/settings/hooks — unified settings form hook.
 //
-// Mirrors the newapi `useSettingsForm` interaction: a server baseline that is
-// updated only when the server payload actually changes, dirty-only diffing
-// on submit, and a reset that restores the last server state. Sections opt in
-// by passing a `serverValues` snapshot derived from GET /api/settings/runtime.
+// The interaction every settings section shares: a server baseline that is
+// refreshed only when the server payload actually changes (so a background
+// refetch cannot discard what the user is typing), dirty-only diffing on submit
+// (so an untouched field is never written back), and a reset that restores the
+// last server state rather than the form's initial one. Sections opt in by
+// passing a `serverValues` snapshot derived from GET /api/settings/runtime.
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useCallback, useEffect, useRef } from 'react'

--- a/web/src/hooks/use-sidebar-view.ts
+++ b/web/src/hooks/use-sidebar-view.ts
@@ -1,47 +1,28 @@
-// metapi-go/hooks — use-sidebar-view ported from newapi, simplified for metapi.
-// metapi has no role-based filtering (fully open) and no server-side module gating,
-// so this hook only resolves the nested drill-in view (Settings) vs root nav.
+// metapi-go/hooks — useSidebarView: which navigation set the current URL selects.
+//
+// The root sidebar and a drill-in workspace are mutually exclusive, so this is a
+// single lookup: `resolveSidebarView(pathname)` returns the registered view whose
+// path pattern matches, or null for the root navigation. The returned `key` is
+// what the sidebar animates on when the two swap.
+//
+// There is no role or module filtering here. metapi's routes are open and the
+// route guards own access, so this hook resolves a view — it does not authorise
+// one.
 
 import { useLocation } from '@tanstack/react-router'
-import { useMemo } from 'react'
 
+import { ROOT_NAVIGATION } from '@/components/layout/config/root-navigation'
 import { resolveSidebarView } from '@/components/layout/lib/sidebar-view-registry'
-import type { NavGroup, ResolvedSidebarView } from '@/components/layout/types'
+import type { ResolvedSidebarView } from '@/components/layout/types'
 
-import { useSidebarData } from './use-sidebar-data'
-
-/** Sentinel key used for the root navigation in animation `key=` props */
+/** Animation key for the root navigation, which has no view id of its own. */
 const ROOT_VIEW_KEY = '__root'
 
-/**
- * Resolve the active sidebar view for the current location.
- *
- * - Returns the matching nested SidebarView (with its nav groups) when the
- *   URL belongs to a registered drill-in workspace (e.g. /settings/*).
- * - Otherwise returns the root navigation from useSidebarData unfiltered.
- */
 export function useSidebarView(): ResolvedSidebarView {
-  const pathname = useLocation({ select: (l) => l.pathname })
-  const rootSidebarData = useSidebarData()
-
-  const rootNavGroups = useMemo<NavGroup[]>(
-    () => rootSidebarData.navGroups,
-    [rootSidebarData]
-  )
-
+  const pathname = useLocation({ select: (location) => location.pathname })
   const view = resolveSidebarView(pathname)
 
-  if (view) {
-    return {
-      key: view.id,
-      view,
-      navGroups: view.getNavGroups(),
-    }
-  }
-
-  return {
-    key: ROOT_VIEW_KEY,
-    view: null,
-    navGroups: rootNavGroups,
-  }
+  return view
+    ? { key: view.id, navGroups: view.getNavGroups(), view }
+    : { key: ROOT_VIEW_KEY, navGroups: ROOT_NAVIGATION.navGroups, view: null }
 }

--- a/web/src/routes/_authenticated/dashboard/$section.tsx
+++ b/web/src/routes/_authenticated/dashboard/$section.tsx
@@ -2,7 +2,8 @@
 //
 // Leaf route for `/dashboard/$section`. `beforeLoad` validates the section id
 // against the dashboard manifest (redirects to the default section on
-// mismatch), mirroring newapi's `dashboard/$section.tsx`. The component
+// mismatch), so a bookmarked or hand-edited section id can never render an
+// empty tab strip. The component
 // renders `DashboardPage` with the active section + a navigate-backed
 // `onSectionChange` so the Tabs switch routes (the dashboard feature stays
 // presentational; the route layer owns URL state).


### PR DESCRIPTION
## What

The layout shell and its navigation model were the last subsystem whose headers claimed another project as their source. Rewritten where the code was inherited, corrected where it was already metapi's own, and reorganised where the two had left the layering muddled.

### Reorganised

`hooks/use-sidebar-data.ts` was not a hook — it called no hooks and returned a module constant. It is now `components/layout/config/root-navigation.ts` exporting `ROOT_NAVIGATION`, beside `system-settings.config.ts` (the Settings view's equivalent), so `hooks/` holds only real hooks and both navigation configs live in one place. Its two readers (`use-sidebar-view`, `search-modal`) import the constant directly, which also retires a `useMemo` in each that was memoising a value with a permanent identity.

### Rewritten

- **`layout/lib/url-utils.ts`** — the leaf match and the branch's child match were two copies of the same rule, and the child copy carried a branch that could never be taken (an exact-match check *after* the identical exact-match check). One `selects()` predicate owns it now. The genuinely different rule (`activeUrls`, which is query-aware in the opposite direction) stays separate rather than being folded in.
- **`hooks/use-sidebar-view.ts`** — the `useMemo` around a property read of a module constant is gone.
- **`layout/components/sidebar-view-header.tsx`** — props destructured, the doubled `cn()` of two static strings collapsed, and `t(view.parent.label)` resolved once so the visible label and the collapsed-rail tooltip cannot drift.

### Prose corrected, code unchanged

Verified metapi's own by line-level comparison against the upstream file — 14–37% substantive overlap, all of it import lines, prop names and className strings dictated by metapi's own types and the ui primitives' APIs:

`nav-group.tsx` · `app-sidebar.tsx` · `authenticated-layout.tsx` · `layout/types.ts` · `system-settings.config.ts` · `sidebar-view-registry.ts`

### Stale claims removed while there

- `layout/types.ts` said i18n "lands in phase 2, so nav builders return plain strings for now" — every title in it is already an i18n key resolved with `t()`.
- `app-sidebar.tsx` justified its sidebar constants as "skeleton defaults" a later phase would replace.
- `dashboard-page.tsx` and `settings-page.tsx` both carried "Phase 3 will…" notes, and the settings one contradicted the code (sections already take a `serverValues` snapshot).
- `web/AGENTS.md` named the wrong compatibility target: it is the metapi TypeScript client contract (camelCase fields, env var names, SQLite/PG dual dialect), not another project's stack.

## Tests

No new tests needed for behaviour that did not change; the existing guards are the point of the refactor:

- `layout/lib/__tests__/url-utils.test.ts` — 9 cases pinning exactly the rules `selects()` folded together (exact match, `activePrefix` subtree and its non-leak to siblings, hash ignored, `activeUrls` bare-path vs query-pinned).
- `layout/__tests__/search-modal.test.tsx` — the navigation layer of the palette, now reading `ROOT_NAVIGATION`.
- `layout/__tests__/header-height-ssot`, `user-menu`, `attention-bell`, plus the settings/dashboard/route suites.

## Gates

- `bun run lint` → oxlint clean, boundaries **685/0**, FormControl **140/0**
- `bun run format:check` · `bun run knip` · `bun run routes:verify` (28/28)
- `bun run vitest run --maxWorkers=1` → **260 files / 1684 tests passed**
- `tsgo -b` cannot run on the 2C/4G dev host (OOM-killed); CI `frontend` is the typecheck authority.