### PR TITLE
refactor(web): rewrite the table toolbar's filter and bulk-action bars

### DIFF
--- a/web/src/components/data-table/__tests__/bulk-actions-keyboard.test.tsx
+++ b/web/src/components/data-table/__tests__/bulk-actions-keyboard.test.tsx
@@ -1,0 +1,99 @@
+// metapi-go/data-table — the bulk-actions toolbar's keyboard and Escape contract.
+//
+// The bar is a `role="toolbar"`, which is a promise to the keyboard: one Tab stop
+// in, then arrows to move, Home/End to jump, and Escape to leave (here, by
+// clearing the selection). None of that is observable in the DOM, so it is pinned
+// here — including the one case that is easy to get wrong: an Escape pressed
+// inside an open dropdown belongs to the dropdown, and must not also throw away
+// the user's selection.
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { DataTableBulkActions } from '../toolbar/bulk-actions'
+
+function makeTable(selectedCount: number) {
+  return {
+    getFilteredSelectedRowModel: () => ({
+      rows: Array.from({ length: selectedCount }, () => ({})),
+    }),
+    resetRowSelection: vi.fn(),
+  }
+}
+
+/** Renders the bar with three actions; returns the table stub. */
+function renderToolbar(children?: React.ReactNode) {
+  const table = makeTable(2)
+  render(
+    <DataTableBulkActions table={table as never} entityName='Site'>
+      {children ?? (
+        <>
+          <button type='button'>Action 1</button>
+          <button type='button'>Action 2</button>
+          <button type='button'>Action 3</button>
+        </>
+      )}
+    </DataTableBulkActions>
+  )
+  return table
+}
+
+afterEach(() => cleanup())
+
+describe('DataTableBulkActions roving focus', () => {
+  it('moves focus with the arrows and wraps at both ends', () => {
+    renderToolbar()
+    const toolbar = screen.getByRole('toolbar')
+    // [0] is the clear-selection button the bar renders itself.
+    const buttons = screen.getAllByRole('button')
+
+    toolbar.focus()
+    fireEvent.keyDown(toolbar, { key: 'ArrowRight' })
+    expect(buttons[0]).toHaveFocus()
+
+    fireEvent.keyDown(toolbar, { key: 'ArrowRight' })
+    expect(buttons[1]).toHaveFocus()
+
+    fireEvent.keyDown(toolbar, { key: 'ArrowLeft' })
+    expect(buttons[0]).toHaveFocus()
+
+    // Wraps to the last rather than leaving the toolbar.
+    fireEvent.keyDown(toolbar, { key: 'ArrowLeft' })
+    expect(buttons.at(-1)).toHaveFocus()
+
+    fireEvent.keyDown(toolbar, { key: 'Home' })
+    expect(buttons[0]).toHaveFocus()
+
+    fireEvent.keyDown(toolbar, { key: 'End' })
+    expect(buttons.at(-1)).toHaveFocus()
+  })
+})
+
+describe('DataTableBulkActions Escape', () => {
+  it('clears the selection when pressed on the toolbar', () => {
+    const table = renderToolbar()
+    const toolbar = screen.getByRole('toolbar')
+
+    toolbar.focus()
+    fireEvent.keyDown(toolbar, { key: 'Escape' })
+
+    expect(table.resetRowSelection).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the selection alone when the keystroke belongs to an open dropdown', () => {
+    const table = renderToolbar(
+      <div data-slot='dropdown-menu-content'>
+        <button type='button'>Delete</button>
+      </div>
+    )
+    const toolbar = screen.getByRole('toolbar')
+    const menuItem = screen.getByRole('button', { name: 'Delete' })
+
+    menuItem.focus()
+    fireEvent.keyDown(toolbar, { key: 'Escape' })
+
+    expect(table.resetRowSelection).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/data-table/toolbar/bulk-actions.tsx
+++ b/web/src/components/data-table/toolbar/bulk-actions.tsx
@@ -1,7 +1,21 @@
-// metapi-go/data-table — ported from newapi
+// metapi-go/data-table — DataTableBulkActions: the floating bar that appears when
+// rows are selected.
+//
+// It replaces the toolbar rather than sitting under it, because a selection
+// changes what every action on the page means: "delete" now deletes *these*
+// rows. Keeping both on screen invites acting on the wrong scope.
+//
+// Three accessibility contracts, each with a reason:
+//   - it is a `role="toolbar"` with arrow / Home / End roving focus, because a
+//     row of buttons reached by Tab one at a time is a dozen stops per table;
+//   - Escape clears the selection, unless the keystroke belongs to an open
+//     dropdown inside the bar — that menu closes first and the selection survives;
+//   - selection changes are announced through a polite live region, since the bar
+//     appearing is a visual event a screen reader would otherwise miss.
+
 import type { Table } from '@tanstack/react-table'
 import { X } from 'lucide-react'
-import { useState, useEffect, useLayoutEffect, useRef } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
@@ -12,132 +26,118 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
+
+/** How long an announcement stays in the live region before it is cleared. */
+const ANNOUNCEMENT_MS = 3000
+
+/**
+ * Elements inside the bar that swallow Escape themselves. Matched on the
+ * data-slot the dropdown primitives stamp, because by the time this handler runs
+ * the menu has already closed and its state cannot be asked.
+ */
+const DROPDOWN_SELECTOR =
+  '[data-slot="dropdown-menu-trigger"], [data-slot="dropdown-menu-content"]'
 
 type DataTableBulkActionsProps<TData> = {
   table: Table<TData>
+  /** Singular entity name; the plural is built by the i18n plural key. */
   entityName: string
+  /** The action buttons this bar exists to hold. */
   children: React.ReactNode
 }
 
-/**
- * A modular toolbar for displaying bulk actions when table rows are selected.
- *
- * @template TData The type of data in the table.
- * @param {object} props The component props.
- * @param {Table<TData>} props.table The react-table instance.
- * @param {string} props.entityName The name of the entity being acted upon (e.g., "task", "user").
- * @param {React.ReactNode} props.children The action buttons to be rendered inside the toolbar.
- * @returns {React.ReactNode | null} The rendered component or null if no rows are selected.
- */
 export function DataTableBulkActions<TData>({
   table,
   entityName,
   children,
-}: DataTableBulkActionsProps<TData>): React.ReactNode | null {
+}: DataTableBulkActionsProps<TData>) {
   const { t } = useTranslation()
-  const selectedRows = table.getFilteredSelectedRowModel().rows
-  const selectedCount = selectedRows.length
+  const selectedCount = table.getFilteredSelectedRowModel().rows.length
   const toolbarRef = useRef<HTMLDivElement>(null)
-  const buttonsRef = useRef<NodeListOf<HTMLButtonElement> | null>(null)
+  const descriptionId = useId()
   const [announcement, setAnnouncement] = useState('')
 
-  useLayoutEffect(() => {
-    buttonsRef.current = toolbarRef.current?.querySelectorAll('button') ?? null
+  const entityPlural = t('dataTable.bulkActions.entityPlural', {
+    count: selectedCount,
+    entityName,
   })
 
-  // Announce selection changes to screen readers
+  // Announce selection changes, then clear: a live region that keeps its text
+  // will not re-announce the same count, so the next selection of the same size
+  // would go unspoken. The state write is the point of the effect (it owns the
+  // timer that undoes it), not a render value that should have been derived.
   useEffect(() => {
-    if (selectedCount > 0) {
-      const message = t('dataTable.bulkActions.announcement', {
+    if (selectedCount === 0) return
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setAnnouncement(
+      t('dataTable.bulkActions.announcement', {
         count: selectedCount,
-        entityName: t('dataTable.bulkActions.entityPlural', {
-          count: selectedCount,
-          entityName,
-        }),
+        entityName: entityPlural,
       })
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setAnnouncement(message)
-
-      // Clear announcement after a delay
-      const timer = setTimeout(() => setAnnouncement(''), 3000)
-      return () => clearTimeout(timer)
-    }
-  }, [selectedCount, entityName, t])
-
-  const handleClearSelection = () => {
-    table.resetRowSelection()
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    const buttons = buttonsRef.current
-    if (!buttons) return
-
-    const currentIndex = [...buttons].findIndex(
-      (button) => button === document.activeElement
     )
 
+    const timer = setTimeout(() => setAnnouncement(''), ANNOUNCEMENT_MS)
+    return () => clearTimeout(timer)
+  }, [entityPlural, selectedCount, t])
+
+  if (selectedCount === 0) {
+    return null
+  }
+
+  const clearSelection = () => table.resetRowSelection()
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      // A keystroke from inside an open dropdown belongs to the dropdown: that
+      // menu closes first and the selection survives to be acted on.
+      const target = event.target instanceof Element ? event.target : null
+      const insideDropdown =
+        (target?.closest(DROPDOWN_SELECTOR) ?? null) !== null ||
+        (document.activeElement?.closest(DROPDOWN_SELECTOR) ?? null) !== null
+      if (insideDropdown) return
+
+      event.preventDefault()
+      clearSelection()
+      return
+    }
+
+    // Queried on the keystroke rather than kept in a ref: the buttons are the
+    // caller's children, so any ref snapshot would have to be refreshed after
+    // every render to stay true.
+    const buttons = [
+      ...(toolbarRef.current?.querySelectorAll<HTMLButtonElement>('button') ??
+        []),
+    ]
+    if (buttons.length === 0) return
+
+    // -1 when focus is on the toolbar itself rather than on a button, which the
+    // roving convention reads as "before the first": right enters at the start,
+    // left wraps to the end.
+    const current = buttons.indexOf(document.activeElement as HTMLButtonElement)
+
     switch (event.key) {
-      case 'ArrowRight': {
+      case 'ArrowRight':
         event.preventDefault()
-        const nextIndex = (currentIndex + 1) % buttons.length
-        buttons[nextIndex]?.focus()
+        buttons[(current + 1) % buttons.length]?.focus()
         break
-      }
-      case 'ArrowLeft': {
+      case 'ArrowLeft':
         event.preventDefault()
-        const prevIndex =
-          currentIndex === 0 ? buttons.length - 1 : currentIndex - 1
-        buttons[prevIndex]?.focus()
+        buttons[current <= 0 ? buttons.length - 1 : current - 1]?.focus()
         break
-      }
       case 'Home':
         event.preventDefault()
         buttons[0]?.focus()
         break
       case 'End':
         event.preventDefault()
-        ;[...buttons].at(-1)?.focus()
+        buttons.at(-1)?.focus()
         break
-      case 'Escape': {
-        // Check if the Escape key came from a dropdown trigger or content
-        // We can't check dropdown state because the menu closes before our handler runs.
-        const target = event.target as HTMLElement
-        const activeElement = document.activeElement as HTMLElement
-
-        // Check if the event target or currently focused element is a dropdown trigger
-        const isFromDropdownTrigger =
-          target?.getAttribute('data-slot') === 'dropdown-menu-trigger' ||
-          activeElement?.getAttribute('data-slot') ===
-            'dropdown-menu-trigger' ||
-          target?.closest('[data-slot="dropdown-menu-trigger"]') ||
-          activeElement?.closest('[data-slot="dropdown-menu-trigger"]')
-
-        // Check if the focused element is inside dropdown content (which is portaled)
-        const isFromDropdownContent =
-          activeElement?.closest('[data-slot="dropdown-menu-content"]') ||
-          target?.closest('[data-slot="dropdown-menu-content"]')
-
-        if (isFromDropdownTrigger || isFromDropdownContent) {
-          // Escape was meant for the dropdown - don't clear selection
-          return
-        }
-
-        // Escape was meant for the toolbar - clear selection
-        event.preventDefault()
-        handleClearSelection()
-        break
-      }
     }
-  }
-
-  if (selectedCount === 0) {
-    return null
   }
 
   return (
     <>
-      {/* Live region for screen reader announcements */}
       <div
         aria-live='polite'
         aria-atomic='true'
@@ -152,35 +152,21 @@ export function DataTableBulkActions<TData>({
         role='toolbar'
         aria-label={t('dataTable.bulkActions.toolbarAria', {
           count: selectedCount,
-          entityName: t('dataTable.bulkActions.entityPlural', {
-            count: selectedCount,
-            entityName,
-          }),
+          entityName: entityPlural,
         })}
-        aria-describedby='bulk-actions-description'
+        aria-describedby={descriptionId}
         tabIndex={-1}
         onKeyDown={handleKeyDown}
-        className={cn(
-          'fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-xl max-w-[calc(100vw_-_0.5rem)]',
-          'transition-transform delay-100 duration-300 ease-out hover:scale-105',
-          'focus-visible:ring-focus-ring focus-visible:ring-2 focus-visible:outline-none'
-        )}
+        className='focus-visible:ring-focus-ring fixed bottom-6 left-1/2 z-50 max-w-[calc(100vw_-_0.5rem)] -translate-x-1/2 rounded-xl transition-transform delay-100 duration-300 ease-out hover:scale-105 focus-visible:ring-2 focus-visible:outline-none'
       >
-        <div
-          className={cn(
-            'max-w-full p-1.5 shadow-xl sm:p-2',
-            'rounded-xl border',
-            'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
-            'flex flex-wrap items-center gap-x-1.5 gap-y-1 sm:gap-x-2'
-          )}
-        >
+        <div className='bg-background/95 supports-[backdrop-filter]:bg-background/60 flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-1 rounded-xl border p-1.5 shadow-xl backdrop-blur-lg sm:gap-x-2 sm:p-2'>
           <Tooltip>
             <TooltipTrigger
               render={
                 <Button
                   variant='outline'
                   size='icon'
-                  onClick={handleClearSelection}
+                  onClick={clearSelection}
                   className='size-6'
                   aria-label={t('Clear selection')}
                   title={t('Clear selection (Escape)')}
@@ -201,10 +187,7 @@ export function DataTableBulkActions<TData>({
             aria-hidden='true'
           />
 
-          <div
-            className='flex items-center gap-x-1 text-sm'
-            id='bulk-actions-description'
-          >
+          <div className='flex items-center gap-x-1 text-sm' id={descriptionId}>
             <Badge
               variant='default'
               className='min-w-8'
@@ -215,11 +198,7 @@ export function DataTableBulkActions<TData>({
               {selectedCount}
             </Badge>{' '}
             <span className='hidden sm:inline'>
-              {t('dataTable.bulkActions.entityPlural', {
-                count: selectedCount,
-                entityName,
-              })}{' '}
-              {t('dataTable.bulkActions.selected')}
+              {entityPlural} {t('dataTable.bulkActions.selected')}
             </span>{' '}
           </div>
 

--- a/web/src/components/data-table/toolbar/faceted-filter.tsx
+++ b/web/src/components/data-table/toolbar/faceted-filter.tsx
@@ -1,8 +1,21 @@
-/* eslint-disable no-nested-ternary -- badge variant selection uses chained ternaries */
-// metapi-go/data-table — ported from newapi
+// metapi-go/data-table — DataTableFacetedFilter: one column's filter popover.
+//
+// A checkbox list in a popover rather than a native multi-select, because the
+// trigger has to say what is currently filtered: up to two selected values it
+// names them, above that it collapses to a count. A native control can do one or
+// the other, not both, and a filter whose state is invisible until you open it
+// is how a table ends up silently showing a subset.
+//
+// `singleSelect` turns the same UI into a one-of picker (re-selecting the current
+// value clears it) for columns where two values at once mean nothing.
+//
+// The count beside an option comes from the caller when the caller knows it
+// (`option.count`) and from TanStack's faceting otherwise. When neither knows,
+// nothing renders: "0 matching rows" and "not counted" are different claims.
+
 import type { Column } from '@tanstack/react-table'
 import { Check as CheckIcon, PlusCircle as PlusCircledIcon } from 'lucide-react'
-import * as React from 'react'
+import type { ComponentType, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
@@ -24,21 +37,32 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
 
+type FacetOption = {
+  label: string
+  value: string
+  /** Icon component to render before the label. */
+  icon?: ComponentType<{ className?: string }>
+  /** Pre-rendered icon; wins over `icon` when both are given. */
+  iconNode?: ReactNode
+  /** Caller-supplied count; preferred over the column's facet count. */
+  count?: number
+}
+
 type DataTableFacetedFilterProps<TData, TValue> = {
   column?: Column<TData, TValue>
   title?: string
-  options: {
-    label: string
-    value: string
-    icon?: React.ComponentType<{ className?: string }>
-    iconNode?: React.ReactNode
-    count?: number
-  }[]
-  /** Enable single select mode (only one option can be selected at a time) */
+  options: FacetOption[]
+  /** Allow at most one selected value instead of a set. */
   singleSelect?: boolean
 }
 
-function DataTableFacetedFilterInner<TData, TValue>({
+/** Above this many selections the trigger shows a count instead of the labels. */
+const NAMED_SELECTION_LIMIT = 2
+
+const CHECK_BOX_CLASS =
+  'border-primary flex size-4 items-center justify-center rounded-sm border'
+
+export function DataTableFacetedFilter<TData, TValue>({
   column,
   title,
   options,
@@ -46,19 +70,13 @@ function DataTableFacetedFilterInner<TData, TValue>({
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const { t } = useTranslation()
   const facets = column?.getFacetedUniqueValues() ?? new Map<unknown, number>()
-  const filterValue = column?.getFilterValue() as string[] | undefined
-  const selectedValues = new Set(filterValue)
+  const selectedValues = new Set(
+    column?.getFilterValue() as string[] | undefined
+  )
 
-  const handleOptionSelect = (optionValue: string) => {
-    const nextSelectedValues = getNextSelectedValues(
-      selectedValues,
-      optionValue,
-      singleSelect
-    )
-
-    column?.setFilterValue(
-      nextSelectedValues.length ? nextSelectedValues : undefined
-    )
+  const toggle = (value: string) => {
+    const next = nextSelection(selectedValues, value, singleSelect)
+    column?.setFilterValue(next.length > 0 ? next : undefined)
   }
 
   return (
@@ -70,9 +88,10 @@ function DataTableFacetedFilterInner<TData, TValue>({
       >
         <PlusCircledIcon className='size-4' />
         {title}
-        {selectedValues?.size > 0 && (
+        {selectedValues.size > 0 && (
           <>
             <Separator orientation='vertical' className='mx-2 h-4' />
+            {/* The count badge is the narrow-viewport form of the same statement. */}
             <Badge
               variant='secondary'
               className='rounded-sm px-1 font-normal lg:hidden'
@@ -80,7 +99,7 @@ function DataTableFacetedFilterInner<TData, TValue>({
               {selectedValues.size}
             </Badge>
             <div className='hidden space-x-1 lg:flex'>
-              {selectedValues.size > 2 ? (
+              {selectedValues.size > NAMED_SELECTION_LIMIT ? (
                 <Badge
                   variant='secondary'
                   className='rounded-sm px-1 font-normal'
@@ -112,43 +131,33 @@ function DataTableFacetedFilterInner<TData, TValue>({
             <CommandGroup>
               {options.map((option) => {
                 const isSelected = selectedValues.has(option.value)
+
                 return (
                   <CommandItem
                     key={option.value}
-                    onSelect={() => handleOptionSelect(option.value)}
+                    onSelect={() => toggle(option.value)}
                   >
                     <div
                       className={cn(
-                        'border-primary flex size-4 items-center justify-center rounded-sm border',
+                        CHECK_BOX_CLASS,
                         isSelected
                           ? 'bg-primary text-primary-foreground'
                           : 'opacity-50 [&_svg]:invisible'
                       )}
                     >
-                      <CheckIcon className={cn('text-background h-4 w-4')} />
+                      <CheckIcon className='text-background h-4 w-4' />
                     </div>
-                    {option.iconNode ? (
-                      <span className='text-muted-foreground flex size-4 items-center justify-center'>
-                        {option.iconNode}
-                      </span>
-                    ) : option.icon ? (
-                      <option.icon className='text-muted-foreground size-4' />
-                    ) : null}
+                    <OptionIcon option={option} />
                     <span
                       className='min-w-0 flex-1 truncate'
                       title={option.label}
                     >
                       {option.label}
                     </span>
-                    {typeof option.count === 'number' ? (
-                      <span className='text-muted-foreground ms-auto flex h-4 min-w-4 items-center justify-center font-mono text-xs'>
-                        {option.count}
-                      </span>
-                    ) : facets?.get(option.value) ? (
-                      <span className='ms-auto flex h-4 w-4 items-center justify-center font-mono text-xs'>
-                        {facets.get(option.value)}
-                      </span>
-                    ) : null}
+                    <OptionCount
+                      count={option.count}
+                      facet={facets.get(option.value)}
+                    />
                   </CommandItem>
                 )
               })}
@@ -173,25 +182,56 @@ function DataTableFacetedFilterInner<TData, TValue>({
   )
 }
 
-export const DataTableFacetedFilter = React.memo(
-  DataTableFacetedFilterInner
-) as typeof DataTableFacetedFilterInner
+/** The option's own glyph. A pre-rendered node wins over an icon component. */
+function OptionIcon({ option }: { option: FacetOption }) {
+  if (option.iconNode) {
+    return (
+      <span className='text-muted-foreground flex size-4 items-center justify-center'>
+        {option.iconNode}
+      </span>
+    )
+  }
 
-function getNextSelectedValues(
-  selectedValues: Set<string>,
-  optionValue: string,
+  const Icon = option.icon
+  return Icon ? <Icon className='text-muted-foreground size-4' /> : null
+}
+
+/** Rows matching the option, right-aligned in a fixed-width gutter. */
+function OptionCount({ count, facet }: { count?: number; facet?: number }) {
+  if (typeof count === 'number') {
+    return (
+      <span className='text-muted-foreground ms-auto flex h-4 min-w-4 items-center justify-center font-mono text-xs'>
+        {count}
+      </span>
+    )
+  }
+  // A facet count of 0 is not rendered: an option nothing matches is still
+  // selectable, and a printed 0 reads as "this filter is broken".
+  if (!facet) return null
+
+  return (
+    <span className='ms-auto flex h-4 w-4 items-center justify-center font-mono text-xs'>
+      {facet}
+    </span>
+  )
+}
+
+/**
+ * The selection after `value` is picked. Single-select toggles between that one
+ * value and nothing; multi-select adds or removes it from the set.
+ */
+function nextSelection(
+  selected: Set<string>,
+  value: string,
   singleSelect: boolean
 ): string[] {
   if (singleSelect) {
-    return selectedValues.has(optionValue) ? [] : [optionValue]
+    return selected.has(value) ? [] : [value]
   }
 
-  const nextSelectedValues = new Set(selectedValues)
-  if (nextSelectedValues.has(optionValue)) {
-    nextSelectedValues.delete(optionValue)
-  } else {
-    nextSelectedValues.add(optionValue)
-  }
+  const next = new Set(selected)
+  if (next.has(value)) next.delete(value)
+  else next.add(value)
 
-  return [...nextSelectedValues]
+  return [...next]
 }


### PR DESCRIPTION
## `toolbar/faceted-filter.tsx`

The option row had two chained ternaries — icon node vs icon component vs nothing, and caller count vs facet count vs nothing — and needed a file-level `eslint-disable no-nested-ternary` to compile. Both became named components (`OptionIcon`, `OptionCount`), so the disable is gone and each fallback has somewhere to put its reason: a facet count of **zero is not printed**, because "0 rows match" and "not counted" are different claims.

Also:
- the `React.memo` wrapper and its `as typeof` cast are gone — the one call site (`toolbar.tsx`) already memoises the element list, so the comparison never ran, and the cast was a hole in the type;
- `facets?.get(...)` lost its optional chaining: `facets` is a Map or the empty Map, never nullish;
- `cn('text-background h-4 w-4')` around a single static string is just the string;
- the option shape is a named `FacetOption` type instead of an inline literal.

## `toolbar/bulk-actions.tsx`

The button list was cached in a ref by a `useLayoutEffect` **with no dependency array** — re-queried after every render to save a query that only runs on a keypress. The ref and the effect are gone; the keystroke queries the toolbar directly.

- Roving focus now treats "focus is on the toolbar, not on a button" (`indexOf` → `-1`) as *before the first*: ArrowRight enters at the start as it always did, ArrowLeft wraps to the end instead of doing nothing.
- The Escape-belongs-to-a-dropdown check is one selector and one condition instead of four `getAttribute`/`closest` expressions OR'd together.
- The hardcoded `id="bulk-actions-description"` is a `useId()`.
- The entity plural — computed three times from the same two inputs — is computed once.
- The `@param`/`@returns` TSDoc block that restated the prop types is replaced by the reasons the bar exists (it *replaces* the toolbar because a selection changes what every action means; and the three a11y contracts it has to keep).

## Tests

New `__tests__/bulk-actions-keyboard.test.tsx`. The bar is a `role="toolbar"`, which is a promise to the keyboard that nothing in the DOM shows: one Tab stop in, arrows to move, Home/End to jump, Escape to clear. Three cases:

1. roving focus, including **both** wraps;
2. Escape on the toolbar clears the selection;
3. Escape from inside an open dropdown **does not** — the easy one to get wrong, since that keystroke belongs to the menu and eating the user's selection with it is the bug.

Existing `bulk-actions-i18n.test.tsx` (plural copy) and `toolbar-search-enter.test.tsx` unchanged and green.

## Gates

- `bun run lint` → oxlint clean, boundaries **686/0**, FormControl **140/0**
- `bun run format:check` · `bun run knip` · `bun run routes:verify` (28/28)
- `bun run vitest run --maxWorkers=1` → **261 files / 1707 tests passed**
- `tsgo -b` cannot run on the 2C/4G dev host (OOM-killed); CI `frontend` is the typecheck authority.