### PR TITLE
refactor(web): cut the data-table toolbar down to the props it uses

### DIFF
--- a/web/src/components/data-table/__tests__/toolbar-reset.test.tsx
+++ b/web/src/components/data-table/__tests__/toolbar-reset.test.tsx
@@ -1,0 +1,108 @@
+// metapi-go/data-table — the toolbar's Reset contract.
+//
+// Reset has to undo two different kinds of state: what the table holds (global
+// filter, column filters) and what only the toolbar holds (a search draft typed
+// but not yet through the debounce). The second is the easy one to break — the
+// table never saw that text, so clearing table state alone leaves it on screen.
+// Both are pinned here, together with the visibility rule that decides when
+// Reset is offered at all.
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { DataTableToolbar } from '../toolbar/toolbar'
+
+type TableState = {
+  globalFilter: string
+  columnFilters: { id: string; value: unknown[] }[]
+}
+
+function makeTable(state: TableState) {
+  return {
+    getState: () => state,
+    getColumn: () => undefined,
+    getAllColumns: () => [],
+    setGlobalFilter: vi.fn((value: string) => {
+      state.globalFilter = value
+    }),
+    resetColumnFilters: vi.fn(() => {
+      state.columnFilters = []
+    }),
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('DataTableToolbar reset', () => {
+  it('is hidden while nothing is filtered', () => {
+    render(
+      <DataTableToolbar
+        table={makeTable({ globalFilter: '', columnFilters: [] }) as never}
+        searchPlaceholder='Search…'
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /Reset/ })).toBeNull()
+  })
+
+  it('clears the table filters and calls onReset', () => {
+    const table = makeTable({
+      globalFilter: 'openai',
+      columnFilters: [{ id: 'status', value: ['active'] }],
+    })
+    const onReset = vi.fn()
+    const view = render(
+      <DataTableToolbar
+        table={table as never}
+        searchPlaceholder='Search…'
+        onReset={onReset}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset/ }))
+
+    expect(table.setGlobalFilter).toHaveBeenCalledWith('')
+    expect(table.resetColumnFilters).toHaveBeenCalledOnce()
+    expect(onReset).toHaveBeenCalledOnce()
+
+    // In production the table state change re-renders the page; the mock table
+    // has no subscribers, so the re-render is driven explicitly.
+    view.rerender(
+      <DataTableToolbar
+        table={table as never}
+        searchPlaceholder='Search…'
+        onReset={onReset}
+      />
+    )
+    expect(screen.getByPlaceholderText('Search…')).toHaveValue('')
+  })
+
+  it('drops a search draft the debounce has not committed yet', () => {
+    vi.useFakeTimers()
+    const table = makeTable({ globalFilter: '', columnFilters: [] })
+    render(
+      <DataTableToolbar
+        table={table as never}
+        searchPlaceholder='Search…'
+        searchDebounceMs={500}
+        // A page-owned filter (proxy logs keeps status + date range in the URL)
+        // is what makes Reset reachable while the table itself is clean.
+        hasAdditionalFilters
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search…')
+    fireEvent.change(input, { target: { value: 'openai' } })
+    expect(input).toHaveValue('openai')
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset/ }))
+
+    expect(input).toHaveValue('')
+    expect(table.setGlobalFilter).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/data-table/__tests__/toolbar-search-enter.test.tsx
+++ b/web/src/components/data-table/__tests__/toolbar-search-enter.test.tsx
@@ -1,6 +1,11 @@
-// Behavior test for the toolbar search Enter shortcut (#889): with debounced
-// filtering the draft only commits after the delay, but pressing Enter must
-// commit immediately so "type → Enter" behaves like an explicit search.
+// metapi-go/data-table — when the toolbar's search draft reaches the table.
+//
+// Two timing rules, both invisible in the DOM:
+//
+// - Enter commits immediately (#889). With debounced filtering the draft would
+//   otherwise sit for the whole delay after the user has said "search now".
+// - An IME composition never commits mid-flight. Half-typed pinyin is not a
+//   filter, so the draft is held until compositionend and only then debounced.
 
 import '@testing-library/jest-dom/vitest'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
@@ -71,5 +76,36 @@ describe('DataTableToolbar search Enter commit', () => {
       vi.advanceTimersByTime(600)
     })
     expect(setGlobalFilter).toHaveBeenCalledWith('gemini')
+  })
+})
+
+describe('DataTableToolbar search composition', () => {
+  it('holds the draft while the IME is composing, then commits it', () => {
+    vi.useFakeTimers()
+    const setGlobalFilter = vi.fn()
+    render(
+      <DataTableToolbar
+        table={makeTable('', setGlobalFilter) as never}
+        searchPlaceholder='Search…'
+        searchDebounceMs={500}
+      />
+    )
+
+    const input = screen.getByPlaceholderText('Search…')
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: 'ni' } })
+    expect(input).toHaveValue('ni')
+
+    // The debounce elapses mid-composition and must still not commit.
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+    expect(setGlobalFilter).not.toHaveBeenCalled()
+
+    fireEvent.compositionEnd(input, { target: { value: '你好' } })
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+    expect(setGlobalFilter).toHaveBeenCalledWith('你好')
   })
 })

--- a/web/src/components/data-table/toolbar/toolbar.tsx
+++ b/web/src/components/data-table/toolbar/toolbar.tsx
@@ -1,4 +1,13 @@
-// metapi-go/data-table — ported from newapi
+// metapi-go/data-table — DataTableToolbar: the filter row above a list page.
+//
+// One `flex-wrap` row, no panel chrome: the search input, any page-supplied
+// controls and the column filter chips flow left, the action cluster hugs the
+// right edge via `ms-auto` and wraps to its own line when the filters fill the
+// row. Visual hierarchy comes from whitespace and the adjacent table border.
+//
+// The toolbar owns the search *draft*, not the search value: commits are
+// debounced, so between keystrokes the input shows what the user typed while
+// the table still holds the last settled value.
 import type { Table } from '@tanstack/react-table'
 import { ChevronDown, X as Cross2Icon } from 'lucide-react'
 import * as React from 'react'
@@ -7,7 +16,6 @@ import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Spinner } from '@/components/ui/spinner'
 import { cn } from '@/lib/utils'
 
 import { useDebounce } from '../hooks/use-debounce'
@@ -27,257 +35,182 @@ type FilterDef = {
   singleSelect?: boolean
 }
 
+/**
+ * What the user has typed but not yet committed. `baseValue` is the committed
+ * value it was typed against, which is how a draft tells "still mine" apart
+ * from "the table moved on without me" (Reset, a URL sync, another filter).
+ */
 type SearchDraft = {
   baseValue: string
   value: string
 }
 
+const DEFAULT_SEARCH_DEBOUNCE_MS = 300
+
 export type DataTableToolbarProps<TData> = {
   table: Table<TData>
   /**
-   * Placeholder for the default search input. Defaults to `t('Filter...')`.
+   * Placeholder for the search input. Defaults to `t('Filter...')`.
    */
   searchPlaceholder?: string
   /**
-   * Delay committing the default search input. Defaults to 300ms so
-   * filter-as-you-type pages do not re-filter (or re-fetch) on every
-   * keystroke; pass 0 for pages that explicitly want immediate commits.
+   * Delay before a keystroke reaches the table's global filter. Defaults to
+   * 300ms: filtering re-runs over the whole page of rows, so a page that
+   * filters as you type should not pay for that per keystroke.
    */
   searchDebounceMs?: number
   /**
-   * Column id to filter on. When provided, the search input filters
-   * a specific column. When omitted, the search input updates the
-   * table's `globalFilter`.
-   */
-  searchKey?: string
-  /**
-   * Column-level filter chips (faceted multi-select / single-select).
+   * Column filter chips (faceted multi-select / single-select). A chip whose
+   * `columnId` does not resolve to a column is skipped rather than rendered
+   * empty.
    */
   filters?: FilterDef[]
   /**
-   * Replaces the default search input entirely. Use when the primary
-   * "search" is something custom — e.g. a date-time range picker.
-   */
-  customSearch?: ReactNode
-  /**
-   * Extra inputs/selects displayed in the primary row alongside the
-   * search input and filter chips.
+   * Extra controls in the filter flow, after the search input — e.g. the
+   * status `<Select>` and date range the proxy-log page drives from the URL.
    */
   additionalSearch?: ReactNode
   /**
-   * Whether non-table filters (e.g. `additionalSearch` or `expandable`
-   * inputs) are currently active. Controls Reset button visibility
-   * when no column filters are set.
+   * Whether filters this toolbar does not own (`additionalSearch`,
+   * `expandable`, or anything the page keeps in the URL) are active. Decides
+   * Reset visibility once the table itself reports no filter.
    */
   hasAdditionalFilters?: boolean
   /**
-   * Callback invoked when the user clicks Reset.
+   * Called after Reset has cleared the table's own filters, so the page can
+   * clear the state it owns.
    */
   onReset?: () => void
   /**
-   * Additional filter inputs hidden behind an Expand/Collapse toggle.
-   * Inputs flow inline with the primary row when expanded.
+   * Extra filter inputs behind the Expand/Collapse toggle. They join the same
+   * wrapping flow when expanded.
    */
   expandable?: ReactNode
   /**
-   * When `expandable` is collapsed, highlights the toggle if any of
-   * the expandable inputs currently hold a value.
+   * Highlights the collapsed toggle when an `expandable` input holds a value,
+   * so a hidden filter is still visible as active.
    */
   hasExpandedActiveFilters?: boolean
   /**
-   * Custom action buttons rendered BEFORE the built-in
-   * Reset / Search / View buttons.
+   * Action buttons rendered before Reset in the right-hand cluster — the
+   * page's primary entry points (Add site, Import accounts, …).
    */
   preActions?: ReactNode
   /**
-   * Explicit "Search" / "Apply" callback. When provided the toolbar
-   * shows a primary Search button. Filters are committed only on click
-   * (form-mode workflow).
-   */
-  onSearch?: () => void
-  /**
-   * Loading state for the explicit Search button.
-   */
-  searchLoading?: boolean
-  /**
-   * Hide the View Options (column visibility) dropdown.
-   */
-  hideViewOptions?: boolean
-  /**
-   * Optional extra control rendered in the right action cluster, before the
-   * View Options dropdown. Omitted by default.
+   * Extra control rendered after Reset, before the column-visibility menu.
    */
   viewToggle?: ReactNode
-  /**
-   * Content rendered on the LEFT side of the secondary actions row. When
-   * provided the toolbar splits into two visual rows:
-   *   Row 1: search inputs / filter chips …… Expand
-   *   Row 2: expanded filters
-   *   Row 3: leftActions …… Reset / Search / ViewOptions
-   */
-  leftActions?: ReactNode
-  /**
-   * Outer wrapper className override.
-   */
-  className?: string
 }
 
-/**
- * Unified data-table filter panel — Ant Design Pro inspired.
- *
- * Layout (single flex-wrap row):
- * - Filters (search input + additional inputs + filter chips + expandable
- *   inputs) flow horizontally and wrap as needed.
- * - The action cluster (Reset / Search / View / Expand) hugs the right
- *   edge via `ms-auto`. When filters fill a row, the cluster naturally
- *   wraps to the next line — still right-aligned — matching the
- *   collapsed/expanded states from the user's reference design.
- *
- * No background panel, no row separators — relies on whitespace and the
- * adjacent table border for visual hierarchy.
- */
 export function DataTableToolbar<TData>(props: DataTableToolbarProps<TData>) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
-  const [isSearchComposing, setIsSearchComposing] = useState(false)
+  const [draft, setDraft] = useState<SearchDraft | null>(null)
+  // True between compositionstart and compositionend. An IME builds a string
+  // across several keystrokes; committing (or debouncing) the intermediate
+  // text would filter on half-typed pinyin.
+  const [composing, setComposing] = useState(false)
 
-  const filters = props.filters ?? []
-  const hasExpandable = props.expandable != null
-  const hasSearch = props.onSearch != null
+  const committed =
+    (props.table.getState().globalFilter as string | undefined) ?? ''
+  const liveDraft =
+    draft && (composing || draft.baseValue === committed) ? draft : null
+  const searchValue = liveDraft?.value ?? committed
+  const debouncedSearchValue = useDebounce(
+    searchValue,
+    props.searchDebounceMs ?? DEFAULT_SEARCH_DEBOUNCE_MS
+  )
 
   const isFiltered =
     (props.table.getState().columnFilters ?? []).length > 0 ||
-    !!props.table.getState().globalFilter ||
-    !!props.hasAdditionalFilters
-
-  const placeholder = props.searchPlaceholder ?? t('Filter...')
-  const currentSearchValue = props.searchKey
-    ? ((props.table.getColumn(props.searchKey)?.getFilterValue() as string) ??
-      '')
-    : ((props.table.getState().globalFilter as string | undefined) ?? '')
-
-  const [searchDraft, setSearchDraft] = useState<SearchDraft | null>(null)
-  const activeSearchDraft =
-    searchDraft &&
-    (isSearchComposing || searchDraft.baseValue === currentSearchValue)
-      ? searchDraft
-      : null
-  const searchValue = activeSearchDraft?.value ?? currentSearchValue
-  const searchDebounceMs = Math.max(0, props.searchDebounceMs ?? 300)
-  const debouncedSearchValue = useDebounce(searchValue, searchDebounceMs)
+    committed !== '' ||
+    props.hasAdditionalFilters === true
 
   const commitSearchValue = React.useCallback(
     (value: string) => {
-      if (value === currentSearchValue) {
-        return
+      if (value !== committed) {
+        props.table.setGlobalFilter(value)
       }
-
-      if (props.searchKey) {
-        props.table.getColumn(props.searchKey)?.setFilterValue(value)
-        return
-      }
-
-      props.table.setGlobalFilter(value)
     },
-    [currentSearchValue, props.searchKey, props.table]
+    [committed, props.table]
   )
 
+  // The debounce has settled — the debounced value caught up with what the
+  // input shows — and the table has not been told yet: publish it.
   React.useEffect(() => {
-    if (
-      searchDebounceMs <= 0 ||
-      isSearchComposing ||
-      debouncedSearchValue !== searchValue
-    ) {
+    if (composing || debouncedSearchValue !== searchValue) {
       return
     }
-
     commitSearchValue(debouncedSearchValue)
-  }, [
-    commitSearchValue,
-    debouncedSearchValue,
-    isSearchComposing,
-    searchDebounceMs,
-    searchValue,
-  ])
-
-  const queueSearchValue = (value: string) => {
-    if (searchDebounceMs <= 0) {
-      commitSearchValue(value)
-    }
-  }
+  }, [commitSearchValue, composing, debouncedSearchValue, searchValue])
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value
-    setSearchDraft({ baseValue: currentSearchValue, value })
-
-    if (!isSearchComposing) {
-      queueSearchValue(value)
-    }
+    setDraft({ baseValue: committed, value: event.target.value })
   }
 
-  const handleSearchCompositionStart = () => {
-    setIsSearchComposing(true)
-  }
-
-  const handleSearchCompositionEnd = (
+  const handleCompositionEnd = (
     event: React.CompositionEvent<HTMLInputElement>
   ) => {
-    setIsSearchComposing(false)
-    const value = event.currentTarget.value
-    setSearchDraft({ baseValue: currentSearchValue, value })
-    queueSearchValue(value)
+    setComposing(false)
+    setDraft({ baseValue: committed, value: event.currentTarget.value })
   }
 
-  // Enter commits the draft immediately instead of waiting out the debounce,
-  // so "type → Enter" feels like an explicit search even with debounced
-  // filtering enabled.
+  // Enter commits the draft instead of waiting out the debounce, so
+  // "type → Enter" behaves like an explicit search.
   const handleSearchKeyDown = (
     event: React.KeyboardEvent<HTMLInputElement>
   ) => {
     if (event.key !== 'Enter') return
     event.preventDefault()
-    setIsSearchComposing(false)
+    setComposing(false)
     commitSearchValue(searchValue)
   }
 
-  const hasSearchValue = searchValue.length > 0
-
   const clearSearchValue = () => {
-    setIsSearchComposing(false)
-    setSearchDraft(null)
+    setComposing(false)
+    setDraft(null)
     commitSearchValue('')
   }
 
-  const searchInput = (
-    <div className='relative w-full sm:w-[200px] lg:w-[240px]'>
-      <Input
-        aria-label={placeholder}
-        placeholder={placeholder}
-        value={searchValue}
-        onChange={handleSearchChange}
-        onKeyDown={handleSearchKeyDown}
-        onCompositionStart={handleSearchCompositionStart}
-        onCompositionEnd={handleSearchCompositionEnd}
-        className={cn('w-full', hasSearchValue && 'pe-8')}
-      />
-      {hasSearchValue && (
-        <Button
-          type='button'
-          variant='ghost'
-          size='icon-xs'
-          aria-label={t('Clear search')}
-          onClick={clearSearchValue}
-          className='text-muted-foreground hover:text-foreground absolute top-1/2 right-1 -translate-y-1/2'
-        >
-          <Cross2Icon className='size-3.5' />
-        </Button>
-      )}
-    </div>
-  )
+  const handleReset = () => {
+    clearSearchValue()
+    props.table.resetColumnFilters()
+    props.onReset?.()
+  }
 
-  const filterChips = React.useMemo(
-    () =>
-      filters.map((filter) => {
+  const placeholder = props.searchPlaceholder ?? t('Filter...')
+  const hasExpandable = props.expandable != null
+
+  return (
+    <div className='flex flex-wrap items-center gap-2 sm:gap-3'>
+      <div className='relative w-full sm:w-[200px] lg:w-[240px]'>
+        <Input
+          aria-label={placeholder}
+          placeholder={placeholder}
+          value={searchValue}
+          onChange={handleSearchChange}
+          onKeyDown={handleSearchKeyDown}
+          onCompositionStart={() => setComposing(true)}
+          onCompositionEnd={handleCompositionEnd}
+          className={cn('w-full', searchValue !== '' && 'pe-8')}
+        />
+        {searchValue !== '' && (
+          <Button
+            type='button'
+            variant='ghost'
+            size='icon-xs'
+            aria-label={t('Clear search')}
+            onClick={clearSearchValue}
+            className='text-muted-foreground hover:text-foreground absolute top-1/2 right-1 -translate-y-1/2'
+          >
+            <Cross2Icon className='size-3.5' />
+          </Button>
+        )}
+      </div>
+
+      {props.additionalSearch}
+
+      {(props.filters ?? []).map((filter) => {
         const column = props.table.getColumn(filter.columnId)
         if (!column) return null
         return (
@@ -289,135 +222,50 @@ export function DataTableToolbar<TData>(props: DataTableToolbarProps<TData>) {
             singleSelect={filter.singleSelect}
           />
         )
-      }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [props.filters, props.table]
-  )
+      })}
 
-  const handleReset = () => {
-    setIsSearchComposing(false)
-    setSearchDraft(null)
-    props.table.resetColumnFilters()
-    props.table.setGlobalFilter('')
-    props.onReset?.()
-  }
+      {expanded && props.expandable}
 
-  // Reset: outline text-only for form mode (always visible, disabled when
-  // nothing to reset); ghost text + X for filter-as-you-type mode (only
-  // visible when active filters exist).
-  let resetButton: ReactNode = null
-  if (hasSearch) {
-    resetButton = (
-      <Button variant='outline' onClick={handleReset} disabled={!isFiltered}>
-        {t('Reset')}
-      </Button>
-    )
-  } else if (isFiltered) {
-    resetButton = (
-      <Button
-        variant='ghost'
-        onClick={handleReset}
-        className='text-muted-foreground hover:text-foreground gap-1 px-2'
-      >
-        {t('Reset')}
-        <Cross2Icon />
-      </Button>
-    )
-  }
-
-  const searchButton = hasSearch ? (
-    <Button onClick={props.onSearch} disabled={props.searchLoading}>
-      {props.searchLoading && <Spinner />}
-      {t('Search')}
-    </Button>
-  ) : null
-
-  const viewOptionsNode = !props.hideViewOptions ? (
-    <DataTableViewOptions table={props.table} />
-  ) : null
-
-  const viewToggleNode = props.viewToggle ?? null
-
-  const expandToggle = hasExpandable ? (
-    <Button
-      variant='ghost'
-      onClick={() => setExpanded((p) => !p)}
-      aria-expanded={expanded}
-      className={cn(
-        'text-muted-foreground hover:text-foreground gap-1 px-2',
-        props.hasExpandedActiveFilters &&
-          !expanded &&
-          'text-primary hover:text-primary'
-      )}
-    >
-      {expanded ? t('Collapse') : t('Expand')}
-      <ChevronDown
-        className={cn(
-          'size-3.5 transition-transform duration-200',
-          expanded && 'rotate-180'
-        )}
-      />
-    </Button>
-  ) : null
-
-  const hasLeftActions = props.leftActions != null
-
-  if (hasLeftActions) {
-    return (
-      <div className={cn('flex flex-col gap-2', props.className)}>
-        <div className='flex flex-wrap items-center gap-2 sm:gap-3'>
-          {props.customSearch !== undefined ? props.customSearch : searchInput}
-          {props.additionalSearch}
-          {filterChips}
-          <div className='ms-auto flex min-w-0 flex-wrap items-center justify-end gap-1.5 sm:gap-2'>
-            {expandToggle}
-          </div>
-        </div>
-
-        {expanded && hasExpandable && (
-          <div className='flex flex-wrap items-center gap-2 sm:gap-3'>
-            {props.expandable}
-          </div>
-        )}
-
-        <div className='flex flex-wrap items-center gap-2 sm:gap-3'>
-          {props.leftActions}
-          <div className='ms-auto flex min-w-0 flex-wrap items-center justify-end gap-1.5 sm:gap-2'>
-            {props.preActions}
-            {resetButton}
-            {searchButton}
-            {viewToggleNode}
-            {viewOptionsNode}
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div
-      className={cn(
-        'flex flex-wrap items-center gap-2 sm:gap-3',
-        props.className
-      )}
-    >
-      {props.customSearch !== undefined ? props.customSearch : searchInput}
-      {props.additionalSearch}
-      {filterChips}
-      {expanded && hasExpandable && props.expandable}
-
-      {/* The action cluster hugs the right edge. `shrink-0` was removed so an
-          over-long `viewToggle` (routes toolbar) cannot push the View Options
-          button past the viewport on mobile — with `min-w-0` children below
-          the label truncates and the 查看 button wraps to its own tight line
-          instead of being clipped by the page's overflow-x hidden. */}
+      {/* `shrink-0` is deliberately absent from the cluster: an over-long
+          `viewToggle` (the routes page's "show zero-channel models" switch)
+          must not push the View Options button past the viewport. With
+          `min-w-0` its label truncates and the button wraps to its own tight
+          line instead of being clipped by the page's overflow-x hidden. */}
       <div className='ms-auto flex min-w-0 flex-wrap items-center justify-end gap-1.5 sm:gap-2'>
         {props.preActions}
-        {resetButton}
-        {searchButton}
-        {viewToggleNode}
-        {viewOptionsNode}
-        {expandToggle}
+        {isFiltered && (
+          <Button
+            variant='ghost'
+            onClick={handleReset}
+            className='text-muted-foreground hover:text-foreground gap-1 px-2'
+          >
+            {t('Reset')}
+            <Cross2Icon />
+          </Button>
+        )}
+        {props.viewToggle}
+        <DataTableViewOptions table={props.table} />
+        {hasExpandable && (
+          <Button
+            variant='ghost'
+            onClick={() => setExpanded((previous) => !previous)}
+            aria-expanded={expanded}
+            className={cn(
+              'text-muted-foreground hover:text-foreground gap-1 px-2',
+              props.hasExpandedActiveFilters &&
+                !expanded &&
+                'text-primary hover:text-primary'
+            )}
+          >
+            {expanded ? t('Collapse') : t('Expand')}
+            <ChevronDown
+              className={cn(
+                'size-3.5 transition-transform duration-200',
+                expanded && 'rotate-180'
+              )}
+            />
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2754,7 +2754,6 @@
     "No records found. Try adjusting your filters.": "No records found. Try adjusting your filters.",
     "Filter...": "Filter…",
     "Reset": "Reset",
-    "Search": "Search",
     "columnSettings": "Columns",
     "Toggle columns": "Toggle columns",
     "selected": "selected",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2754,7 +2754,6 @@
     "No records found. Try adjusting your filters.": "未找到记录，请尝试调整筛选条件。",
     "Filter...": "筛选…",
     "Reset": "重置",
-    "Search": "搜索",
     "columnSettings": "列设置",
     "Toggle columns": "切换列",
     "selected": "已选",


### PR DESCRIPTION
The toolbar carried seven props that nothing passes. Checked against every `toolbarProps={{…}}` literal in the tree and both `<DataTableToolbar>` sites (`DataTablePage`'s pass-through and the search-commit test): `searchKey`, `customSearch`, `onSearch`, `searchLoading`, `hideViewOptions`, `leftActions` and `className` have zero call sites.

### What leaves with them

- **The form-mode Search button** — it needed `onSearch`, so it never rendered — and the outline Reset variant that only existed beside it. Reset is now the single ghost button that appears while something is filtered.
- **The `leftActions` branch**, i.e. the whole three-row layout. The toolbar is the one `flex-wrap` row [`docs/internal/design/a11y-checklist.md`](docs/internal/design/a11y-checklist.md) says it is.
- **The `searchKey` branch**, so the input only ever drives `table.globalFilter` and `commitSearchValue` no longer reaches for `getColumn`.
- **The flat `"Search"` i18n entry**, whose only reader was that button — removed from both locales in the same commit, since `i18n-keys.test.ts` requires parity.

Also gone: the `filterChips` `useMemo` and the `eslint-disable exhaustive-deps` holding it up. Every consumer builds `filters: [...]` inline in JSX, so the dependency changed identity on every render and the memo never served a cached value — it only cost a comparison. The chips map inline now.

### Tests

Both behaviours existed; neither was pinned.

- **`toolbar-reset.test.tsx`** (new): Reset is hidden while nothing is filtered; it clears the table's own filters and calls `onReset`; and it drops a search draft the debounce has not committed yet — the case where clearing table state alone would leave the typed text on screen.
- **`toolbar-search-enter.test.tsx`**: gains the IME case — a composition must not commit mid-flight, and must commit once it settles.

`424 → 272` lines.

### Verification (local, 2C/4G host)

- `oxlint` + `check:boundaries` (687 files / 0 cross-layer edges) + `check:form-control` (140 sites / 0 native)
- `oxfmt --check` (730 files) · `knip` · `routes:verify` (28/28)
- `vitest run --maxWorkers=1`: **262 files / 1711 tests** — one pre-existing 5s-timeout flake (`route-form-dialog-channels`, 120-account bulk submit) that is green on re-run in isolation
- leak-guard `--range master..HEAD`: RC 0

`tsgo -b` is not run locally (the host OOM-kills it); CI `frontend` is the typecheck authority.
