### PR TITLE
refactor(web): rewrite the auth-redirect guard, and test it

### DIFF
--- a/web/src/lib/helpers/__tests__/sanitize-auth-redirect.test.ts
+++ b/web/src/lib/helpers/__tests__/sanitize-auth-redirect.test.ts
@@ -1,0 +1,70 @@
+// metapi-go/lib/helpers — the open-redirect guard's accept/reject matrix.
+//
+// This function is the only thing standing between an attacker-controlled
+// `?redirect=` and a `navigate()` after login, and it is called from three
+// places that must agree (sign-in route, login form, HTTP client 401). Every
+// branch it has is therefore pinned here: the shapes it accepts, the shapes it
+// refuses, and the fact that what it returns can never carry an origin.
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeAuthRedirect } from '../sanitize-auth-redirect'
+
+const ORIGIN = 'https://metapi.example'
+
+describe('sanitizeAuthRedirect accepts same-origin targets', () => {
+  it.each([
+    ['/dashboard', '/dashboard'],
+    ['/models?q=gpt-4o#top', '/models?q=gpt-4o#top'],
+    ['  /sites  ', '/sites'],
+    ['https://metapi.example/sites', '/sites'],
+    ['HTTPS://METAPI.EXAMPLE/sites?a=1', '/sites?a=1'],
+    ['/', '/'],
+  ])('sanitizes %s to %s', (input, expected) => {
+    expect(sanitizeAuthRedirect(input, ORIGIN)).toBe(expected)
+  })
+
+  it('never returns an origin, so the router cannot re-parse one', () => {
+    const result = sanitizeAuthRedirect('https://metapi.example/a?b#c', ORIGIN)
+    expect(result).toBe('/a?b#c')
+    expect(result).not.toContain('//')
+  })
+})
+
+describe('sanitizeAuthRedirect refuses everything else', () => {
+  it.each([
+    ['another origin', 'https://evil.example/steal'],
+    ['protocol-relative', '//evil.example/steal'],
+    ['backslash normalised to protocol-relative', '/\\evil.example/steal'],
+    ['javascript scheme', 'javascript:alert(1)'],
+    ['data scheme', 'data:text/html,<script>alert(1)</script>'],
+    ['non-http scheme on the trusted host', 'ftp://metapi.example/x'],
+    ['empty string', ''],
+    ['whitespace only', '   '],
+  ])('rejects %s', (_label, input) => {
+    expect(sanitizeAuthRedirect(input, ORIGIN)).toBeNull()
+  })
+
+  it.each([
+    ['null', null],
+    ['a number', 42],
+    ['an object', { pathname: '/dashboard' }],
+    ['an array', ['/dashboard']],
+    ['undefined', undefined],
+  ])('rejects non-string input (%s)', (_label, input) => {
+    expect(sanitizeAuthRedirect(input, ORIGIN)).toBeNull()
+  })
+
+  it.each([
+    ['not a URL', 'metapi.example'],
+    ['empty', ''],
+    ['non-http origin', 'ftp://metapi.example'],
+  ])(
+    'rejects an untrustworthy origin (%s) rather than trusting every target',
+    (_label, origin) => {
+      expect(sanitizeAuthRedirect('/dashboard', origin)).toBeNull()
+      expect(
+        sanitizeAuthRedirect('https://metapi.example/dashboard', origin)
+      ).toBeNull()
+    }
+  )
+})

--- a/web/src/lib/helpers/sanitize-auth-redirect.ts
+++ b/web/src/lib/helpers/sanitize-auth-redirect.ts
@@ -1,17 +1,29 @@
-// metapi-go/lib/helpers — auth-redirect sanitizer.
-// Prevents open-redirect attacks by constraining the `redirect` search param
-// to same-origin paths. Ported from newapi (simplified: no getSavedLanguage
-// since metapi-go tokens carry no user profile in the skeleton).
+// metapi-go/lib/helpers — sanitizeAuthRedirect: the open-redirect guard behind
+// every post-authentication jump.
 //
-// Lives in lib/ (not features/auth) because the shared HTTP client
-// (src/lib/http-client.ts) applies the same whitelist when building its 401
-// sign-in redirect — lib must never import from features/.
+// Three callers depend on it agreeing with itself, which is why the rule lives in
+// one function instead of at each site: the sign-in route validates its
+// `redirect` search param, the login form validates the value it is about to
+// navigate to, and the shared HTTP client (lib/http-client.ts) validates the
+// return target it builds for a 401. It sits in lib/ rather than features/auth
+// because lib must never import from features/.
+//
+// Accepted: a root-relative path, or an absolute http(s) URL on this exact
+// origin. Returned: pathname + search + hash only, so no origin ever travels back
+// into a location the router would re-parse.
+//
+// Rejected (null): anything else — another origin, a `//host` protocol-relative
+// form, a backslash (browsers normalise `/\evil.example` into `//evil.example`),
+// a non-http(s) scheme such as `javascript:` or `data:`, non-string input, and an
+// `origin` that is not itself a trustworthy http(s) URL.
 
-const allowedRedirectProtocols = new Set(['http:', 'https:'])
+const SAFE_PROTOCOLS = new Set(['http:', 'https:'])
 
 /**
- * Sanitize a post-login redirect target. Accepts only same-origin absolute
- * or root-relative paths; returns the path+search+hash or null if unsafe.
+ * Sanitise a post-login redirect target against `origin`.
+ *
+ * @returns the path, query and fragment to navigate to, or null when the value
+ *          must not be followed.
  */
 export function sanitizeAuthRedirect(
   value: unknown,
@@ -20,31 +32,42 @@ export function sanitizeAuthRedirect(
   if (typeof value !== 'string') return null
 
   const target = value.trim()
-  if (!target || target.includes('\\') || target.startsWith('//')) return null
+  if (target === '' || target.includes('\\') || target.startsWith('//')) {
+    return null
+  }
 
-  let trustedOrigin: URL
+  const trustedOrigin = parseTrustedOrigin(origin)
+  if (trustedOrigin === null) return null
+
+  const resolved = resolveTarget(target, trustedOrigin)
+  if (resolved === null) return null
+  if (!SAFE_PROTOCOLS.has(resolved.protocol)) return null
+  if (resolved.origin !== trustedOrigin) return null
+
+  return `${resolved.pathname}${resolved.search}${resolved.hash}`
+}
+
+/**
+ * The origin to trust, or null when `origin` is not an http(s) URL. Checked
+ * first so a caller that hands over a hostile or malformed origin cannot turn
+ * every absolute target into a "same-origin" one.
+ */
+function parseTrustedOrigin(origin: string): string | null {
   try {
-    trustedOrigin = new URL(origin)
+    const url = new URL(origin)
+    return SAFE_PROTOCOLS.has(url.protocol) ? url.origin : null
   } catch {
     return null
   }
-  if (!allowedRedirectProtocols.has(trustedOrigin.protocol)) return null
+}
 
-  let redirectURL: URL
+/** Resolves a root-relative or absolute target; null when it does not parse. */
+function resolveTarget(target: string, trustedOrigin: string): URL | null {
   try {
-    redirectURL = target.startsWith('/')
-      ? new URL(target, trustedOrigin.origin)
+    return target.startsWith('/')
+      ? new URL(target, trustedOrigin)
       : new URL(target)
   } catch {
     return null
   }
-
-  if (
-    !allowedRedirectProtocols.has(redirectURL.protocol) ||
-    redirectURL.origin !== trustedOrigin.origin
-  ) {
-    return null
-  }
-
-  return `${redirectURL.pathname}${redirectURL.search}${redirectURL.hash}`
 }


### PR DESCRIPTION
## Why

`sanitizeAuthRedirect` is the only thing between an attacker-controlled `?redirect=` and a `navigate()` after login, and three call sites depend on it agreeing with itself:

| caller | what it validates |
| --- | --- |
| `routes/sign-in.tsx` | the `redirect` search param |
| `features/auth/components/login-form.tsx` | the target it is about to navigate to |
| `lib/http-client.ts` | the return target it builds for a 401 |

It had **no test at all**.

## What

Rewritten as one documented rule, with the two parsing steps named for what they actually decide instead of four inline `try`/`catch` blocks:

- `parseTrustedOrigin` — an `origin` that is not itself a trustworthy http(s) URL must not turn every absolute target into a "same-origin" one;
- `resolveTarget` — root-relative resolves against the trusted origin, anything else has to parse on its own.

**Behaviour is unchanged, deliberately.** Same accept set, same rejections, same `pathname + search + hash` return that can never carry an origin back into a location the router would re-parse.

## Tests

New `lib/helpers/__tests__/sanitize-auth-redirect.test.ts` pins the matrix the function exists for.

Accepted: `/dashboard` · `/models?q=gpt-4o#top` · surrounding whitespace · `https://<origin>/sites` · upper-case scheme and host · `/`. Plus an assertion that the result never contains `//`.

Refused: another origin · `//evil.example` · a backslash (browsers normalise `/\evil.example` into `//evil.example`) · `javascript:` · `data:` · a non-http scheme on the trusted host · empty and whitespace-only input · every non-string shape (null / number / object / array / undefined) · an untrustworthy `origin` — the last checked against **both** a relative and an absolute target, because that is the pair that would silently pass if the origin check were ever dropped.

## Gates

- `bun run lint` → oxlint clean, boundaries **686/0**, FormControl **140/0**
- `bun run format:check` · `bun run knip` · `bun run routes:verify` (28/28)
- `bun run vitest run --maxWorkers=1` → **261 files / 1707 tests passed**
- `tsgo -b` cannot run on the 2C/4G dev host (OOM-killed); CI `frontend` is the typecheck authority.