### PR TITLE
refactor(web): move the HTTP status badge to the shared component layer

### DIFF
--- a/web/src/__tests__/status-badge-variant-wiring.test.tsx
+++ b/web/src/__tests__/status-badge-variant-wiring.test.tsx
@@ -2,8 +2,7 @@
 // status → badge-variant wiring assertion that used to live in seven
 // copy-pasted `status-badge-variants.test.tsx` files. These are wiring
 // assertions (feature X's column cell renders semantic variant Y for status
-// Z), not Badge-primitive recipe assertions; the primitive contract stays in
-// components/data-table/__tests__/status-badge-copy.test.tsx.
+// Z), not Badge-primitive recipe assertions.
 //
 // Housed at src/__tests__ (not src/components/data-table/__tests__) because
 // the package boundary gate forbids src/components/ from importing feature

--- a/web/src/components/common/__tests__/http-status-badge.test.tsx
+++ b/web/src/components/common/__tests__/http-status-badge.test.tsx
@@ -1,4 +1,4 @@
-// metapi-go/features/proxy-logs — StatusBadge label resolution tests.
+// metapi-go/components/common — HttpStatusBadge label resolution tests.
 //
 // Covers the i18n fix (#869): known string statuses (success/failed/…)
 // resolve to translated labels, numeric HTTP codes stay numeric, unknown
@@ -11,7 +11,7 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import '@/i18n/config'
 
-import { StatusBadge } from '../components/status-badge'
+import { HttpStatusBadge } from '../http-status-badge'
 
 beforeAll(async () => {
   await i18n.changeLanguage('zhCN')
@@ -25,10 +25,10 @@ function renderBadge(props: {
   httpStatus?: number | null
   status?: string | null
 }) {
-  return render(<StatusBadge {...props} />)
+  return render(<HttpStatusBadge {...props} />)
 }
 
-describe('StatusBadge', () => {
+describe('HttpStatusBadge', () => {
   it('translates the "success" string status via i18n', () => {
     renderBadge({ status: 'success' })
     expect(screen.getByText('成功')).toBeTruthy()

--- a/web/src/components/common/http-status-badge.tsx
+++ b/web/src/components/common/http-status-badge.tsx
@@ -1,5 +1,17 @@
-// metapi-go/features/proxy-logs/components — HTTP status badge.
-// i18n: fallback labels resolved via t().
+// metapi-go/components/common — HttpStatusBadge: an HTTP outcome as a pill.
+//
+// Shared rather than feature-local because two features render it: proxy logs
+// (per row, from a numeric status) and the observability overview (recent
+// failures, where the upstream may report a word instead of a code). Both need
+// the same three rules, which is what this file owns:
+//
+//   a number  → its class band (2xx/3xx/4xx/5xx), rendered as the number
+//   a word    → mapped to the nearest band ("timeout" is a failure, not an
+//               unknown), rendered as the translated word
+//   neither   → the neutral band and the translated "unknown"
+//
+// The label is never invented: an unrecognised string is shown verbatim, so a
+// new upstream status reads as itself instead of silently becoming "unknown".
 
 import { useTranslation } from 'react-i18next'
 
@@ -15,28 +27,28 @@ const STATUS_TIERS = {
   success: {
     className: 'bg-success/10 text-success-soft-fg border-success/30',
     dotClassName: 'bg-success',
-    fallbackLabelKey: 'proxyLogs.status.success',
+    fallbackLabelKey: 'httpStatus.success',
   },
   redirect: {
     className: 'bg-info/10 text-info-soft-fg border-info/30',
     dotClassName: 'bg-info',
-    fallbackLabelKey: 'proxyLogs.status.redirect',
+    fallbackLabelKey: 'httpStatus.redirect',
   },
   clientError: {
     className: 'bg-warning/10 text-warning-soft-fg border-warning/30',
     dotClassName: 'bg-warning',
-    fallbackLabelKey: 'proxyLogs.status.clientError',
+    fallbackLabelKey: 'httpStatus.clientError',
   },
   serverError: {
     className:
       'bg-destructive/10 text-destructive-soft-fg border-destructive/30',
     dotClassName: 'bg-destructive',
-    fallbackLabelKey: 'proxyLogs.status.serverError',
+    fallbackLabelKey: 'httpStatus.serverError',
   },
   neutral: {
     className: 'bg-muted/40 text-muted-foreground border-border',
     dotClassName: 'bg-muted-foreground',
-    fallbackLabelKey: 'proxyLogs.status.unknown',
+    fallbackLabelKey: 'httpStatus.unknown',
   },
 } as const
 
@@ -54,7 +66,7 @@ function resolveTierFromStatusString(status: string): {
 } {
   const normalized = status.toLowerCase()
   if (['success', 'ok', 'succeeded', 'succeed'].includes(normalized)) {
-    return { tier: STATUS_TIERS.success, labelKey: 'proxyLogs.status.success' }
+    return { tier: STATUS_TIERS.success, labelKey: 'httpStatus.success' }
   }
   if (
     ['failed', 'error', 'failure', 'timeout', 'timeouterror'].includes(
@@ -63,19 +75,19 @@ function resolveTierFromStatusString(status: string): {
   ) {
     return {
       tier: STATUS_TIERS.serverError,
-      labelKey: 'proxyLogs.status.failed',
+      labelKey: 'httpStatus.failed',
     }
   }
   if (normalized.includes('redirect')) {
     return {
       tier: STATUS_TIERS.redirect,
-      labelKey: 'proxyLogs.status.redirect',
+      labelKey: 'httpStatus.redirect',
     }
   }
   if (normalized.includes('client')) {
     return {
       tier: STATUS_TIERS.clientError,
-      labelKey: 'proxyLogs.status.clientError',
+      labelKey: 'httpStatus.clientError',
     }
   }
   return { tier: STATUS_TIERS.neutral, labelKey: null }
@@ -121,19 +133,19 @@ function resolveTier(
   }
 }
 
-export type StatusBadgeProps = {
+export type HttpStatusBadgeProps = {
   httpStatus?: number | null
   status?: string | null
   className?: string
   showDot?: boolean
 }
 
-export function StatusBadge({
+export function HttpStatusBadge({
   httpStatus,
   status,
   className,
   showDot = true,
-}: StatusBadgeProps) {
+}: HttpStatusBadgeProps) {
   const { t } = useTranslation()
   const resolved = resolveTier(httpStatus, status)
   const tier = resolved.tier
@@ -142,7 +154,7 @@ export function StatusBadge({
     : (resolved.rawLabel ?? '')
   return (
     <span
-      title={t('proxyLogs.status.titlePrefix', { label })}
+      title={t('httpStatus.titlePrefix', { label })}
       className={cn(
         'inline-flex w-fit items-center gap-1 rounded-4xl border px-1.5 py-0.5 text-xs font-medium tabular-nums whitespace-nowrap',
         tier.className,

--- a/web/src/features/observability/sections/overview/overview-section.tsx
+++ b/web/src/features/observability/sections/overview/overview-section.tsx
@@ -6,6 +6,7 @@ import { BarChart3, Flame } from 'lucide-react'
 import { useMemo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { HttpStatusBadge } from '@/components/common/http-status-badge'
 import {
   Card,
   CardContent,
@@ -22,7 +23,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { StatusBadge } from '@/features/proxy-logs/components/status-badge'
 import { toBcp47 } from '@/i18n/languages'
 import { formatDateTime, formatLatency } from '@/lib/format'
 
@@ -231,7 +231,7 @@ function renderSlowRequestsBody(
               {item.httpStatus || '—'}
             </TableCell>
             <TableCell>
-              <StatusBadge
+              <HttpStatusBadge
                 httpStatus={item.httpStatus ?? null}
                 status={item.status ?? null}
               />

--- a/web/src/features/proxy-logs/components/proxy-log-detail-sheet.tsx
+++ b/web/src/features/proxy-logs/components/proxy-log-detail-sheet.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DetailField } from '@/components/common/detail-field'
+import { HttpStatusBadge } from '@/components/common/http-status-badge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import {
@@ -26,7 +27,6 @@ import { toast } from '@/lib/toast'
 import { useProxyLog } from '../api'
 import type { ProxyLog, ProxyLogBillingDetails, ProxyLogDetail } from '../types'
 import { LatencyBadge } from './latency-badge'
-import { StatusBadge } from './status-badge'
 
 /** Count 0 renders as "0" (no retry happened); only a missing count is a dash. */
 function formatRetryCount(retryCount: number | null | undefined): string {
@@ -77,7 +77,7 @@ export function ProxyLogDetailSheet({
             <span className='truncate'>
               {log.modelRequested || log.modelActual || `#${log.id}`}
             </span>
-            <StatusBadge
+            <HttpStatusBadge
               status={log.status}
               httpStatus={detail?.httpStatus ?? null}
             />
@@ -148,7 +148,7 @@ function DetailOverview({ detail }: { detail: ProxyLogDetail }) {
           {formatDateTime(detail.createdAt, locale)}
         </DetailField>
         <DetailField label={t('proxyLogs.detail.httpStatus')}>
-          <StatusBadge
+          <HttpStatusBadge
             status={detail.status}
             httpStatus={detail.httpStatus ?? null}
           />

--- a/web/src/features/proxy-logs/components/proxy-logs-columns.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-columns.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { HttpStatusBadge } from '@/components/common/http-status-badge'
 import { DataTableColumnHeader } from '@/components/data-table'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -26,7 +27,6 @@ import {
 import { cn } from '@/lib/utils'
 
 import type { ProxyLog } from '../types'
-import { StatusBadge } from './status-badge'
 import { TimingCell } from './timing-cell'
 
 export type ProxyLogsColumnActions = { onView: (log: ProxyLog) => void }
@@ -168,7 +168,7 @@ export function useProxyLogsColumns(
         const log = row.original
         return (
           <div className='flex min-w-0 flex-col items-start gap-1'>
-            <StatusBadge status={log.status} httpStatus={log.httpStatus} />
+            <HttpStatusBadge status={log.status} httpStatus={log.httpStatus} />
             {log.errorMessage ? (
               <span
                 className='text-destructive-soft-fg block max-w-[16rem] truncate text-[11px] leading-tight'

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -11,6 +11,15 @@
         "selected": "selected"
       }
     },
+    "httpStatus": {
+      "success": "Success",
+      "redirect": "Redirect",
+      "clientError": "Client error",
+      "serverError": "Server error",
+      "unknown": "Unknown",
+      "titlePrefix": "Status {{label}}",
+      "failed": "Failed"
+    },
     "auth": {
       "login": {
         "brandName": "Metapi",
@@ -2641,15 +2650,6 @@
         "downstreamPath": "Downstream path",
         "upstreamPath": "Upstream path",
         "usageSource": "Usage source"
-      },
-      "status": {
-        "success": "Success",
-        "redirect": "Redirect",
-        "clientError": "Client error",
-        "serverError": "Server error",
-        "unknown": "Unknown",
-        "titlePrefix": "Status {{label}}",
-        "failed": "Failed"
       },
       "latency": {
         "totalLatency": "Total latency {{label}}",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -11,6 +11,15 @@
         "selected": "已选择"
       }
     },
+    "httpStatus": {
+      "success": "成功",
+      "redirect": "重定向",
+      "clientError": "客户端错误",
+      "serverError": "服务端错误",
+      "unknown": "未知",
+      "titlePrefix": "状态 {{label}}",
+      "failed": "失败"
+    },
     "auth": {
       "login": {
         "brandName": "Metapi",
@@ -2641,15 +2650,6 @@
         "downstreamPath": "下行路径",
         "upstreamPath": "上行路径",
         "usageSource": "用量来源"
-      },
-      "status": {
-        "success": "成功",
-        "redirect": "重定向",
-        "clientError": "客户端错误",
-        "serverError": "服务端错误",
-        "unknown": "未知",
-        "titlePrefix": "状态 {{label}}",
-        "failed": "失败"
       },
       "latency": {
         "totalLatency": "总延迟 {{label}}",

--- a/web/src/styles/__tests__/contrast-gate.test.ts
+++ b/web/src/styles/__tests__/contrast-gate.test.ts
@@ -19,7 +19,7 @@
 //      lake-view dark override (were 3.95 / 1.75:1)
 //   7. chart-1..5 across presets — light values darkened and dark
 //      values lightened so every chart color clears AA text contrast on its
-//      card surface (chart colors double as StatusBadge text-chart-N
+//      card surface (chart colors double as HttpStatusBadge text-chart-N
 //      foregrounds, so text AA 4.5:1 — not the 3:1 non-text floor — applies)
 
 import { readFileSync } from 'node:fs'
@@ -431,7 +431,7 @@ describe('theme contrast gate (WCAG AA 4.5:1)', () => {
   })
 
   it('chart colors clear AA text contrast on the card surface across presets and modes', () => {
-    // Chart series colors are also StatusBadge text foregrounds
+    // Chart series colors are also HttpStatusBadge text foregrounds
     // (text-chart-N in status-badge.tsx), so text AA applies, not the 3:1
     // non-text floor. The 2026-08-29 batch darkened 40 light values (worst
     // 1.08:1 lavender-dream-family near-whites) and lightened 8 dark values


### PR DESCRIPTION
`features/proxy-logs/components/status-badge.tsx` grew a second consumer: the
observability overview renders the same badge for recent failures. A component
two features need belongs to neither of them — that is the rule the data-table
package states for itself ("code belongs here only once a second feature needs
it") — and the import graph was already breaking it, with `features/observability`
reaching sideways into `features/proxy-logs`.

So: `components/common/http-status-badge.tsx`, `StatusBadge` → `HttpStatusBadge`,
and its test moves with it. The rename is not cosmetic. `StatusBadge` was also
the name of two module-local components (`checkin-columns.tsx`,
`sites-columns.tsx`), so four things in the tree answered to it; the shared one
is now named for what it renders, and the two feature-local ones stay local.

Its i18n keys moved too — `proxyLogs.status.*` → `httpStatus.*`, in both locales
in the same commit, as the key-parity gate requires. The observability overview
was translating through a `proxyLogs` namespace it has nothing to do with. The
values are unchanged, so no copy changes anywhere.

The header comment now states the three resolution rules the file owns (a number
→ its class band; a word → the nearest band, so "timeout" is a failure and not
an unknown; neither → neutral "unknown") plus the one that is easy to lose: an
unrecognised string is rendered verbatim rather than quietly becoming "unknown",
so a status this code has never seen still reads as itself.

While here: `src/__tests__/status-badge-variant-wiring.test.tsx` claimed the
Badge primitive's contract "stays in
components/data-table/__tests__/status-badge-copy.test.tsx" — that file went with
the dead data-table status badge (#1322). The stale pointer is gone, and
`contrast-gate.test.ts`'s note about chart colors doubling as badge foregrounds
now names the badge that exists.

### Verification (local, 2C/4G host)

- `oxlint` + `check:boundaries` (689 files / 0 cross-layer edges) + `check:form-control` (140 sites / 0 native)
- `oxfmt --check` (732 files) · `knip` · `routes:verify` (28/28)
- `vitest run --maxWorkers=1`: **264 files / 1722 tests passed** (full suite pre-rebase; 25 files / 169 tests re-run scoped to every directory this touches after the rebase onto #1328)
- leak-guard `--range master..HEAD`: RC 0

`tsgo -b` is not run locally (the host OOM-kills it); CI `frontend` is the typecheck authority.
