### PR TITLE
refactor(web): rewrite the data-table row and card rendering

### DIFF
--- a/web/src/components/data-table/core/pagination.tsx
+++ b/web/src/components/data-table/core/pagination.tsx
@@ -1,10 +1,21 @@
-// metapi-go/data-table — ported from newapi
+// metapi-go/data-table — DataTablePagination: the table footer's page controls.
+//
+// Right-aligned and container-query driven (`@container/pagination`) rather than
+// viewport driven, because the table is not the whole viewport: it sits inside a
+// sidebar-inset panel that can be narrowed independently of the window. Labels
+// and the first/last buttons drop out as the *container* tightens, so the page
+// numbers — the part that actually navigates — are the last thing to go.
+//
+// Every icon button carries an `sr-only` label; the glyphs alone do not name the
+// action, and "chevron left" is not "previous page".
+
 import type { Table } from '@tanstack/react-table'
 import {
   ChevronLeft as ChevronLeftIcon,
   ChevronRight as ChevronRightIcon,
   ChevronsLeft as DoubleArrowLeftIcon,
   ChevronsRight as DoubleArrowRightIcon,
+  type LucideIcon,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -19,39 +30,68 @@ import {
 } from '@/components/ui/select'
 import { cn, getPageNumbers } from '@/lib/utils'
 
-type DataTablePaginationProps<TData> = {
-  table: Table<TData>
-}
-
+/** Page sizes offered in the selector. */
 const PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50, 100] as const
+
+/** `items` gives the Select its value→label map, so it can render the current
+ *  size even before the list is opened. */
 const PAGE_SIZE_SELECT_ITEMS = PAGE_SIZE_OPTIONS.map((pageSize) => ({
   value: `${pageSize}`,
   label: pageSize,
 }))
 
-export function DataTablePagination<TData>({
-  table,
-}: DataTablePaginationProps<TData>) {
+const STEP_BUTTON_CLASS =
+  'text-muted-foreground hover:text-foreground disabled:text-muted-foreground/50 size-8 p-0'
+/** The first/last pair is the first thing dropped when the footer gets tight. */
+const EDGE_BUTTON_CLASS = `${STEP_BUTTON_CLASS} @max-lg/pagination:hidden`
+
+type NavButtonProps = {
+  className: string
+  disabled: boolean
+  icon: LucideIcon
+  label: string
+  onClick: () => void
+}
+
+function NavButton({
+  className,
+  disabled,
+  icon: Icon,
+  label,
+  onClick,
+}: NavButtonProps) {
+  return (
+    <Button
+      variant='outline'
+      className={className}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <span className='sr-only'>{label}</span>
+      <Icon className='h-4 w-4' />
+    </Button>
+  )
+}
+
+export function DataTablePagination<TData>({ table }: { table: Table<TData> }) {
   const { t } = useTranslation()
-  const pagination = table.getState().pagination
-  const currentPage = pagination.pageIndex + 1
-  const pageSize = pagination.pageSize
+  const { pageIndex, pageSize } = table.getState().pagination
+  const currentPage = pageIndex + 1
   const totalPages = table.getPageCount()
-  const totalRows = table.getRowCount()
   const pageNumbers = getPageNumbers(currentPage, totalPages)
 
   return (
+    // `overflow-clip` keeps a long page-number run from stretching the footer;
+    // the 1px clip margin leaves the buttons' focus ring intact at the edge.
     <div
-      className={cn(
-        '@container/pagination flex min-w-0 items-center justify-end overflow-clip'
-      )}
+      className='@container/pagination flex min-w-0 items-center justify-end overflow-clip'
       style={{ overflowClipMargin: 1 }}
     >
       <div className='flex min-w-0 shrink-0 items-center gap-2 @xl/pagination:gap-3'>
         <div className='flex shrink-0 items-baseline gap-1.5 text-xs font-medium whitespace-nowrap sm:text-sm'>
           <span className='text-muted-foreground'>{t('Total:')}</span>
           <span className='text-foreground tabular-nums'>
-            {totalRows.toLocaleString()}
+            {table.getRowCount().toLocaleString()}
           </span>
         </div>
 
@@ -62,9 +102,7 @@ export function DataTablePagination<TData>({
           <Select
             items={PAGE_SIZE_SELECT_ITEMS}
             value={`${pageSize}`}
-            onValueChange={(value) => {
-              table.setPageSize(Number(value))
-            }}
+            onValueChange={(value) => table.setPageSize(Number(value))}
           >
             <SelectTrigger
               aria-label={t('Rows per page')}
@@ -74,9 +112,9 @@ export function DataTablePagination<TData>({
             </SelectTrigger>
             <SelectContent side='top' alignItemWithTrigger={false}>
               <SelectGroup>
-                {PAGE_SIZE_OPTIONS.map((pageSize) => (
-                  <SelectItem key={pageSize} value={`${pageSize}`}>
-                    {pageSize}
+                {PAGE_SIZE_OPTIONS.map((option) => (
+                  <SelectItem key={option} value={`${option}`}>
+                    {option}
                   </SelectItem>
                 ))}
               </SelectGroup>
@@ -85,26 +123,24 @@ export function DataTablePagination<TData>({
         </div>
 
         <div className='flex min-w-0 shrink-0 items-center gap-1 @lg/pagination:gap-1.5 @xl/pagination:gap-2'>
-          <Button
-            variant='outline'
-            className='text-muted-foreground hover:text-foreground disabled:text-muted-foreground/50 size-8 p-0 @max-lg/pagination:hidden'
+          <NavButton
+            className={EDGE_BUTTON_CLASS}
+            disabled={!table.getCanPreviousPage()}
+            icon={DoubleArrowLeftIcon}
+            label={t('Go to first page')}
             onClick={() => table.setPageIndex(0)}
+          />
+          <NavButton
+            className={STEP_BUTTON_CLASS}
             disabled={!table.getCanPreviousPage()}
-          >
-            <span className='sr-only'>{t('Go to first page')}</span>
-            <DoubleArrowLeftIcon className='h-4 w-4' />
-          </Button>
-          <Button
-            variant='outline'
-            className='text-muted-foreground hover:text-foreground disabled:text-muted-foreground/50 size-8 p-0'
+            icon={ChevronLeftIcon}
+            label={t('Go to previous page')}
             onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            <span className='sr-only'>{t('Go to previous page')}</span>
-            <ChevronLeftIcon className='h-4 w-4' />
-          </Button>
+          />
 
           {pageNumbers.map((pageNumber, index) => (
+            // `getPageNumbers` can emit more than one `'...'` gap, so the index is
+            // part of the key: without it the two gaps collide.
             // eslint-disable-next-line react/no-array-index-key
             <div key={`${pageNumber}-${index}`} className='flex items-center'>
               {pageNumber === '...' ? (
@@ -131,24 +167,20 @@ export function DataTablePagination<TData>({
             </div>
           ))}
 
-          <Button
-            variant='outline'
-            className='text-muted-foreground hover:text-foreground disabled:text-muted-foreground/50 size-8 p-0'
+          <NavButton
+            className={STEP_BUTTON_CLASS}
+            disabled={!table.getCanNextPage()}
+            icon={ChevronRightIcon}
+            label={t('Go to next page')}
             onClick={() => table.nextPage()}
+          />
+          <NavButton
+            className={EDGE_BUTTON_CLASS}
             disabled={!table.getCanNextPage()}
-          >
-            <span className='sr-only'>{t('Go to next page')}</span>
-            <ChevronRightIcon className='h-4 w-4' />
-          </Button>
-          <Button
-            variant='outline'
-            className='text-muted-foreground hover:text-foreground disabled:text-muted-foreground/50 size-8 p-0 @max-lg/pagination:hidden'
-            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-            disabled={!table.getCanNextPage()}
-          >
-            <span className='sr-only'>{t('Go to last page')}</span>
-            <DoubleArrowRightIcon className='h-4 w-4' />
-          </Button>
+            icon={DoubleArrowRightIcon}
+            label={t('Go to last page')}
+            onClick={() => table.setPageIndex(totalPages - 1)}
+          />
         </div>
       </div>
     </div>

--- a/web/src/components/data-table/layout/card-row-content.tsx
+++ b/web/src/components/data-table/layout/card-row-content.tsx
@@ -1,94 +1,114 @@
-// metapi-go/data-table — ported from newapi
+// metapi-go/data-table — CardRowContent: one row rendered as a card.
+//
+// The mobile list and the desktop card grid differ only in their container (a
+// single bordered list versus a responsive grid), so the per-row content lives
+// here and both render the same thing. That is the whole reason this module
+// exists: a card that looks different on a phone and on a narrow desktop window
+// is a bug nobody would think to file.
+//
+// Two layouts, chosen per table by `tableHasCompactMeta`:
+//
+//   compact    a column declared `mobileTitle` / `mobileBadge`, so the card gets
+//              a header row — title left, badge right — and the rest of the
+//              fields wrap into two columns beneath it, with the action menu on
+//              its own bottom-right row.
+//   condensed  no column declared either, so every field renders as a
+//              label/value line. Used by tables that were never given a card
+//              design and still have to be readable on a phone.
+//
+// `mobileHidden` is honoured by both, and `mobileOrder` decides field order.
+// Badges render through `StatusBadgeTypeContext` as `text` rather than as chips:
+// a chip's background and border cost more than a card row has room for.
+
 import type { Cell, Row } from '@tanstack/react-table'
-import * as React from 'react'
 
 import { StatusBadgeTypeContext } from '../core/status-badge'
 import { getCellLabel, renderCellContent } from './card-cell-utils'
 
-function orderCardCells<TData>(
-  cells: Cell<TData, unknown>[]
-): Cell<TData, unknown>[] {
-  return [...cells].sort((a, b) => {
-    const aOrder = a.column.columnDef.meta?.mobileOrder
-    const bOrder = b.column.columnDef.meta?.mobileOrder
+type CardCells<TData> = {
+  actions: Cell<TData, unknown> | undefined
+  badge: Cell<TData, unknown> | undefined
+  fields: Cell<TData, unknown>[]
+  title: Cell<TData, unknown> | undefined
+}
 
-    if (aOrder == null && bOrder == null) return 0
-    if (aOrder == null) return 1
-    if (bOrder == null) return -1
-    return aOrder - bOrder
+/**
+ * Splits a row's visible cells into the roles the card layout needs.
+ *
+ * The selection column is dropped (the card is not selectable in place) and the
+ * action menu is pulled out of the field flow so it can sit bottom-right. Title
+ * and badge are only looked for in the compact layout: in the condensed one they
+ * are ordinary fields, which is what makes the two layouts share this function.
+ */
+function cardCells<TData>(row: Row<TData>, compact: boolean): CardCells<TData> {
+  const cells = row
+    .getVisibleCells()
+    .filter((cell) => cell.column.id !== 'select')
+  const actions = cells.find((cell) => cell.column.id === 'actions')
+  const title = compact
+    ? cells.find((cell) => cell.column.columnDef.meta?.mobileTitle)
+    : undefined
+  const badge = compact
+    ? cells.find((cell) => cell.column.columnDef.meta?.mobileBadge)
+    : undefined
+
+  const fields = inMobileOrder(
+    cells.filter(
+      (cell) =>
+        cell !== title &&
+        cell !== badge &&
+        cell !== actions &&
+        !cell.column.columnDef.meta?.mobileHidden
+    )
+  )
+
+  return { actions, badge, fields, title }
+}
+
+/**
+ * Fields by `mobileOrder`, unordered ones last. `Array.prototype.sort` is
+ * stable, so "no order declared" keeps the table's own column order rather than
+// reshuffling it.
+ */
+function inMobileOrder<TData>(cells: Cell<TData, unknown>[]) {
+  return [...cells].sort((a, b) => {
+    const left = a.column.columnDef.meta?.mobileOrder
+    const right = b.column.columnDef.meta?.mobileOrder
+
+    if (left == null && right == null) return 0
+    if (left == null) return 1
+    if (right == null) return -1
+    return left - right
   })
 }
 
 /**
- * Shared, column-meta-driven card content rendering for TanStack rows.
- *
- * Both {@link MobileCardList} (mobile) and {@link DataTableCardGrid} (desktop
- * card view) render the same inner content; only the surrounding container
- * differs (single bordered list vs. responsive grid of cards). Keeping the
- * per-row content here guarantees the two stay visually consistent.
- *
- * Column meta extensions (see `card-cell-utils.ts`):
- * - `mobileTitle`  — card header (left, larger text)
- * - `mobileBadge`  — inline with title (right, e.g. status badge)
- * - `mobileHidden` — hidden in card content
- */
-
-/**
- * Compact content — structured layout with title header + side-by-side fields.
- * Used when columns define mobileTitle or mobileBadge meta.
- *
- * Visual structure:
- *   [Title content]             [Badge]
- *   [Field1 label] [Field2 label]
- *   [Field1 value] [Field2 value]
- *                          [Actions ⋯]
+ * Header row plus a two-column field grid. The grid is what keeps a card with
+ * six fields short: fields wrap into columns instead of squeezing onto one line.
  */
 function CompactContent<TData>({ row }: { row: Row<TData> }) {
-  const allCells = row
-    .getVisibleCells()
-    .filter((cell) => cell.column.id !== 'select')
-
-  // Read each cell's meta once, then reuse for all categorisation checks.
-  const cellMetas = React.useMemo(
-    () => allCells.map((c) => c.column.columnDef.meta),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [allCells.map((c) => c.id).join(',')]
-  )
-
-  const titleCell = allCells.find((_, i) => cellMetas[i]?.mobileTitle)
-  const badgeCell = allCells.find((_, i) => cellMetas[i]?.mobileBadge)
-  const actionsCell = allCells.find((c) => c.column.id === 'actions')
-  const fieldCells = orderCardCells(
-    allCells.filter(
-      (c, i) =>
-        c !== titleCell &&
-        c !== badgeCell &&
-        c !== actionsCell &&
-        !cellMetas[i]?.mobileHidden
-    )
-  )
+  const { actions, badge, fields, title } = cardCells(row, true)
 
   return (
     <>
-      {/* Row 1: Title + Badge */}
       <div className='flex items-center justify-between gap-2'>
-        {titleCell && (
+        {title && (
           <div className='min-w-0 flex-1 text-sm font-medium [&_[data-slot=status-badge]]:max-w-full [&_[data-slot=status-badge]]:whitespace-normal'>
-            {renderCellContent(titleCell)}
+            {renderCellContent(title)}
           </div>
         )}
-        {badgeCell && (
+        {badge && (
           <div className='flex-none [&_[data-slot=status-badge]]:max-w-none'>
-            {renderCellContent(badgeCell)}
+            {renderCellContent(badge)}
           </div>
         )}
       </div>
 
-      {/* Row 2: Key fields wrap into compact columns instead of squeezing */}
-      {fieldCells.length > 0 && (
+      {fields.length > 0 && (
         <div className='mt-1.5 grid grid-cols-2 gap-x-3 gap-y-1.5'>
-          {fieldCells.map((cell) => {
+          {fields.map((cell) => {
             const label = getCellLabel(cell)
+
             return (
               <div key={cell.id} className='min-w-0 flex-1 overflow-hidden'>
                 {label && (
@@ -97,9 +117,7 @@ function CompactContent<TData>({ row }: { row: Row<TData> }) {
                   </div>
                 )}
                 <div className='min-w-0 overflow-hidden text-xs [&_:is([data-slot=badge-cell],[data-slot=provider-badge],[data-slot=status-badge])]:ml-0'>
-                  <StatusBadgeTypeContext.Provider value='text'>
-                    {renderCellContent(cell) ?? '-'}
-                  </StatusBadgeTypeContext.Provider>
+                  {renderCellContent(cell) ?? '-'}
                 </div>
               </div>
             )
@@ -107,10 +125,9 @@ function CompactContent<TData>({ row }: { row: Row<TData> }) {
         </div>
       )}
 
-      {/* Actions */}
-      {actionsCell && (
+      {actions && (
         <div className='mt-1 -mb-0.5 flex justify-end'>
-          {renderCellContent(actionsCell)}
+          {renderCellContent(actions)}
         </div>
       )}
     </>
@@ -118,30 +135,16 @@ function CompactContent<TData>({ row }: { row: Row<TData> }) {
 }
 
 /**
- * Fallback content — condensed label:value pairs for tables without
- * mobileTitle/mobileBadge. Still respects mobileHidden.
+ * One label/value line per field. A field with no label takes the whole width
+ * and right-aligns, which is how a lone status or icon column stays readable
+ * without an empty label gutter beside it.
  */
-function FallbackContent<TData>({ row }: { row: Row<TData> }) {
-  const allCells = row
-    .getVisibleCells()
-    .filter((cell) => cell.column.id !== 'select')
-
-  const cellMetas = React.useMemo(
-    () => allCells.map((c) => c.column.columnDef.meta),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [allCells.map((c) => c.id).join(',')]
-  )
-
-  const actionsCell = allCells.find((c) => c.column.id === 'actions')
-  const contentCells = orderCardCells(
-    allCells.filter(
-      (c, i) => c.column.id !== 'actions' && !cellMetas[i]?.mobileHidden
-    )
-  )
+function CondensedContent<TData>({ row }: { row: Row<TData> }) {
+  const { actions, fields } = cardCells(row, false)
 
   return (
     <>
-      {contentCells.map((cell) => {
+      {fields.map((cell) => {
         const label = getCellLabel(cell)
 
         if (!label) {
@@ -150,9 +153,7 @@ function FallbackContent<TData>({ row }: { row: Row<TData> }) {
               key={cell.id}
               className='flex justify-end overflow-hidden [&_:is([data-slot=badge-cell],[data-slot=provider-badge],[data-slot=status-badge])]:ml-0'
             >
-              <StatusBadgeTypeContext.Provider value='text'>
-                {renderCellContent(cell)}
-              </StatusBadgeTypeContext.Provider>
+              {renderCellContent(cell)}
             </div>
           )
         }
@@ -166,16 +167,15 @@ function FallbackContent<TData>({ row }: { row: Row<TData> }) {
               {label}
             </span>
             <div className='flex min-w-0 flex-1 items-center justify-end overflow-hidden text-xs [&_:is([data-slot=badge-cell],[data-slot=provider-badge],[data-slot=status-badge])]:ml-0'>
-              <StatusBadgeTypeContext.Provider value='text'>
-                {renderCellContent(cell) ?? '-'}
-              </StatusBadgeTypeContext.Provider>
+              {renderCellContent(cell) ?? '-'}
             </div>
           </div>
         )
       })}
-      {actionsCell && (
+
+      {actions && (
         <div className='-mb-0.5 flex justify-end pt-0.5'>
-          {renderCellContent(actionsCell)}
+          {renderCellContent(actions)}
         </div>
       )}
     </>
@@ -183,17 +183,25 @@ function FallbackContent<TData>({ row }: { row: Row<TData> }) {
 }
 
 /**
- * Renders a single row's card content, auto-selecting the compact or fallback
- * layout. Callers compute `compact` once per table (via `tableHasCompactMeta`)
- * and pass it down to avoid recomputation per row.
+ * A single row's card content.
+ *
+ * `compact` is decided once per table by the caller (`tableHasCompactMeta`), not
+ * per row: every card in a list has to have the same shape, and recomputing the
+ * scan for each row would be pure waste.
+ *
+ * The badge-type provider wraps the whole card rather than each field, so both
+ * layouts declare it once.
  */
-export function CardRowContent<TData>(props: {
+export function CardRowContent<TData>({
+  row,
+  compact,
+}: {
   row: Row<TData>
   compact: boolean
 }) {
-  return props.compact ? (
-    <CompactContent row={props.row} />
-  ) : (
-    <FallbackContent row={props.row} />
+  return (
+    <StatusBadgeTypeContext.Provider value='text'>
+      {compact ? <CompactContent row={row} /> : <CondensedContent row={row} />}
+    </StatusBadgeTypeContext.Provider>
   )
 }

--- a/web/src/components/data-table/layout/mobile-card-list.tsx
+++ b/web/src/components/data-table/layout/mobile-card-list.tsx
@@ -1,4 +1,12 @@
-// metapi-go/data-table — ported from newapi
+// metapi-go/data-table — MobileCardList: the narrow-viewport rendering of a table.
+//
+// Not a grid of cards: rows sit in one bordered container separated by dividers,
+// because at phone width the gaps between separate cards cost more vertical space
+// than they add clarity. Per-row content is `CardRowContent`, shared with the
+// desktop card grid so the two cannot drift.
+//
+// A row is clickable only when the table has a selection column, and only on its
+// bare surface — see `isInteractiveTarget`.
 import type { Row, Table } from '@tanstack/react-table'
 import { Database } from 'lucide-react'
 import * as React from 'react'
@@ -27,10 +35,19 @@ interface MobileCardListProps<TData> {
   getRowClassName?: (row: Row<TData>) => string | undefined
 }
 
+/** The bordered, divided shell both skeletons share with the real list. */
+function SkeletonList({ children }: { children: React.ReactNode }) {
+  return (
+    <div className='divide-y overflow-hidden rounded-lg border'>{children}</div>
+  )
+}
+
+const SKELETON_ROWS = [1, 2, 3, 4, 5]
+
 function ListSkeleton() {
   return (
-    <div className='divide-y overflow-hidden rounded-lg border'>
-      {[1, 2, 3, 4, 5].map((i) => (
+    <SkeletonList>
+      {SKELETON_ROWS.map((i) => (
         <div key={i} className='px-3 py-2.5'>
           <div className='flex items-center justify-between'>
             <Skeleton className='h-4 w-32' />
@@ -48,14 +65,14 @@ function ListSkeleton() {
           </div>
         </div>
       ))}
-    </div>
+    </SkeletonList>
   )
 }
 
 function FallbackListSkeleton() {
   return (
-    <div className='divide-y overflow-hidden rounded-lg border'>
-      {[1, 2, 3, 4, 5].map((i) => (
+    <SkeletonList>
+      {SKELETON_ROWS.map((i) => (
         <div key={i} className='space-y-1.5 px-3 py-2.5'>
           {[1, 2, 3].map((j) => (
             <div key={j} className='flex items-center justify-between'>
@@ -65,20 +82,25 @@ function FallbackListSkeleton() {
           ))}
         </div>
       ))}
-    </div>
+    </SkeletonList>
   )
 }
 
 /**
- * Mobile-optimized list view for table data.
- *
- * Renders rows inside a single bordered container with dividers —
- * a Vercel/Stripe-style list rather than individual cards.
- *
- * Per-row content is shared with the desktop card view via
- * {@link CardRowContent}; see `card-row-content.tsx` for the column-meta
- * extensions (`mobileTitle`, `mobileBadge`, `mobileHidden`).
+ * Clicking a row toggles its selection, except when the click landed on
+ * something that already does something: a button, a link, an input, the
+ * selection checkbox itself, or an open row menu. Without this, opening a row's
+ * action menu would also select the row.
  */
+const INTERACTIVE_SELECTOR =
+  'button, a, input, [data-slot=checkbox], [data-slot=dropdown-menu-content], [role=menuitem]'
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element && target.closest(INTERACTIVE_SELECTOR) !== null
+  )
+}
+
 export function MobileCardList<TData>(props: MobileCardListProps<TData>) {
   const {
     table,
@@ -94,12 +116,11 @@ export function MobileCardList<TData>(props: MobileCardListProps<TData>) {
   const resolvedEmptyTitle = emptyTitle ?? t('No Data')
   const resolvedEmptyDescription = emptyDescription ?? t('No data available')
 
-  const visibleColumns = table.getVisibleLeafColumns()
-  const hasCompactMeta = React.useMemo(
-    () => tableHasCompactMeta(table),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [visibleColumns]
-  )
+  // No memo: `getVisibleLeafColumns()` returns a fresh array each render, so a
+  // dependency on it invalidates every time and the memo only ever added an
+  // eslint-disable. The check itself is a `.some()` over the visible columns,
+  // which TanStack already caches.
+  const hasCompactMeta = tableHasCompactMeta(table)
 
   if (isLoading) {
     return hasCompactMeta ? <ListSkeleton /> : <FallbackListSkeleton />
@@ -110,7 +131,7 @@ export function MobileCardList<TData>(props: MobileCardListProps<TData>) {
     .getVisibleLeafColumns()
     .some((column) => column.id === 'select')
 
-  if (!rows || rows.length === 0) {
+  if (rows.length === 0) {
     return (
       <div className='rounded-lg border p-6'>
         <Empty className='border-none p-0'>
@@ -146,14 +167,7 @@ export function MobileCardList<TData>(props: MobileCardListProps<TData>) {
             onClick={
               selectCell
                 ? (event) => {
-                    const target = event.target as HTMLElement
-                    if (
-                      target.closest(
-                        'button, a, input, [data-slot=checkbox], [data-slot=dropdown-menu-content], [role=menuitem]'
-                      )
-                    ) {
-                      return
-                    }
+                    if (isInteractiveTarget(event.target)) return
                     row.toggleSelected()
                   }
                 : undefined


### PR DESCRIPTION
## What

Three modules of the data-table package, each carrying a defect that this rewrite removes rather than restates.

### `layout/card-row-content.tsx`

The compact and the condensed layout each built the **same** split of a row's cells — drop the selection column, pull out the action menu, honour `mobileHidden`, sort by `mobileOrder` — and each did it against a parallel `cellMetas` array indexed positionally, held together by a `useMemo` whose dependency was recomputed on every render, plus an `eslint-disable` for the exhaustive-deps rule it could not satisfy.

`cardCells()` now returns the four roles once, reads each cell's meta **off the cell** instead of by index into a second array, and takes `compact` so the two layouts differ only in what they do with the result. The `StatusBadgeTypeContext` provider moved from four per-field copies to one around the card.

### `layout/mobile-card-list.tsx`

The `tableHasCompactMeta` memo depended on `getVisibleLeafColumns()`, which returns a **fresh array every render** — so the memo invalidated every render. A memo that never memoised, kept alive by an `eslint-disable`. It is a direct call now (the check is a `.some()` over columns TanStack already caches).

Also: the row's click guard is now `isInteractiveTarget`, named for the reason it exists — without it, opening a row's action menu also selected the row; `if (!rows || rows.length === 0)` lost the half that could not be taken; the two loading skeletons share their shell.

### `core/pagination.tsx`

The four navigation buttons were four copies of the same `Button` + `sr-only` label + icon, with two long class strings duplicated verbatim. One `NavButton`, two named class constants. **No behaviour or class change** — both constants are complete literal strings, so the Tailwind scanner still sees every candidate.

## Behaviour

Rendered output is unchanged apart from the removed `StatusBadgeTypeContext` nesting (providers render no DOM, and the value reaching each badge is identical). `visual-regression` and `ui-screenshots` are the guards.

## Gates

- `bun run lint` → oxlint clean, boundaries **686/0**, FormControl **140/0**
- `bun run format:check` · `bun run knip` · `bun run routes:verify` (28/28)
- `bun run vitest run --maxWorkers=1` → **261 files / 1707 tests passed**
- scoped: data-table package + every feature that renders a table → **205 files / 1315 tests passed**
- `tsgo -b` cannot run on the 2C/4G dev host (OOM-killed); CI `frontend` is the typecheck authority.