### PR TITLE
refactor(web): rewrite the table state hook around the state it owns

### DIFF
--- a/web/src/components/data-table/core/__tests__/header-keyboard-resize.test.tsx
+++ b/web/src/components/data-table/core/__tests__/header-keyboard-resize.test.tsx
@@ -1,0 +1,108 @@
+// metapi-go/data-table — the header's keyboard resize path.
+//
+// Column resizing has two inputs and only one of them is pointer-based: the drag
+// handler TanStack supplies cannot be reached from a keyboard, so the handle is
+// a focusable `role="separator"` that steps the width on arrows (Shift for a
+// coarser step) and reports the current width through `aria-valuenow`.
+//
+// jsdom has no layout engine, so a width cannot be observed as pixels here.
+// What is observable — and what the colgroup turns into `<col>` widths on a real
+// page — is the column-sizing state the handle writes, which is what these pin.
+import '@testing-library/jest-dom/vitest'
+import {
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from '@tanstack/react-table'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import '@/i18n/config'
+
+import { DataTableHeader } from '../data-table-header'
+
+type ProbeRow = { name: string }
+type ProbeTable = ReturnType<typeof useReactTable<ProbeRow>>
+
+const columns: ColumnDef<ProbeRow, unknown>[] = [
+  { accessorKey: 'name', header: 'Name', size: 200 },
+  // Content-sized: no share of the width budget, so no handle to resize it with.
+  { id: 'actions', header: 'Actions' },
+]
+
+function requireTable(table: ProbeTable | null): ProbeTable {
+  if (table === null) throw new Error('table instance was not initialized')
+  return table
+}
+
+function renderHeader() {
+  let tableInstance: ProbeTable | null = null
+
+  function Harness() {
+    const table = useReactTable({
+      data: [{ name: 'alpha' }],
+      columns,
+      getCoreRowModel: getCoreRowModel(),
+      enableColumnResizing: true,
+      columnResizeMode: 'onChange',
+    })
+    tableInstance = table
+    return (
+      <table>
+        <DataTableHeader table={table} />
+      </table>
+    )
+  }
+
+  render(<Harness />)
+  return { table: () => requireTable(tableInstance) }
+}
+
+afterEach(() => cleanup())
+
+describe('DataTableHeader keyboard resize', () => {
+  it('offers a handle on sized columns only', () => {
+    renderHeader()
+
+    const handles = screen.getAllByRole('separator')
+    expect(handles).toHaveLength(1)
+    expect(handles[0].closest('th')?.getAttribute('data-column-id')).toBe(
+      'name'
+    )
+  })
+
+  it('steps the width by 10px, and by 50px with Shift held', () => {
+    const { table } = renderHeader()
+    const handle = screen.getByRole('separator')
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' })
+    expect(table().getState().columnSizing).toEqual({ name: 210 })
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight', shiftKey: true })
+    expect(table().getState().columnSizing).toEqual({ name: 260 })
+
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' })
+    expect(table().getState().columnSizing).toEqual({ name: 250 })
+  })
+
+  it('leaves the width alone for keys that do not resize', () => {
+    const { table } = renderHeader()
+
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowUp' })
+    expect(table().getState().columnSizing).toEqual({})
+  })
+
+  it('announces the current width, and the new one after a step', () => {
+    const { table } = renderHeader()
+    const handle = screen.getByRole('separator')
+
+    expect(handle).toHaveAttribute('aria-valuenow', '200')
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' })
+    expect(table().getState().columnSizing).toEqual({ name: 210 })
+    expect(screen.getByRole('separator')).toHaveAttribute(
+      'aria-valuenow',
+      '210'
+    )
+  })
+})

--- a/web/src/components/data-table/core/data-table-header.tsx
+++ b/web/src/components/data-table/core/data-table-header.tsx
@@ -96,12 +96,16 @@ export function DataTableHeader<TData>({
   )
 }
 
+/** Keyboard resize steps in px: one arrow press, and one with Shift held. */
+const RESIZE_STEP_PX = 10
+const RESIZE_COARSE_STEP_PX = 50
+
 function handleColumnResizeKeyDown<TData>(
   event: KeyboardEvent<HTMLDivElement>,
   table: TanstackTable<TData>,
   header: Header<TData, unknown>
 ) {
-  const step = event.shiftKey ? 50 : 10
+  const step = event.shiftKey ? RESIZE_COARSE_STEP_PX : RESIZE_STEP_PX
 
   if (event.key === 'ArrowLeft') {
     event.preventDefault()
@@ -128,10 +132,7 @@ function resizeColumnByKeyboard<TData>(
 ) {
   table.setColumnSizing((previous) => ({
     ...previous,
-    [header.column.id]: getClampedColumnSize(
-      header,
-      header.column.getSize() + delta
-    ),
+    [header.column.id]: header.column.getSize() + delta,
   }))
 }
 
@@ -149,27 +150,13 @@ function autoSizeColumn<TData>(
     return
   }
 
+  // No clamping here: `column.getSize()` is where TanStack applies a column's
+  // own `minSize`/`maxSize` (and its 20px floor) on every read, so a second
+  // clamp on the way into state would only be a second rule to keep in step.
   table.setColumnSizing((previous) => ({
     ...previous,
-    [header.column.id]: getClampedColumnSize(header, measuredSize),
+    [header.column.id]: measuredSize,
   }))
-}
-
-function getClampedColumnSize<TData>(
-  header: Header<TData, unknown>,
-  nextSize: number
-) {
-  const { minSize, maxSize } = header.column.columnDef
-
-  if (typeof minSize === 'number' && nextSize < minSize) {
-    return minSize
-  }
-
-  if (typeof maxSize === 'number' && nextSize > maxSize) {
-    return maxSize
-  }
-
-  return nextSize
 }
 
 /** The widest laid-out width among the column's own cells, or undefined if

--- a/web/src/components/data-table/core/table-sizing.ts
+++ b/web/src/components/data-table/core/table-sizing.ts
@@ -7,8 +7,8 @@
 // This module is the whole model and nothing else — pure functions, no JSX, so
 // it stays on the non-component side of the `only-export-components` boundary.
 // `data-table-colgroup.tsx` renders it, `data-table-header.tsx` consults the
-// same predicate so a content-sized column is never given an explicit width,
-// and `getTableSizeStyle` reserves the budget on the `<table>` itself. The three
+// same predicate so a content-sized column gets no resize handle, and
+// `getTableSizeStyle` reserves the budget on the `<table>` itself. The three
 // have to agree, which is why they share one definition of "the budget".
 
 import type { Table as TanstackTable } from '@tanstack/react-table'

--- a/web/src/components/data-table/hooks/__tests__/use-data-table-persistence.test.tsx
+++ b/web/src/components/data-table/hooks/__tests__/use-data-table-persistence.test.tsx
@@ -1,0 +1,182 @@
+// metapi-go/data-table — the persisted column preferences.
+//
+// Column visibility and sizing are the only table state that outlives the page:
+// both go to localStorage under a per-page key. That makes them the one place
+// where user-editable data flows *into* table state, so the contract is pinned
+// here: hydrate from storage, write changes back, survive junk instead of
+// throwing on it, and re-read when the storage key changes under a mounted hook
+// (the settings pages reuse one table component across sections).
+import type { ColumnDef } from '@tanstack/react-table'
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDataTable } from '@/components/data-table'
+
+type ProbeRow = { id: number; name: string }
+type ProbeTable = ReturnType<typeof useDataTable<ProbeRow>>['table']
+type ProbeOptions = {
+  columnVisibilityStorageKey?: string
+  columnSizingStorageKey?: string
+  initialColumnVisibility?: Record<string, boolean>
+}
+
+const VISIBILITY_KEY = 'test.probe.columnVisibility'
+const OTHER_VISIBILITY_KEY = 'test.probe.columnVisibility.other'
+const SIZING_KEY = 'test.probe.columnSizing'
+
+const rows: ProbeRow[] = [
+  { id: 1, name: 'alpha' },
+  { id: 2, name: 'beta' },
+]
+
+const columns: ColumnDef<ProbeRow, unknown>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { id: 'owner', header: 'Owner' },
+]
+
+function requireTable(table: ProbeTable | null): ProbeTable {
+  if (table === null) throw new Error('table instance was not initialized')
+  return table
+}
+
+function stored(key: string): unknown {
+  const raw = window.localStorage.getItem(key)
+  return raw === null ? null : JSON.parse(raw)
+}
+
+function renderTable(options: ProbeOptions) {
+  let tableInstance: ProbeTable | null = null
+
+  function Harness(props: { options: ProbeOptions }) {
+    const { table } = useDataTable<ProbeRow>({
+      data: rows,
+      columns,
+      enableColumnResizing: true,
+      ...props.options,
+    })
+    tableInstance = table
+    return <span>harness</span>
+  }
+
+  const view = render(<Harness options={options} />)
+
+  return {
+    table: () => requireTable(tableInstance),
+    rerenderWith: (next: ProbeOptions) =>
+      view.rerender(<Harness options={next} />),
+  }
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('useDataTable column visibility persistence', () => {
+  it('hides the columns storage says are hidden', () => {
+    window.localStorage.setItem(
+      VISIBILITY_KEY,
+      JSON.stringify({ owner: false, name: true })
+    )
+
+    const { table } = renderTable({
+      columnVisibilityStorageKey: VISIBILITY_KEY,
+    })
+
+    expect(table().getColumn('owner')?.getIsVisible()).toBe(false)
+    expect(table().getColumn('name')?.getIsVisible()).toBe(true)
+  })
+
+  it('writes a visibility change back to storage', () => {
+    const { table } = renderTable({
+      columnVisibilityStorageKey: VISIBILITY_KEY,
+    })
+
+    act(() => {
+      table().setColumnVisibility({ owner: false })
+    })
+
+    expect(stored(VISIBILITY_KEY)).toEqual({ owner: false })
+  })
+
+  it('keeps everything visible when storage holds junk', () => {
+    for (const junk of ['{not json', '[1,2]', '"owner"', 'null']) {
+      window.localStorage.setItem(VISIBILITY_KEY, junk)
+
+      const { table } = renderTable({
+        columnVisibilityStorageKey: VISIBILITY_KEY,
+      })
+
+      expect(table().getColumn('owner')?.getIsVisible()).toBe(true)
+      cleanup()
+    }
+  })
+
+  it('drops stored entries that are not booleans', () => {
+    window.localStorage.setItem(
+      VISIBILITY_KEY,
+      JSON.stringify({ owner: 'no', name: false })
+    )
+
+    const { table } = renderTable({
+      columnVisibilityStorageKey: VISIBILITY_KEY,
+    })
+
+    // `name` is a real preference; `owner`'s string is not, and defaults win.
+    expect(table().getState().columnVisibility).toEqual({ name: false })
+  })
+
+  it('re-reads when the storage key changes under a mounted table', () => {
+    window.localStorage.setItem(
+      VISIBILITY_KEY,
+      JSON.stringify({ owner: false })
+    )
+    window.localStorage.setItem(
+      OTHER_VISIBILITY_KEY,
+      JSON.stringify({ name: false })
+    )
+
+    const { table, rerenderWith } = renderTable({
+      columnVisibilityStorageKey: VISIBILITY_KEY,
+    })
+    expect(table().getColumn('owner')?.getIsVisible()).toBe(false)
+
+    rerenderWith({ columnVisibilityStorageKey: OTHER_VISIBILITY_KEY })
+
+    expect(table().getState().columnVisibility).toEqual({ name: false })
+    // Re-hydrating is not a user change: the old key keeps what it had.
+    expect(stored(VISIBILITY_KEY)).toEqual({ owner: false })
+  })
+})
+
+describe('useDataTable column sizing persistence', () => {
+  it('debounces the write, because a resize drag changes it per pointer move', () => {
+    vi.useFakeTimers()
+    const { table } = renderTable({ columnSizingStorageKey: SIZING_KEY })
+
+    act(() => {
+      table().setColumnSizing({ name: 240 })
+    })
+    expect(window.localStorage.getItem(SIZING_KEY)).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(250)
+    })
+    expect(stored(SIZING_KEY)).toEqual({ name: 240 })
+  })
+
+  it('drops stored widths that are not positive numbers', () => {
+    window.localStorage.setItem(
+      SIZING_KEY,
+      JSON.stringify({ name: -5, owner: '180', id: 0, size: 120 })
+    )
+
+    const { table } = renderTable({ columnSizingStorageKey: SIZING_KEY })
+
+    expect(table().getState().columnSizing).toEqual({ size: 120 })
+  })
+})

--- a/web/src/components/data-table/hooks/use-data-table.ts
+++ b/web/src/components/data-table/hooks/use-data-table.ts
@@ -1,24 +1,38 @@
-// metapi-go/data-table — ported from newapi
-// useDataTable provides the controlled-state layer of the three-stage URL state
-// sync pattern (route validateSearch -> feature useSearch -> useDataTable). The
-// hook accepts externally-owned state (sorting/pagination/filters) plus
-// onChange callbacks, so a route loader can feed URL params in and onChange
-// can drive router navigation. The validateSearch + useSearch stages live in
-// the feature/route layer (out of data-table scope).
+// metapi-go/data-table — useDataTable: the table's state layer.
+//
+// The only place this package touches `useReactTable`. It wires the row models
+// to the page's filtering mode, hands TanStack the server's row count, and owns
+// the two column preferences that survive a reload.
+//
+// Who owns which state is the part worth being precise about, because this is
+// where the three-stage URL sync (route `validateSearch` → feature `useSearch` →
+// `useDataTable`) meets the table:
+//
+//   URL-owned       sorting, pagination, column filters and the global filter
+//                   are *controlled* here — the feature passes the value it
+//                   read from the route plus an `onChange` that navigates, and
+//                   the table keeps no copy of its own. That is what makes a
+//                   reload or a back-navigation restore the view.
+//   table-owned     row selection is left to TanStack. Nothing outside the
+//                   table reads it, and a second copy would only be a second
+//                   thing to keep in sync.
+//   storage-owned   column visibility and sizing are uncontrolled but
+//                   persisted: they are presentation, not a shareable view.
+//
+// Every setter below keeps the previous reference when an update changes
+// nothing. That is load-bearing rather than a micro-optimisation — see
+// `isShallowEqual`.
 import {
   type ColumnDef,
   type ColumnFiltersState,
   type ColumnSizingState,
-  type ExpandedState,
   type OnChangeFn,
   type PaginationState,
-  type RowSelectionState,
   type SortingState,
   type TableOptions,
   type Updater,
   type VisibilityState,
   getCoreRowModel,
-  getExpandedRowModel,
   getFacetedRowModel,
   getFacetedUniqueValues,
   getFilteredRowModel,
@@ -28,79 +42,11 @@ import {
 } from '@tanstack/react-table'
 import * as React from 'react'
 
-type DataTableFeatureOptions<TData> = Pick<
-  TableOptions<TData>,
-  | 'enableRowSelection'
-  | 'getRowId'
-  | 'getSubRows'
-  | 'globalFilterFn'
-  | 'autoResetPageIndex'
-  | 'manualFiltering'
-  | 'manualPagination'
-  | 'manualSorting'
-  | 'enableSorting'
-  | 'enableColumnResizing'
->
-
-type DataTableStateOptions = {
-  initialSorting?: SortingState
-  sorting?: SortingState
-  onSortingChange?: OnChangeFn<SortingState>
-  initialColumnVisibility?: VisibilityState
-  columnVisibilityStorageKey?: string | false
-  columnVisibility?: VisibilityState
-  onColumnVisibilityChange?: OnChangeFn<VisibilityState>
-  initialColumnSizing?: ColumnSizingState
-  columnSizingStorageKey?: string | false
-  columnSizing?: ColumnSizingState
-  onColumnSizingChange?: OnChangeFn<ColumnSizingState>
-  initialRowSelection?: RowSelectionState
-  rowSelection?: RowSelectionState
-  onRowSelectionChange?: OnChangeFn<RowSelectionState>
-  initialExpanded?: ExpandedState
-  expanded?: ExpandedState
-  onExpandedChange?: OnChangeFn<ExpandedState>
-  columnFilters?: ColumnFiltersState
-  onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>
-  globalFilter?: string
-  onGlobalFilterChange?: OnChangeFn<string>
-  initialPagination?: PaginationState
-  pagination?: PaginationState
-  onPaginationChange?: OnChangeFn<PaginationState>
-}
-
-type DataTableRowModelOptions = {
-  withFilteredRowModel?: boolean
-  withPaginationRowModel?: boolean
-  withSortedRowModel?: boolean
-  withFacetedRowModel?: boolean
-  withExpandedRowModel?: boolean
-}
-
-type UseDataTableOptions<TData> = DataTableFeatureOptions<TData> &
-  DataTableStateOptions &
-  DataTableRowModelOptions & {
-    data: TData[]
-    columns: ColumnDef<TData, unknown>[]
-    totalCount?: number
-    pageCount?: number
-    ensurePageInRange?: (pageCount: number) => void
-  }
-
-type ColumnSizingBounds = Record<
-  string,
-  {
-    minSize?: number
-    maxSize?: number
-  }
->
-
-type ColumnWithSizing<TData> = ColumnDef<TData, unknown> & {
-  accessorKey?: string | number
-  columns?: ColumnDef<TData, unknown>[]
-}
-
-const COLUMN_SIZING_PERSIST_DELAY_MS = 250
+/** Where a page that does not control pagination starts. */
+const DEFAULT_PAGINATION: PaginationState = { pageIndex: 0, pageSize: 20 }
+const EMPTY_SORTING: SortingState = []
+const EMPTY_VISIBILITY: VisibilityState = {}
+const EMPTY_SIZING: ColumnSizingState = {}
 
 /**
  * Shared empty column-filters value for tables without filtering.
@@ -117,12 +63,65 @@ const COLUMN_SIZING_PERSIST_DELAY_MS = 250
  */
 const EMPTY_COLUMN_FILTERS: ColumnFiltersState = []
 
+/** Column sizing is written debounced: a resize drag changes it per pointer move. */
+const COLUMN_SIZING_PERSIST_DELAY_MS = 250
+
+type UseDataTableOptions<TData> = Pick<
+  TableOptions<TData>,
+  | 'autoResetPageIndex'
+  | 'enableColumnResizing'
+  | 'enableRowSelection'
+  | 'getRowId'
+  | 'globalFilterFn'
+  | 'manualFiltering'
+  | 'manualPagination'
+  | 'manualSorting'
+> & {
+  data: TData[]
+  columns: ColumnDef<TData, unknown>[]
+
+  /**
+   * Total row count reported by the server. Drives the page count and is handed
+   * to TanStack as `rowCount`, so `manualPagination` pages show a real pager.
+   */
+  totalCount?: number
+
+  /**
+   * Called whenever the table's page count changes, so a page can pull itself
+   * back into range — e.g. after deleting the last row of the last page.
+   */
+  ensurePageInRange?: (pageCount: number) => void
+
+  // --- URL-owned (controlled) state -------------------------------------
+
+  sorting?: SortingState
+  onSortingChange?: OnChangeFn<SortingState>
+  pagination?: PaginationState
+  onPaginationChange?: OnChangeFn<PaginationState>
+  columnFilters?: ColumnFiltersState
+  onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>
+  globalFilter?: string
+  onGlobalFilterChange?: OnChangeFn<string>
+
+  // --- storage-owned column preferences ---------------------------------
+
+  /** Visibility to start from; what is in storage wins over it. */
+  initialColumnVisibility?: VisibilityState
+  /** localStorage key holding column visibility. Omit to keep it in memory. */
+  columnVisibilityStorageKey?: string
+  /** localStorage key holding column widths. Omit to keep them in memory. */
+  columnSizingStorageKey?: string
+}
+
 /**
- * Shallow structural equality (one level, reference-equal leaves) over
- * plain objects and arrays. Used by `useControllableTableState` to treat
- * no-op table updates (e.g. a page-index reset to the current value, which
- * TanStack still emits as a fresh `{ ...old, pageIndex }` object) as
- * unchanged, so React's eager state bail-out can skip the re-render.
+ * Shallow structural equality (one level, reference-equal leaves) over plain
+ * objects and arrays.
+ *
+ * A no-op table update must keep the previous reference: TanStack's
+ * `resetPageIndex` emits `{ ...old, pageIndex }` even when the page index is
+ * unchanged, and re-rendering on that fresh object is what re-fuels the
+ * auto-reset microtask loop described on `EMPTY_COLUMN_FILTERS`. Returning the
+ * same reference lets React's eager state bail-out skip the render entirely.
  */
 function isShallowEqual<TValue>(a: TValue, b: TValue): boolean {
   if (Object.is(a, b)) {
@@ -161,171 +160,188 @@ function resolveUpdater<TValue>(
     : updater
 }
 
+/** State the table owns alone, with the no-op bail-out above. */
+function useTableState<TValue>(
+  initialValue: TValue | (() => TValue)
+): [TValue, OnChangeFn<TValue>] {
+  const [value, setValue] = React.useState<TValue>(initialValue)
+
+  const onChange = React.useCallback<OnChangeFn<TValue>>((updater) => {
+    setValue((previous) => {
+      const next = resolveUpdater(updater, previous)
+      return isShallowEqual(next, previous) ? previous : next
+    })
+  }, [])
+
+  return [value, onChange]
+}
+
+/**
+ * State a feature owns through the URL, with the table as fallback for pages
+ * that do not.
+ *
+ * The `onChange` is called through a ref so the setter keeps one identity: a
+ * fresh setter per render re-resolves the TanStack table, which re-runs its
+ * `autoResetPageIndex` effect and can feed an infinite render loop through the
+ * URL sync.
+ */
 function useControllableTableState<TValue>(
   controlledValue: TValue | undefined,
   defaultValue: TValue,
   onChange: OnChangeFn<TValue> | undefined
 ): [TValue, OnChangeFn<TValue>] {
-  const [uncontrolledValue, setUncontrolledValue] =
-    React.useState<TValue>(defaultValue)
+  const [uncontrolledValue, setUncontrolledValue] = useTableState(defaultValue)
 
-  const value = controlledValue ?? uncontrolledValue
-
-  // Keep the callback stable: a fresh setValue identity on every render
-  // re-resolves the TanStack table, which re-runs its autoResetPageIndex
-  // effect and can feed an infinite render loop through the URL sync.
   const onChangeRef = React.useRef(onChange)
   onChangeRef.current = onChange
 
   const setValue = React.useCallback<OnChangeFn<TValue>>(
     (updater) => {
       if (controlledValue === undefined) {
-        setUncontrolledValue((previous) => {
-          const next = resolveUpdater(updater, previous)
-          // No-op updates must keep the previous reference: TanStack's
-          // resetPageIndex emits `{ ...old, pageIndex }` even when the page
-          // index is unchanged, and re-rendering on that fresh object is
-          // what re-fuels the auto-reset microtask loop. Returning the same
-          // reference lets React's eager bail-out skip the render entirely.
-          return isShallowEqual(next, previous) ? previous : next
-        })
+        setUncontrolledValue(updater)
       }
       onChangeRef.current?.(updater)
     },
-    [controlledValue]
+    [controlledValue, setUncontrolledValue]
   )
 
-  return [value, setValue]
+  return [controlledValue ?? uncontrolledValue, setValue]
 }
 
-function readColumnVisibility(storageKey: string | undefined): VisibilityState {
-  if (!storageKey || typeof window === 'undefined') return {}
-
-  try {
-    const raw = window.localStorage.getItem(storageKey)
-    if (!raw) return {}
-
-    const parsed = JSON.parse(raw) as unknown
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return {}
-    }
-
-    return Object.entries(parsed).reduce<VisibilityState>(
-      (visibility, [key, value]) => {
-        if (typeof value === 'boolean') {
-          visibility[key] = value
-        }
-        return visibility
-      },
-      {}
-    )
-  } catch {
-    return {}
-  }
-}
-
-function getColumnId<TData>(column: ColumnDef<TData, unknown>) {
-  const columnWithSizing = column as ColumnWithSizing<TData>
-
-  if (typeof columnWithSizing.id === 'string') {
-    return columnWithSizing.id
-  }
-
-  if (typeof columnWithSizing.accessorKey === 'string') {
-    return columnWithSizing.accessorKey.replaceAll('.', '_')
-  }
-
-  if (typeof columnWithSizing.accessorKey === 'number') {
-    return String(columnWithSizing.accessorKey)
-  }
-
-  return undefined
-}
-
-function buildColumnSizingBounds<TData>(
-  columns: ColumnDef<TData, unknown>[]
-): ColumnSizingBounds {
-  return columns.reduce<ColumnSizingBounds>((bounds, column) => {
-    const columnWithSizing = column as ColumnWithSizing<TData>
-    const columnId = getColumnId(column)
-
-    if (columnId) {
-      const minSize =
-        typeof columnWithSizing.minSize === 'number' &&
-        Number.isFinite(columnWithSizing.minSize)
-          ? columnWithSizing.minSize
-          : undefined
-      const maxSize =
-        typeof columnWithSizing.maxSize === 'number' &&
-        Number.isFinite(columnWithSizing.maxSize)
-          ? columnWithSizing.maxSize
-          : undefined
-
-      if (minSize !== undefined || maxSize !== undefined) {
-        bounds[columnId] = { minSize, maxSize }
-      }
-    }
-
-    if (Array.isArray(columnWithSizing.columns)) {
-      Object.assign(bounds, buildColumnSizingBounds(columnWithSizing.columns))
-    }
-
-    return bounds
-  }, {})
-}
-
-function getBoundedColumnSize(
-  columnId: string,
-  value: unknown,
-  bounds: ColumnSizingBounds
-) {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return undefined
-  }
-
-  const columnBounds = bounds[columnId]
-  let size = value
-
-  if (columnBounds?.minSize !== undefined && size < columnBounds.minSize) {
-    size = columnBounds.minSize
-  }
-
-  if (columnBounds?.maxSize !== undefined && size > columnBounds.maxSize) {
-    size = columnBounds.maxSize
-  }
-
-  return size > 0 ? size : undefined
-}
-
-function readColumnSizing(
+/**
+ * A JSON object read out of localStorage, validated entry by entry.
+ *
+ * Everything unusable — no key, unreadable storage, invalid JSON, a non-object,
+ * an entry `readEntry` rejects — is dropped rather than thrown. These keys are
+ * user-editable, and a corrupt column preference must not break the table.
+ */
+function readStoredRecord<TValue>(
   storageKey: string | undefined,
-  bounds: ColumnSizingBounds
-): ColumnSizingState {
-  if (!storageKey || typeof window === 'undefined') return {}
+  readEntry: (value: unknown) => TValue | undefined
+): Record<string, TValue> {
+  if (!storageKey) return {}
 
   try {
     const raw = window.localStorage.getItem(storageKey)
     if (!raw) return {}
 
-    const parsed = JSON.parse(raw) as unknown
+    const parsed: unknown = JSON.parse(raw)
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return {}
     }
 
-    return Object.entries(parsed).reduce<ColumnSizingState>(
-      (sizing, [key, value]) => {
-        const boundedSize = getBoundedColumnSize(key, value, bounds)
-
-        if (boundedSize !== undefined) {
-          sizing[key] = boundedSize
-        }
-        return sizing
-      },
-      {}
-    )
+    const record: Record<string, TValue> = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      const entry = readEntry(value)
+      if (entry !== undefined) record[key] = entry
+    }
+    return record
   } catch {
     return {}
   }
+}
+
+function writeStoredRecord(storageKey: string, value: unknown) {
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(value))
+  } catch {
+    // Private mode and full quotas are ordinary; losing the preference is not
+    // worth breaking the table over.
+  }
+}
+
+/** Stored column visibility: booleans, anything else dropped. */
+function readStoredColumnVisibility(
+  storageKey: string | undefined
+): VisibilityState {
+  return readStoredRecord(storageKey, (value) =>
+    typeof value === 'boolean' ? value : undefined
+  )
+}
+
+/**
+ * Stored column widths in px: positive finite numbers, anything else dropped.
+ * Out-of-range values need no clamping here — TanStack clamps a column's size
+ * to its own `minSize`/`maxSize` when it is read back, so a width stored before
+ * a column changed cannot escape the bounds it has now.
+ */
+function readStoredColumnSizing(
+  storageKey: string | undefined
+): ColumnSizingState {
+  return readStoredRecord(storageKey, (value) =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? value
+      : undefined
+  )
+}
+
+type PersistedColumnStateOptions<TValue extends object> = {
+  storageKey: string | undefined
+  /** Reads and validates what is in storage. Must be a stable reference. */
+  read: (storageKey: string | undefined) => TValue
+  /** Values the stored ones are merged over. Must be a stable reference. */
+  defaults: TValue
+  /** Debounce the write; 0 writes on the change itself. */
+  debounceMs?: number
+}
+
+/**
+ * Column state that survives a reload: read once per storage key, written back
+ * on change.
+ *
+ * The read is deliberately *not* per render. Reading and parsing localStorage
+ * on every render is what the previous shape did (its memo depended on a
+ * destructuring default that was a fresh object each time), and it is pure
+ * waste: the stored value cannot change while the component is mounted.
+ *
+ * A write is skipped once after a re-hydration. When the storage key changes
+ * under a mounted hook — the settings pages reuse one table component across
+ * sections, each with its own key — the freshly read value is pushed into
+ * state, and echoing it straight back to storage would be a no-op at best.
+ */
+function usePersistedColumnState<TValue extends object>({
+  storageKey,
+  read,
+  defaults,
+  debounceMs = 0,
+}: PersistedColumnStateOptions<TValue>): [TValue, OnChangeFn<TValue>] {
+  const [value, setValue] = useTableState<TValue>(() => ({
+    ...defaults,
+    ...read(storageKey),
+  }))
+
+  const hydratedKeyRef = React.useRef(storageKey)
+  const skipNextPersistRef = React.useRef(false)
+
+  React.useEffect(() => {
+    if (storageKey === hydratedKeyRef.current) return
+
+    hydratedKeyRef.current = storageKey
+    skipNextPersistRef.current = true
+    setValue(() => ({ ...defaults, ...read(storageKey) }))
+  }, [defaults, read, setValue, storageKey])
+
+  React.useEffect(() => {
+    if (!storageKey) return
+
+    if (skipNextPersistRef.current) {
+      skipNextPersistRef.current = false
+      return
+    }
+
+    if (debounceMs <= 0) {
+      writeStoredRecord(storageKey, value)
+      return
+    }
+
+    const timer = window.setTimeout(
+      () => writeStoredRecord(storageKey, value),
+      debounceMs
+    )
+    return () => window.clearTimeout(timer)
+  }, [debounceMs, storageKey, value])
+
+  return [value, setValue]
 }
 
 export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
@@ -333,122 +349,65 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
     data,
     columns,
     totalCount,
-    pageCount: explicitPageCount,
     ensurePageInRange,
     manualFiltering,
     manualPagination,
     manualSorting,
-    initialSorting = [],
-    initialColumnVisibility = {},
-    initialColumnSizing = {},
-    initialRowSelection = {},
-    initialExpanded = {},
-    initialPagination = { pageIndex: 0, pageSize: 20 },
-    withFilteredRowModel = !manualFiltering,
-    withPaginationRowModel = !manualPagination,
-    withSortedRowModel = !manualSorting && !manualPagination,
-    withFacetedRowModel = !manualFiltering,
-    withExpandedRowModel = false,
   } = options
 
-  const columnVisibilityStorageKey =
-    typeof options.columnVisibilityStorageKey === 'string'
-      ? options.columnVisibilityStorageKey
-      : undefined
-  const columnSizingStorageKey =
-    typeof options.columnSizingStorageKey === 'string'
-      ? options.columnSizingStorageKey
-      : undefined
-  const resolvedInitialColumnVisibility = React.useMemo(
-    () => ({
-      ...initialColumnVisibility,
-      ...readColumnVisibility(columnVisibilityStorageKey),
-    }),
-    [columnVisibilityStorageKey, initialColumnVisibility]
-  )
-  const columnSizingBounds = React.useMemo(
-    () => buildColumnSizingBounds(columns),
-    [columns]
-  )
-  const resolvedInitialColumnSizing = React.useMemo(
-    () => ({
-      ...initialColumnSizing,
-      ...readColumnSizing(columnSizingStorageKey, columnSizingBounds),
-    }),
-    [columnSizingBounds, columnSizingStorageKey, initialColumnSizing]
-  )
+  const [columnVisibility, onColumnVisibilityChange] =
+    usePersistedColumnState<VisibilityState>({
+      storageKey: options.columnVisibilityStorageKey,
+      read: readStoredColumnVisibility,
+      defaults: options.initialColumnVisibility ?? EMPTY_VISIBILITY,
+    })
+
+  const [columnSizing, onColumnSizingChange] =
+    usePersistedColumnState<ColumnSizingState>({
+      storageKey: options.columnSizingStorageKey,
+      read: readStoredColumnSizing,
+      defaults: EMPTY_SIZING,
+      debounceMs: COLUMN_SIZING_PERSIST_DELAY_MS,
+    })
 
   const [sorting, onSortingChange] = useControllableTableState(
     options.sorting,
-    initialSorting,
+    EMPTY_SORTING,
     options.onSortingChange
-  )
-  const [columnVisibility, onColumnVisibilityChange] =
-    useControllableTableState(
-      options.columnVisibility,
-      resolvedInitialColumnVisibility,
-      options.onColumnVisibilityChange
-    )
-  const [columnSizing, onColumnSizingChange] = useControllableTableState(
-    options.columnSizing,
-    resolvedInitialColumnSizing,
-    options.onColumnSizingChange
-  )
-  const hydratedColumnVisibilityStorageKeyRef = React.useRef(
-    columnVisibilityStorageKey
-  )
-  const hydratedColumnSizingStorageKeyRef = React.useRef(columnSizingStorageKey)
-  const skipNextColumnVisibilityPersistRef = React.useRef(false)
-  const skipNextColumnSizingPersistRef = React.useRef(false)
-  const columnSizingPersistTimerRef = React.useRef<number | undefined>(
-    undefined
-  )
-  const [rowSelection, onRowSelectionChange] = useControllableTableState(
-    options.rowSelection,
-    initialRowSelection,
-    options.onRowSelectionChange
-  )
-  const [expanded, onExpandedChange] = useControllableTableState(
-    options.expanded,
-    initialExpanded,
-    options.onExpandedChange
   )
   const [pagination, onPaginationChange] = useControllableTableState(
     options.pagination,
-    initialPagination,
+    DEFAULT_PAGINATION,
     options.onPaginationChange
   )
 
-  const resolvedPageCount =
-    explicitPageCount ??
-    (totalCount !== undefined
-      ? Math.ceil(totalCount / pagination.pageSize)
-      : undefined)
-  const resolvedEnableSorting =
-    options.enableSorting ??
-    (!manualPagination ||
-      Boolean(options.sorting) ||
-      Boolean(options.onSortingChange))
+  // Sorting is only offered where it can be honoured: a server-paginated page
+  // that does not wire sorting through the URL would render clickable headers
+  // that reorder nothing.
+  const enableSorting =
+    !manualPagination ||
+    options.sorting !== undefined ||
+    options.onSortingChange !== undefined
 
   const table = useReactTable({
     data,
     columns,
     rowCount: totalCount,
-    pageCount: resolvedPageCount,
+    pageCount:
+      totalCount !== undefined
+        ? Math.ceil(totalCount / pagination.pageSize)
+        : undefined,
     state: {
       sorting,
       columnVisibility,
       columnSizing,
-      rowSelection,
-      expanded,
       columnFilters: options.columnFilters ?? EMPTY_COLUMN_FILTERS,
       globalFilter: options.globalFilter ?? '',
       pagination,
     },
     enableRowSelection: options.enableRowSelection,
-    enableSorting: resolvedEnableSorting,
+    enableSorting,
     getRowId: options.getRowId,
-    getSubRows: options.getSubRows,
     globalFilterFn: options.globalFilterFn ?? 'auto',
     autoResetPageIndex: options.autoResetPageIndex,
     manualFiltering,
@@ -459,120 +418,29 @@ export function useDataTable<TData>(options: UseDataTableOptions<TData>) {
     onSortingChange,
     onColumnVisibilityChange,
     onColumnSizingChange,
-    onRowSelectionChange,
-    onExpandedChange,
     onColumnFiltersChange: options.onColumnFiltersChange,
     onGlobalFilterChange: options.onGlobalFilterChange,
     onPaginationChange,
     getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: withFilteredRowModel
-      ? getFilteredRowModel()
-      : undefined,
-    getPaginationRowModel: withPaginationRowModel
-      ? getPaginationRowModel()
-      : undefined,
-    getSortedRowModel: withSortedRowModel ? getSortedRowModel() : undefined,
-    getFacetedRowModel: withFacetedRowModel ? getFacetedRowModel() : undefined,
-    getFacetedUniqueValues: withFacetedRowModel
-      ? getFacetedUniqueValues()
-      : undefined,
-    getExpandedRowModel: withExpandedRowModel
-      ? getExpandedRowModel()
-      : undefined,
+    // Row models follow the mode: a `manual*` page does that work server-side,
+    // and a client-side model here would re-filter or re-sort only the rows of
+    // the current page — contradicting the count the server reported.
+    getFilteredRowModel: manualFiltering ? undefined : getFilteredRowModel(),
+    getPaginationRowModel: manualPagination
+      ? undefined
+      : getPaginationRowModel(),
+    getSortedRowModel:
+      manualSorting || manualPagination ? undefined : getSortedRowModel(),
+    getFacetedRowModel: manualFiltering ? undefined : getFacetedRowModel(),
+    getFacetedUniqueValues: manualFiltering
+      ? undefined
+      : getFacetedUniqueValues(),
   })
 
-  const actualPageCount = table.getPageCount()
+  const resolvedPageCount = table.getPageCount()
   React.useEffect(() => {
-    ensurePageInRange?.(actualPageCount)
-  }, [actualPageCount, ensurePageInRange])
-
-  React.useEffect(() => {
-    if (
-      options.columnVisibility !== undefined ||
-      columnVisibilityStorageKey ===
-        hydratedColumnVisibilityStorageKeyRef.current
-    ) {
-      return
-    }
-
-    hydratedColumnVisibilityStorageKeyRef.current = columnVisibilityStorageKey
-    skipNextColumnVisibilityPersistRef.current = true
-    onColumnVisibilityChange(() => resolvedInitialColumnVisibility)
-  }, [
-    columnVisibilityStorageKey,
-    onColumnVisibilityChange,
-    options.columnVisibility,
-    resolvedInitialColumnVisibility,
-  ])
-
-  React.useEffect(() => {
-    if (
-      options.columnSizing !== undefined ||
-      columnSizingStorageKey === hydratedColumnSizingStorageKeyRef.current
-    ) {
-      return
-    }
-
-    hydratedColumnSizingStorageKeyRef.current = columnSizingStorageKey
-    skipNextColumnSizingPersistRef.current = true
-    onColumnSizingChange(() => resolvedInitialColumnSizing)
-  }, [
-    columnSizingStorageKey,
-    onColumnSizingChange,
-    options.columnSizing,
-    resolvedInitialColumnSizing,
-  ])
-
-  React.useEffect(() => {
-    if (!columnVisibilityStorageKey || typeof window === 'undefined') return
-
-    if (skipNextColumnVisibilityPersistRef.current) {
-      skipNextColumnVisibilityPersistRef.current = false
-      return
-    }
-
-    try {
-      window.localStorage.setItem(
-        columnVisibilityStorageKey,
-        JSON.stringify(columnVisibility)
-      )
-    } catch {
-      // Storage can be unavailable in private mode; table controls still work.
-    }
-  }, [columnVisibility, columnVisibilityStorageKey])
-
-  React.useEffect(() => {
-    if (!columnSizingStorageKey || typeof window === 'undefined') return
-
-    if (skipNextColumnSizingPersistRef.current) {
-      skipNextColumnSizingPersistRef.current = false
-      return
-    }
-
-    if (columnSizingPersistTimerRef.current !== undefined) {
-      window.clearTimeout(columnSizingPersistTimerRef.current)
-    }
-
-    columnSizingPersistTimerRef.current = window.setTimeout(() => {
-      try {
-        window.localStorage.setItem(
-          columnSizingStorageKey,
-          JSON.stringify(columnSizing)
-        )
-      } catch {
-        // Storage can be unavailable in private mode; table controls still work.
-      } finally {
-        columnSizingPersistTimerRef.current = undefined
-      }
-    }, COLUMN_SIZING_PERSIST_DELAY_MS)
-
-    return () => {
-      if (columnSizingPersistTimerRef.current !== undefined) {
-        window.clearTimeout(columnSizingPersistTimerRef.current)
-        columnSizingPersistTimerRef.current = undefined
-      }
-    }
-  }, [columnSizing, columnSizingStorageKey])
+    ensurePageInRange?.(resolvedPageCount)
+  }, [ensurePageInRange, resolvedPageCount])
 
   return {
     table,


### PR DESCRIPTION
`useDataTable`'s options type listed 43 fields; 22 had no caller in any of the
thirteen call sites (nine pages, four test harnesses) — checked by parsing every
`useDataTable({…})` literal and collecting its keys, not by reading:

  initial{Sorting,ColumnSizing,RowSelection,Expanded,Pagination}, pageCount,
  enableSorting, getSubRows, expanded, onExpandedChange, rowSelection,
  onRowSelectionChange, columnVisibility, onColumnVisibilityChange,
  columnSizing, onColumnSizingChange,
  with{Filtered,Pagination,Sorted,Faceted,Expanded}RowModel

What goes with them:

- Five `with*RowModel` flags, always left at the default the hook derived from
  `manual*` anyway. The row models now follow the mode directly, with the reason
  written where they are chosen: on a `manual*` page the server already did the
  work, and a client-side model here would re-sort only the current page and
  contradict the count the server reported.
- The row-selection and expansion state. Both were "controlled" for nobody: the
  hook returns `{ table }`, so no caller could read them, and TanStack keeps its
  own copy the moment they are left out of `state`. Expansion went entirely —
  `getExpandedRowModel` was off by default and nothing turned it on, so the
  state was inert.
- `enableSorting`, whose default was the only behaviour any caller ever got:
  offer sorting where it can be honoured, i.e. not on a server-paginated page
  unless that page wires sorting through the URL. The default is now the code,
  with that reason next to it.
- The column-size bounds machinery — `ColumnSizingBounds`, `ColumnWithSizing`,
  `getColumnId` (which re-derived TanStack's own column-id rules, grouped
  columns included), `buildColumnSizingBounds`, `getBoundedColumnSize`: ~75
  lines clamping stored widths to a column's `minSize`/`maxSize`. No column in
  the app declares either, and `column.getSize()` already clamps on every read
  (with TanStack's own 20px floor), so a second clamp on the way into state
  could only drift from the first. The matching `getClampedColumnSize` in
  `data-table-header` went for the same reason; both resize paths now write what
  they computed and let the framework clamp on read.

Real defect fixed:

- The persisted column preferences were read from localStorage on **every
  render**. `initialColumnVisibility = {}` and `initialColumnSizing = {}` are
  fresh objects per render and both were memo dependencies, so `getItem` +
  `JSON.parse` + entry validation — plus, for sizing, a full walk of the column
  defs to build bounds — ran per render on the five pages that persist. Storage
  is read once per key now, in a lazy state initializer, and re-read only when
  the key changes under a mounted hook.

Also:

- `readColumnVisibility` and `readColumnSizing` were the same 25 lines of
  guard/try/parse/validate/reduce twice; they are one `readStoredRecord` plus a
  per-entry reader. The two write effects (one immediate, one debounced with a
  timer ref *and* a cleanup) are one `usePersistedColumnState`.
- `columnVisibilityStorageKey` / `columnSizingStorageKey` were typed
  `string | false` and narrowed with a `typeof` check; no caller passes `false`.
- The keyboard resize steps (10 / 50 px) are named, and the keyboard path —
  arrows, Shift, `aria-valuenow`, no handle on a content-sized column — is
  covered by `header-keyboard-resize.test.tsx`. It had no test at all, and this
  is the commit that changes what it writes.

New `use-data-table-persistence.test.tsx` pins the storage contract: hydrate;
write back; junk in storage (unparseable, an array, a bare string, `null`) falls
back to defaults instead of throwing; non-boolean and non-positive entries are
dropped; sizing writes are debounced; a key change under a mounted hook re-reads
without echoing the old key.

580 -> 447 lines.

### Verification (local, 2C/4G host)

- `oxlint` + `check:boundaries` (689 files / 0 cross-layer edges) + `check:form-control` (140 sites / 0 native)
- `oxfmt --check` (732 files) · `knip` · `routes:verify` (28/28)
- `vitest run --maxWorkers=1`: **264 files / 1722 tests passed** (was 262/1711; +2 files, +11 tests)
- leak-guard `--range master..HEAD`: RC 0

`tsgo -b` is not run locally (the host OOM-kills it); CI `frontend` is the typecheck authority.
