### PR TITLE
docs: strip internal programme codes from the shipped tree

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,8 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - run: go test ./docs -run TestPublicMarkdownHygiene -count=1
+      - name: Prose hygiene gates (public markdown + programme codes in sources)
+        run: go test ./docs -run 'Hygiene|ProgrammeCode' -count=1
 
   frontend:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,5 @@ web/playwright/.cache/
 .repro/
 .local/
 
-# local dev instance matrix (Wave 7 local toolchain)
+# local dev instance matrix (local toolchain, never committed)
 .dev-local/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ go test ./... -count=1 -race        # backend suite with race detector
 cd web && bun install                # once
 cd web && bun run typecheck && bun run lint && bun run test && bun run knip
 cd web && bun run format:check       # oxfmt
-make docs-hygiene                    # public-markdown hygiene (no local paths/secrets)
+make docs-hygiene                    # public-tree hygiene (no local paths/secrets/plan codes)
 ```
 
 TL;DR: `make verify` covers the Go side; `make verify-race` adds the race
@@ -64,7 +64,7 @@ detector. The pre-push hook runs all of it automatically.
 ## Versioning & release cadence
 
 Releases follow a **patch-first** cadence (pre-1.0 the last digit iterates
-continuously): each merged wave with user-visible changes bumps the **patch**
+continuously): each merged batch of user-visible changes bumps the **patch**
 digit and ships immediately; the minor digit is reserved for themed
 milestones; the major digit stays `0` until the 1.0 readiness criteria. The
 single source of truth is
@@ -84,8 +84,8 @@ single source of truth is
   (checked by `web/src/i18n/__tests__/i18n-keys.test.ts`).
 - **Docs**: user-facing behavior changes update public product docs and the
   `CHANGELOG.md`; open work is tracked in GitHub issues. Public docs must never
-  contain local paths, private hostnames, or credentials (`make docs-hygiene`
-  enforces this).
+  contain local paths, private hostnames, credentials, or internal work-programme
+  codes (`make docs-hygiene` enforces this).
 - **Single binary**: the production image ships no Node/Bun runtime. Don't
   add npm scripts to the runtime path.
 

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,10 @@ vuln:
 mod-verify:
 	go mod verify
 
-# Check public Markdown for local paths, credential examples, AI citation artifacts, and unsupported runtime claims
+# Check the published tree for local paths, credential examples, AI citation artifacts,
+# unsupported runtime claims, and internal work-programme codes
 docs-hygiene:
-	go test ./docs -run TestPublicMarkdownHygiene -count=1
+	go test ./docs -run 'Hygiene|ProgrammeCode' -count=1
 
 # Run routing benchmark smoke set with allocation reporting
 bench-routing:

--- a/app/observability/dbmetrics.go
+++ b/app/observability/dbmetrics.go
@@ -1,6 +1,6 @@
 // Package observability is a true leaf (stdlib-only) holding cross-cutting
 // counters that lower layers (scheduler) must record without importing
-// handler/shared or app. Resolves package-boundaries §5.11: scheduler sat
+// handler/shared or app. It resolves a boundary cycle: scheduler sat
 // below app in the dependency chain (app → handler/proxy → scheduler), so
 // it could not import either app or handler/shared to bump the DB-connection
 // error metric. This leaf has no internal imports, breaking the cycle.

--- a/app/proxy_path_traversal_test.go
+++ b/app/proxy_path_traversal_test.go
@@ -80,7 +80,7 @@ func (env *geminiTraversalEnv) postGemini(t *testing.T, target string) *httptest
 	return rec
 }
 
-// TestGeminiWildcardPathTraversalNeverReachesUpstream is the Wave 4 S-line T1
+// TestGeminiWildcardPathTraversalNeverReachesUpstream is the path-traversal
 // regression: a legitimate downstream key holder must not be able to escape
 // the site API prefix by smuggling ".." segments through the Gemini wildcard
 // route (POST /v1beta/models/*). net/http has already percent-decoded the

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -93,7 +93,7 @@ func main() {
 	// before the server accepts traffic so the admin list endpoint never
 	// pays the old per-request scan+update cost. See app.RunOauthIdentityBackfill.
 	app.RunOauthIdentityBackfill()
-	// N7: apply operator-configured cache-ratio fallback overrides to routing.
+	// Apply operator-configured cache-ratio fallback overrides to routing.
 	app.ApplyCacheRatioOverrides()
 	if err := app.ConfigureProxyUpstream(cfg); err != nil {
 		slog.Error("proxy upstream wiring failed", "error", err)

--- a/config/config_race_test.go
+++ b/config/config_race_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/config"
 )
 
-// C1 (Wave 21 config-race): the runtime-mutable settings live on an
+// Config-race contract: the runtime-mutable settings live on an
 // immutable RuntimeSettings snapshot published through an atomic.Pointer.
 // Writers go through config.UpdateRuntime (copy-mutate-publish under a
 // mutex); readers take one atomic snapshot via config.Runtime() and never
@@ -92,8 +92,8 @@ func TestSetRuntimePublishesCopies(t *testing.T) {
 	}
 }
 
-// TestRuntimeWriteRace_TornReadReproduction reproduces the Wave 18
-// concurrency-audit finding against the FIXED access shape: writers publish
+// TestRuntimeWriteRace_TornReadReproduction reproduces the concurrency-audit
+// finding against the FIXED access shape: writers publish
 // correlated field tuples through UpdateRuntime while readers take atomic
 // snapshots. Each published generation g carries ProxyToken "sk-gen-g",
 // ProxyRetryStatusRanges "g-g" and NotifyCooldownSec g; a reader that ever

--- a/config/runtime_settings.go
+++ b/config/runtime_settings.go
@@ -10,7 +10,7 @@ import (
 // (PUT /api/settings/runtime), auth-token rotation, scheduler schedule
 // write-backs, and the runtime database switch.
 //
-// Concurrency contract (Wave 18 config-race fix, Milestone C1):
+// Concurrency contract:
 //
 //   - Readers take the current immutable snapshot via Runtime() /
 //     RuntimeSafe() and must treat it as strictly read-only. The pointer
@@ -55,7 +55,7 @@ type RuntimeSettings struct {
 	LogCleanupCron        string
 	// Site & Branding (5 fields) - empty defaults keep the embedded frontend
 	// branding and login-page copy unchanged. homePageContent was removed
-	// (Wave 8 Lane D): the value was stored but never rendered anywhere.
+	// long ago: the value was stored but never rendered anywhere.
 	SystemName    string
 	Logo          string
 	Footer        string

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -125,7 +125,7 @@ Download a backup payload from `fileUrl` with HTTP `GET` and import its `tables`
 
 ### POST /api/settings/backup/import/preview
 
-Preview a backup import without writing anything (F1). Same body shapes as `POST /api/settings/backup/import` (`{ "tables": {...} }`, optional `{ "data": { "tables": {...} } }` wrapper, TS backup v2.1 payloads).
+Preview a backup import without writing anything. Same body shapes as `POST /api/settings/backup/import` (`{ "tables": {...} }`, optional `{ "data": { "tables": {...} } }` wrapper, TS backup v2.1 payloads).
 
 **Response**: `{ success, plan: { "<table>": { rows, toInsert, duplicates, skippedRows } } }` — `duplicates` are rows whose PK already exists in the target DB (they would be dropped by `ON CONFLICT DO NOTHING`); `skippedRows` are runtime-local settings skipped by policy. No rows are written.
 

--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -45,8 +45,7 @@ func TestPublicMarkdownHygiene(t *testing.T) {
 			// Skip VCS/build caches and local evidence/worktrees so hygiene only
 			// covers published tree paths. CI clones are clean, while ignored
 			// .dev-local evidence may contain absolute capture paths by design.
-			if name == ".git" || name == "node_modules" || name == "dist" ||
-				name == ".claude" || name == ".dev-local" || name == ".worktrees" || name == ".local" {
+			if skipHygieneDir(name) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -523,4 +522,172 @@ func TestChangelogStaysANarrativeNotAForensicRecord(t *testing.T) {
 
 func utf8RuneLen(s string) int {
 	return len([]rune(s))
+}
+
+// skipHygieneDir names the directories that are not part of the published tree:
+// VCS/build caches plus local evidence and worktree checkouts. CI clones are
+// clean, while ignored .dev-local evidence may carry absolute capture paths and
+// archived plan extracts by design.
+func skipHygieneDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "dist", ".claude", ".dev-local", ".worktrees", ".local":
+		return true
+	}
+	return false
+}
+
+// hygieneSkipFile names files the source scan must not read: generated or
+// vendored output whose text nobody authors (a match there would be noise, not
+// a finding), plus this gate's own file. A gate that bans a vocabulary cannot
+// state its fixtures without quoting that vocabulary, so doc_hygiene_test.go is
+// the one exemption — and its content is pinned by the sanity test below, which
+// fails if a fixture stops matching.
+func hygieneSkipFile(name string) bool {
+	switch name {
+	case "bun.lock", "routeTree.gen.ts", "MANIFEST.md", "doc_hygiene_test.go":
+		return true
+	}
+	return false
+}
+
+// programmeCodeRE matches internal work-programme vocabulary: wave / lane /
+// milestone labels from archived plans, private backlog priority codes, a
+// private design-doc item code, and citations of design files that were never
+// published. Every one of them says how a change was scheduled and nothing
+// about what the shipped code does, and it rots the moment the plan behind it
+// is archived: a reader who cannot resolve the label gets noise where a reason
+// should be. Public-tree comments describe the product; the plan that produced
+// a line stays with the plan.
+//
+// Deliberately out of scope: bare single-letter audit item codes ("S10", "F5",
+// "M1"). They cannot be told apart from model-family names (MiniMax-M2) or
+// RFC 3339 fragments ("…T15:04:05Z") without a context rule more fragile than
+// the codes themselves. The vocabulary below is what actually recurs. Matching
+// is case-sensitive on purpose: the labels are proper nouns of a plan, while
+// the same word in lower case is ordinary prose.
+var programmeCodeRE = regexp.MustCompile(strings.Join([]string{
+	`\bWave \d+\b`,
+	`\bS-line\b`,
+	`\bMilestone [A-Z]\d\b`,
+	`\bLane [A-Z]\b`,
+	`\bP[01]-\d+\b`,
+	`\bK1b\b`,
+	`\bw\d+-[a-z]+(?:-[a-z]+)*\b`,
+	`\bscout §`,
+	`\b(?:plan|limitation(?:-[a-z]+)*|p\d+-[a-z]+(?:-[a-z]+)*)\.md\b`,
+	`\b[a-z0-9]+(?:-[a-z0-9]+)*-design-\d{4}-\d{2}-\d{2}\.md\b`,
+	`\b\d+-report §`,
+}, "|"))
+
+// hygieneSourceExt lists the extensions whose text is authored by hand and can
+// therefore carry a programme code. "" covers extension-less files that are
+// still prose-bearing (.gitignore, Makefile, Dockerfile, LICENSE).
+var hygieneSourceExt = map[string]bool{
+	".go": true, ".ts": true, ".tsx": true, ".mjs": true, ".js": true,
+	".sh": true, ".md": true, ".css": true, ".yml": true, ".yaml": true,
+	".json": true, ".sql": true, ".tmpl": true, "": true,
+}
+
+func TestNoInternalProgrammeCodesInShippedSources(t *testing.T) {
+	root := repoRoot(t)
+	var findings []string
+	scanned := 0
+
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if skipHygieneDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// A symlink is not part of the published tree: a worktree checkout
+		// links web/node_modules at a shared install, and following it would
+		// scan (and report on) files this repository does not ship.
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if hygieneSkipFile(entry.Name()) || !hygieneSourceExt[filepath.Ext(path)] {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Size() > 1<<20 { // a prose gate has no business reading megabytes
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		scanned++
+		rel := filepath.ToSlash(mustRel(t, root, path))
+		for i, line := range strings.Split(string(data), "\n") {
+			if programmeCodeRE.MatchString(line) {
+				findings = append(findings, formatFinding(rel, i+1,
+					"internal programme code: state what the code does, not which plan asked for it", line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same invariant as every other gate in this file: a hygiene gate that
+	// scans nothing and reports no violations is not a lenient gate, it is an
+	// absent one. Both the skip list and the extension map could narrow it to
+	// silence, so the scan itself is asserted to be non-empty.
+	if scanned == 0 {
+		t.Fatal("gate would pass vacuously: no source files were scanned")
+	}
+	if len(findings) > 0 {
+		t.Fatalf("internal programme codes in the published tree (%d files scanned):\n%s",
+			scanned, strings.Join(findings, "\n"))
+	}
+}
+
+// TestProgrammeCodeGateRegexpSanity proves the gate above can actually fire and
+// that its near-misses stay quiet. A hygiene pattern that matches nothing is
+// indistinguishable from a clean tree; a pattern that matches product strings
+// trains contributors to ignore the gate.
+func TestProgrammeCodeGateRegexpSanity(t *testing.T) {
+	mustMatch := []string{
+		"// fixed in Wave 18",
+		"// the Wave 4 S-line T1 regression",
+		"// Milestone C1 contract",
+		"// removed in Wave 8 Lane D",
+		"// P0-3: structured cooldown reasons",
+		"// P1-2 operator-tunable auto-disable",
+		"// K1b: keep the registry fresh",
+		"// (w18-pg-dialect audit)",
+		"// Single funnel (scout §settings_apply)",
+		"// see plan.md §5.5.5",
+		"// Design: k1-model-redirect-design-2026-08-01.md §7",
+		"// 13-report §4",
+		"// See limitation-update-center.md.",
+		"// spec p3-sites-accounts.md lines 528-542",
+	}
+	for _, sample := range mustMatch {
+		if !programmeCodeRE.MatchString(sample) {
+			t.Errorf("gate missed a programme code it exists to catch: %q", sample)
+		}
+	}
+	mustNotMatch := []string{
+		`Description: "add common M2 coding models"`, // MiniMax model family
+		`dayStart := day + "T00:00:00Z"`,             // RFC 3339 fragment
+		"// Lexical compare of …T15:04:05.500Z vs …T15:04:05Z",
+		"// the second wave 3 km inland", // lower-case prose, not a plan label
+		"// P2P transfers stay disabled",
+		"// see docs/architecture.md and docs/testing.md",
+		"// config.Load §3.14 defines this key",
+		"// milestone releases are tagged v*",
+	}
+	for _, sample := range mustNotMatch {
+		if programmeCodeRE.MatchString(sample) {
+			t.Errorf("gate fired on product text it must leave alone: %q", sample)
+		}
+	}
 }

--- a/docs/internal/design/BACKEND.md
+++ b/docs/internal/design/BACKEND.md
@@ -122,7 +122,7 @@ The diagram above is the *intent* — which direction is down. The contract is
 [`docs/architecture.md`](../../architecture.md) §"Ownership and boundary map": one row per
 package, the decision it owns, and what it must not import. Its executable form is
 [`docs/package_boundary_test.go`](../../package_boundary_test.go) — rules 1–8, every approved
-exception with the architecture section that justifies it, and an assertion that all twelve
+exception with the reason it is approved, and an assertion that all twelve
 domains were really scanned, because a boundary gate that scans nothing and reports no
 violations is not a lenient gate but an absent one. That is not a hypothetical: it is the shape
 that let roughly thirty release tags stay green while their required shards ran zero tests.

--- a/docs/package_boundary_test.go
+++ b/docs/package_boundary_test.go
@@ -15,9 +15,8 @@ import (
 // as-built package map in docs/architecture.md as a machine assertion, so the
 // package dependency discipline cannot silently drift.
 
-// This is the Go analogue of a grep-based architecture boundary check
-// (test.yml:134-148 "web handlers must route through commands/*_core"):
-// every architecture-level boundary decision is frozen into a CI test.
+// Every architecture-level boundary decision is frozen into a CI test rather
+// than left to reviewer memory.
 
 // Rules enforced (denylist from the architecture contract):
 //  1. store        ↛ handler, proxy, routing, service, scheduler, router, auth
@@ -30,18 +29,14 @@ import (
 //  8. no revived TS-era top-level names proxycore/protocol
 //  9. no production file imports "testing" (a test helper belongs in a _test.go file)
 
-// Documented architecture exceptions are
-// allowed and excluded from the denylist:
-//   - handler/admin → scheduler (admin-ops cron validation only, §5.1)
-//   - handler/admin → app (checkin schedule lifecycle, §5.2)
-//   - app → handler/proxy (ConfigureProxyUpstream composition helper, §5.3)
-//   - platform → proxy/profiles (profile detection, §3.2)
-//   - handler/* → platform (thin admin/verify actions; docs/architecture.md boundary map)
-//   - handler/proxy → transform/* (one-way protocol wiring, §5.4)
+// Documented architecture exceptions are allowed and excluded from the denylist:
+//   - handler/admin → scheduler (admin-ops cron validation only)
+//   - handler/admin → app (checkin schedule lifecycle)
+//   - app → handler/proxy (ConfigureProxyUpstream composition helper)
+//   - platform → proxy/profiles (profile detection)
+//   - handler/* → platform (thin admin/verify actions)
+//   - handler/proxy → transform/* (one-way protocol wiring)
 //   - auth → internal/sharedcount
-//   - (scheduler → handler/shared §5.11 exception RESOLVED 2026-07-31:
-//     scheduler now records DB-conn errors via the `app` facade, no direct
-//     handler/shared import)
 
 // cmd/server is the composition root and may import anything.
 // cmd/migrate, e2e, internal, docs, web are out of scope.
@@ -211,20 +206,18 @@ func forbiddenImport(pkg, imp string) string {
 		}
 	case "scheduler":
 		// scheduler must not depend on the HTTP/handler or routing layers.
-		// DB-connection error metrics are recorded via the `app` facade
-		// (app.RecordDBConnError delegates to handler/shared), not by
-		// importing handler/shared directly — this resolved the §5.11
-		// exception (was: scheduler/lease.go imported handler/shared).
+		// DB-connection error counters live in app/observability, a stdlib-only
+		// leaf, so scheduler/lease.go needs no handler/shared import.
 		if inGroups("handler", "router", "proxy") {
-			return "rule 6: scheduler ↛ handler/router/proxy (DB-conn metric via app facade, not handler/shared)"
+			return "rule 6: scheduler ↛ handler/router/proxy (DB-conn counters go through app/observability)"
 		}
 	case "handler":
 		// handler/admin documented exceptions: → scheduler (admin-ops), → app (lifecycle).
 		if pkg == "handler/admin" && (suffix == "scheduler" || impTop == "scheduler") {
-			return "" // §5.1 admin-ops cron validation exception
+			return "" // admin-ops cron validation exception
 		}
 		if pkg == "handler/admin" && impTop == "app" {
-			return "" // §5.2 checkin schedule lifecycle exception
+			return "" // checkin schedule lifecycle exception
 		}
 		// handler → router forbidden (router mounts handlers).
 		if impTop == "router" {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -184,7 +184,7 @@ Regeneration discipline:
 - [`../testbed/compose.template.yml`](../testbed/compose.template.yml): sanitized loopback-only service template for Metapi, New API, One API, and optional adapter targets.
 - [`../scripts/e2e/smoke.sh`](../scripts/e2e/smoke.sh): idempotent password-login chain from health and site detection through `/v1` proxying. Re-runs converge: `POST /api/accounts/login` upserts, so the login step refreshes the stored credential on every run.
 - [`../scripts/e2e/verify-token-import.sh`](../scripts/e2e/verify-token-import.sh): equivalent chain for session JWTs, API keys, and management keys. Re-runs converge as well (#1209): an account that already exists is re-bound to the credential this run holds instead of being skipped, and a reused downstream key has its relay policy re-asserted when this script owns the record. A short-lived upstream credential left stored by the previous run used to pass `verify-token` and then fail the chain two steps later on `balance`.
-- Operator-gated multi-channel cascade evidence procedure (see `scripts/verify-cascade-prod.sh` and the P0-585 verification test).
+- Operator-gated multi-channel cascade evidence procedure (see `scripts/verify-cascade-prod.sh` and the cascade verification test).
 
 ## Run a real-platform chain
 

--- a/e2e/e2e_cascade_isolation_test.go
+++ b/e2e/e2e_cascade_isolation_test.go
@@ -147,7 +147,7 @@ func TestCascadeIsolation_5xxThenHealthySiblingSucceeds(t *testing.T) {
 	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		goodHits.Add(1)
 		writeJSONHelper(w, 200, map[string]any{
-			"id": "chatcmpl-p0585", "object": "chat.completion", "model": "gpt-4",
+			"id": "chatcmpl-cascade", "object": "chat.completion", "model": "gpt-4",
 			"choices": []map[string]any{{
 				"index": 0,
 				"message": map[string]any{"role": "assistant", "content": "recovered"},

--- a/e2e/e2e_cascade_production_test.go
+++ b/e2e/e2e_cascade_production_test.go
@@ -2,11 +2,11 @@
 
 // Package e2e contains end-to-end integration tests for the proxy pipeline.
 //
-// This file holds the P0-585 production / staging cascade verification test.
+// This file holds the production / staging cascade verification test.
 // It is guarded by the `staging` build tag so it is NEVER compiled into the
 // normal CI test binary — it only runs when an operator explicitly invokes:
 //
-//	go test ./e2e -tags=staging -run 'P0585_ProductionCascade_Staging' \
+//	go test ./e2e -tags=staging -run 'ProductionCascade_Staging' \
 //	  -v -timeout=120s
 //
 // The test connects to a real metapi instance (env: METAPI_STAGING_URL,
@@ -57,7 +57,7 @@ func requireStagingEnv(t *testing.T) (baseURL, authToken, proxyToken string) {
 	}
 	if len(missing) > 0 {
 		t.Fatalf("staging cascade test requires env: %s (missing: %s). "+
-			"Run with: go test ./e2e -tags=staging -run P0585_ProductionCascade_Staging",
+			"Run with: go test ./e2e -tags=staging -run ProductionCascade_Staging",
 			strings.Join([]string{stagingURLEnv, stagingAuthEnv, stagingProxyEnv}, ", "),
 			strings.Join(missing, ", "))
 	}
@@ -96,7 +96,7 @@ func stagingProxyChat(t *testing.T, client *http.Client, baseURL, proxyToken, mo
 	t.Helper()
 	payload := map[string]any{
 		"model":      model,
-		"messages":   []map[string]string{{"role": "user", "content": "p0585 cascade staging verify (read-only)"}},
+		"messages":   []map[string]string{{"role": "user", "content": "cascade staging verify (read-only)"}},
 		"max_tokens": 1,
 		"stream":     false,
 	}
@@ -110,7 +110,7 @@ func stagingProxyChat(t *testing.T, client *http.Client, baseURL, proxyToken, mo
 	}
 	req.Header.Set("Authorization", "Bearer "+proxyToken)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Metapi-Verify", "cascade-p0585-staging")
+	req.Header.Set("X-Metapi-Verify", "cascade-staging-verify")
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("staging POST chat/completions: %v", err)
@@ -212,7 +212,7 @@ func fetchStagingProxyLogs(t *testing.T, client *http.Client, baseURL, authToken
 	return rows
 }
 
-// TestP0585_ProductionCascade_Staging gathers honest cascade evidence against a
+// TestProductionCascade_Staging gathers honest cascade evidence against a
 // real staging/production instance. It is NOT a self-contained cascade trigger:
 // it sends one minimal request and then reads proxy_logs for the resulting
 // X-Request-Id. Cascade is only observable when an upstream genuinely returned
@@ -227,7 +227,7 @@ func fetchStagingProxyLogs(t *testing.T, client *http.Client, baseURL, authToken
 // Asserts (always):
 //   - at least one proxy_log row exists for the request_id (request-path + logging works)
 //   - the chat probe either succeeded (200) or failed without crashing the instance
-func TestP0585_ProductionCascade_Staging(t *testing.T) {
+func TestProductionCascade_Staging(t *testing.T) {
 	baseURL, authToken, proxyToken := requireStagingEnv(t)
 	client := stagingHTTPClient()
 
@@ -314,7 +314,7 @@ func TestP0585_ProductionCascade_Staging(t *testing.T) {
 
 	// Distinct channels prove channel-scoped exclude (failed channel not retried).
 	if len(channelIDs) < 2 {
-		t.Errorf("cascade rows share a single channel_id (%v) — exclude is not channel-scoped as P0-585 requires",
+		t.Errorf("cascade rows share a single channel_id (%v) — exclude is not channel-scoped as the cascade contract requires",
 			channelIDs)
 	} else {
 		t.Logf("verified: cascade used %d distinct channels (channel-scoped exclude intact): %v",
@@ -337,7 +337,7 @@ func TestP0585_ProductionCascade_Staging(t *testing.T) {
 		t.Logf("cascade exhausted without recovery (last status=%q) — bounded failure, not a crash", last.Status)
 	}
 
-	t.Logf("P0-585 staging cascade evidence captured for request_id=%q: rows=%d channels=%d max_retry=%d",
+	t.Logf("staging cascade evidence captured for request_id=%q: rows=%d channels=%d max_retry=%d",
 		requestID, len(matchingRows), len(channelIDs), maxRetry)
 }
 

--- a/handler/admin/account_tokens_sync.go
+++ b/handler/admin/account_tokens_sync.go
@@ -483,7 +483,7 @@ func syncTokensAfterAccountCreate(ctx context.Context, db *sqlx.DB, cfg *config.
 		}
 	}
 
-	// Product decision (Wave 12): only session-credential accounts sync
+	// Product decision: only session-credential accounts sync
 	// automatically; API-key connections are explicitly skipped.
 	if service.IsAPIKeyConnection(&row.Account) {
 		return postCreateTokenSyncReport{

--- a/handler/admin/accounts_auth.go
+++ b/handler/admin/accounts_auth.go
@@ -400,7 +400,7 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	// Sub2API managed auth: merge refreshToken/tokenExpiresAt into extraConfig.sub2apiAuth
-	// without clobbering unrelated keys (spec p3-sites-accounts lines 528-542).
+	// without clobbering unrelated keys.
 	extraConfigPatch := map[string]any{
 		"credentialMode": "session",
 	}

--- a/handler/admin/accounts_expired_recovery_test.go
+++ b/handler/admin/accounts_expired_recovery_test.go
@@ -343,7 +343,7 @@ func TestAccounts_Update_ExpiredAPIKeyRecovery_InjectableRefresh(t *testing.T) {
 			t.Fatalf("accountID = %d, want %d", id, accountID)
 		}
 		sawAllowInactive = allowInactive
-		// Simulate successful model write without upstream (Wave 15 moved
+		// Simulate successful model write without upstream (a later change moved
 		// persistAccountModelAvailability into the service package).
 		if _, err := dbx.Exec(dbx.Rebind(
 			"INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, TRUE, FALSE, ?)",

--- a/handler/admin/accounts_models_refresh_test.go
+++ b/handler/admin/accounts_models_refresh_test.go
@@ -1,6 +1,6 @@
 package admin
 
-// Focused tests for the Wave 12 account Models surface (#998):
+// Focused tests for the account Models surface (#998):
 //   - manual upstream refresh persists availability into the existing owner
 //     (model_availability) — proven by store read-back;
 //   - each refresh action triggers exactly one route rebuild + one routing
@@ -31,7 +31,7 @@ import (
 
 // withRefreshSideEffectCounters swaps the rebuild/invalidate seams for
 // counting fakes and restores the production owners on cleanup.
-// Wave 15 (#1005) moved the refresh core to service.RefreshAccountModels, so
+// #1005 moved the refresh core to service.RefreshAccountModels, so
 // the "exactly one route rebuild + one routing-cache invalidation per refresh
 // action" contract is asserted against the service seams; the manual-models
 // endpoint keeps using the handler-level invalidateRoutingCache seam, which is

--- a/handler/admin/accounts_write.go
+++ b/handler/admin/accounts_write.go
@@ -243,7 +243,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Expired API-key recovery (p3-sites-accounts.md 594-602 / TS accounts.ts):
+	// Expired API-key recovery (TS accounts.ts parity):
 	// when credentials change on an expired apikey account and status is not forced
 	// disabled, refresh models with allowInactive and reactivate only on success.
 	recovery := shouldRecoverExpiredAPIKey(row.Account, nextAccount, updates)

--- a/handler/admin/auth_settings.go
+++ b/handler/admin/auth_settings.go
@@ -97,7 +97,7 @@ func (h *authSettingsHandler) changeToken(w http.ResponseWriter, r *http.Request
 
 	// Log the change event
 	// read is a BOOLEAN column on PostgreSQL: bind FALSE, not the integer
-	// literal 0 (w18-pg-dialect: PG rejects integer literals for booleans).
+	// literal 0 (PG rejects integer literals for booleans).
 	h.db.Exec(`INSERT INTO events (type, title, message, level, related_type, created_at, read)
 		VALUES ('token', 'Admin login token updated', 'The admin login token was changed. Use the new token to log in.', 'warning', 'settings', ?, FALSE)`, now)
 

--- a/handler/admin/channels.go
+++ b/handler/admin/channels.go
@@ -35,7 +35,7 @@ type channelListRow struct {
 	SuccessCount   *int64  `db:"success_count"`
 	TotalLatencyMs *int64  `db:"total_latency_ms"`
 	CooldownUntil  *string `db:"cooldown_until"`
-	// Structured cooldown reason (P0-3): why the channel cooled down. NULL on
+	// Structured cooldown reason: why the channel cooled down. NULL on
 	// rows cooled before the reason columns existed.
 	CooldownReasonCode *string `db:"cooldown_reason_code"`
 	CooldownReason     *string `db:"cooldown_reason"`

--- a/handler/admin/channels_batch_update_test.go
+++ b/handler/admin/channels_batch_update_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// ---- PUT /api/channels/batch (Wave 17 P1-3: batch test closure loop) ----
+// ---- PUT /api/channels/batch: batch test closure loop ----
 //
 // The model-tester batch comparison's "disable failed channels" action calls
 // this endpoint with `enabled:false` items. These tests pin the per-item

--- a/handler/admin/config_race_test.go
+++ b/handler/admin/config_race_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/deliciousbuding/metapi-go/routing"
 )
 
-// TestSettingsRuntime_ConcurrentApplyVsHotReaders reproduces the Wave 18
-// config-race cluster end to end: the real PUT /api/settings/runtime writer
+// TestSettingsRuntime_ConcurrentApplyVsHotReaders reproduces the config-race
+// cluster end to end: the real PUT /api/settings/runtime writer
 // (settings_apply.go) runs concurrently with the hot-path readers that
 // dereference the same config fields lock-free:
 //

--- a/handler/admin/contract_envelope_test.go
+++ b/handler/admin/contract_envelope_test.go
@@ -1,6 +1,6 @@
 package admin
 
-// Wave 4 contract audit — envelope consistency.
+// Admin API contract audit — envelope consistency.
 //
 // The admin API has two response families and both are pinned here:
 //

--- a/handler/admin/contract_filters_test.go
+++ b/handler/admin/contract_filters_test.go
@@ -1,6 +1,6 @@
 package admin
 
-// Wave 4 contract audit — list filters actually reach the SQL WHERE clause.
+// Admin API contract audit — list filters actually reach the SQL WHERE clause.
 //
 // Positive filter coverage already exists elsewhere:
 //   - proxy-logs: TestStats_SQLiteProxyLogs*Filter* (status/search/client/

--- a/handler/admin/contract_pagination_bounds_test.go
+++ b/handler/admin/contract_pagination_bounds_test.go
@@ -1,6 +1,6 @@
 package admin
 
-// Wave 4 contract audit — pagination boundary behavior.
+// Admin API contract audit — pagination boundary behavior.
 //
 // Four admin list endpoints accept ?page/&pageSize= with identical clamp
 // semantics (page → [1, 1_000_000], pageSize → [1, 200]); two more use the

--- a/handler/admin/error_codes_test.go
+++ b/handler/admin/error_codes_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/config"
 )
 
-// Audit S4: machine-readable errorCode on admin 400 responses.
+// Machine-readable errorCode on admin 400 responses.
 //
 // These tests pin the errorCode contract so it cannot silently regress:
 //

--- a/handler/admin/events_write_regression_test.go
+++ b/handler/admin/events_write_regression_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// Regression guards for the w18-pg-dialect incident class: event writers that
+// Regression guards for the dialect incident class: event writers that
 // bound the INTEGER literal 0 to events.read. On SQLite (INTEGER column) the
 // row was written anyway, so these tests pass on both sides of the fix
 // locally; the PostgreSQL type-error proof lives in

--- a/handler/admin/model_redirects.go
+++ b/handler/admin/model_redirects.go
@@ -130,7 +130,7 @@ func (h *modelRedirectHandler) update(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"message": "redirect not found"})
 		return
 	}
-	service.ReloadRedirectRegistry(r.Context(), h.db) // K1b: keep hot-path registry fresh
+	service.ReloadRedirectRegistry(r.Context(), h.db) // keep the hot-path redirect registry fresh
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 
@@ -149,7 +149,7 @@ func (h *modelRedirectHandler) remove(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"message": "redirect not found"})
 		return
 	}
-	service.ReloadRedirectRegistry(r.Context(), h.db) // K1b: keep hot-path registry fresh
+	service.ReloadRedirectRegistry(r.Context(), h.db) // keep the hot-path redirect registry fresh
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 
@@ -185,7 +185,7 @@ func (h *modelRedirectHandler) generate(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"success": true, "created": created})
-		service.ReloadRedirectRegistry(r.Context(), h.db) // K1b: keep hot-path registry fresh
+		service.ReloadRedirectRegistry(r.Context(), h.db) // keep the hot-path redirect registry fresh
 		return
 	}
 
@@ -212,14 +212,14 @@ func (h *modelRedirectHandler) generate(w http.ResponseWriter, r *http.Request) 
 		}
 		total += n
 	}
-	service.ReloadRedirectRegistry(r.Context(), h.db) // K1b: keep hot-path registry fresh
+	service.ReloadRedirectRegistry(r.Context(), h.db) // keep the hot-path redirect registry fresh
 	writeJSON(w, http.StatusOK, map[string]any{"success": true, "created": total, "accounts": len(byAccount)})
 }
 
 // POST /api/model-redirects/apply — body {dryRun: true}
 // The single apply path for redirect-fix candidates (the duplicated
-// /api/models/redirect-fix-candidates endpoints were removed in Wave 8
-// Lane B). Lists disabled-model entries fixable via redirects; dryRun=true
+// /api/models/redirect-fix-candidates endpoints were removed). Lists
+// disabled-model entries fixable via redirects; dryRun=true
 // reports without deleting (default). dryRun=false deletes and records events.
 func (h *modelRedirectHandler) apply(w http.ResponseWriter, r *http.Request) {
 	var body struct {
@@ -259,7 +259,7 @@ func (h *modelRedirectHandler) apply(w http.ResponseWriter, r *http.Request) {
 	for _, c := range candidates {
 		_ = recordRedirectEvent(h.db, c)
 	}
-	service.ReloadRedirectRegistry(r.Context(), h.db) // K1b: keep hot-path registry fresh
+	service.ReloadRedirectRegistry(r.Context(), h.db) // keep the hot-path redirect registry fresh
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
 		"dryRun":  false,

--- a/handler/admin/model_refresh.go
+++ b/handler/admin/model_refresh.go
@@ -15,8 +15,8 @@ import (
 var accountModelRefresher = refreshAccountModels
 
 // invalidateRoutingCache remains the side-effect seam for the manual-models
-// path (accounts_models.go). The refresh path moved to the service layer in
-// Wave 15 (#1005) carries its own rebuild/invalidate seams there — see
+// path (accounts_models.go). The refresh path moved to the service layer for
+// #1005, which carries its own rebuild/invalidate seams there — see
 // service.SetModelRefreshSideEffectsForTest.
 var invalidateRoutingCache = routing.InvalidateCache
 
@@ -31,7 +31,7 @@ func refreshAccountModels(ctx context.Context, db *sqlx.DB, accountID int64, all
 }
 
 // accountModelRefreshPayload maps a service.AccountModelRefreshResult onto the
-// exact operator-facing JSON shape the handler returned before Wave 15.
+// exact operator-facing JSON shape the handler returned before #1005.
 func accountModelRefreshPayload(accountID int64, result service.AccountModelRefreshResult) map[string]any {
 	rebuildPayload := map[string]any{
 		"routesConsidered":    result.Rebuild.RoutesConsidered,

--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -41,7 +41,7 @@ func RegisterMonitorRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
 // surface. Authentication is the HttpOnly meta_monitor_auth cookie minted by
 // createSession — iframe sub-resource requests cannot carry an Authorization
 // header, so mounting these routes behind the Bearer AdminAuth middleware
-// breaks the LDOH iframe (Wave 4 security handoff F1). The handler enforces
+// breaks the LDOH iframe. The handler enforces
 // the cookie itself via ensureMonitorAuth; keep this registrar outside any
 // Bearer-gated group.
 func RegisterMonitorProxyRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
@@ -253,11 +253,11 @@ func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wildcardPath := resolveLdohProxyPath(r)
-	// Wave 4 security handoff M1: reject ".." segments before joining the
+	// Reject ".." segments before joining the
 	// LDOH base URL. The request path arrives percent-decoded, so %2e%2e is
 	// caught in the same scan. Without this check a monitor-session cookie
 	// holder could normalize outside the LDOH base subpath on the upstream
-	// host once the surface is reachable with cookie-only auth (F1).
+	// host once the surface is reachable with cookie-only auth.
 	if proxy.ContainsPathTraversal(wildcardPath) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid proxy path"})
 		return

--- a/handler/admin/monitor_proxy_traversal_test.go
+++ b/handler/admin/monitor_proxy_traversal_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// TestLdohProxy_PathTraversalRejected is the Wave 4 S-line M1 regression: a
+// TestLdohProxy_PathTraversalRejected is the path-traversal regression: a
 // monitor session cookie must not let its holder escape the LDOH base
 // subpath by smuggling ".." segments through /monitor-proxy/ldoh/*. net/http
 // has already percent-decoded the request target into r.URL.Path before the

--- a/handler/admin/ops_admin_stubs_test.go
+++ b/handler/admin/ops_admin_stubs_test.go
@@ -35,7 +35,7 @@ func setupOpsAdminStubsTest(t *testing.T) (*store.DB, chi.Router, *config.Config
 	r := chi.NewRouter()
 	RegisterNotifyRoutes(r)
 	RegisterMonitorRoutes(r, db.DB, cfg)
-	// The LDOH iframe proxy surface is a separate registrar since Wave 4 F1
+	// The LDOH iframe proxy surface is a separate registrar
 	// (it must stay outside the Bearer admin auth group in production); the
 	// stub harness mounts both so handler-level tests keep their routes.
 	RegisterMonitorProxyRoutes(r, db.DB, cfg)

--- a/handler/admin/probe_history.go
+++ b/handler/admin/probe_history.go
@@ -1,7 +1,7 @@
 package admin
 
 // Read-only exposure of model_probe_results history for the row-level probe
-// health bars on the channels/accounts pages (P0-2). The scheduler
+// health bars on the channels/accounts pages. The scheduler
 // (scheduler/model_probe.go) is the only writer; these endpoints answer
 // "recent N probe results per channel/account" in ONE bounded query per page
 // render so the tables never issue per-row requests.

--- a/handler/admin/search.go
+++ b/handler/admin/search.go
@@ -91,7 +91,7 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 
 	// SQLite LIKE is case-insensitive for ASCII but PostgreSQL LIKE is
 	// case-sensitive; normalize both sides with LOWER() so the same query
-	// matches the same rows on both dialects (w18-pg-dialect).
+	// matches the same rows on both dialects.
 	likePattern := "%" + strings.ToLower(q) + "%"
 
 	// Search sites. Each query surfaces its error so a DB failure yields an

--- a/handler/admin/search_case_test.go
+++ b/handler/admin/search_case_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// TestSearch_MixedCaseQueryMatchesMixedCaseRows guards the w18-pg-dialect
-// LIKE divergence fix: SQLite LIKE is case-insensitive for ASCII while
+// TestSearch_MixedCaseQueryMatchesMixedCaseRows guards the LIKE divergence
+// fix: SQLite LIKE is case-insensitive for ASCII while
 // PostgreSQL LIKE is case-sensitive, so the shared search filters normalize
 // both sides with LOWER(). On SQLite this test passes before and after the
 // fix; the PostgreSQL half of the divergence is proven in

--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -146,7 +146,7 @@ func (h *settingsHandler) getRuntime(w http.ResponseWriter, r *http.Request) {
 		// Global filters (always JSON arrays; never null)
 		"globalBlockedBrands": stringSliceOrEmpty(rt.GlobalBlockedBrands),
 		"globalAllowedModels": stringSliceOrEmpty(rt.GlobalAllowedModels),
-		// N7: effective prompt-cache ratio fallbacks (reflect overrides).
+		// Effective prompt-cache ratio fallbacks (reflect overrides).
 		"cacheRatioDefault": routing.DefaultCacheRatioForModel("gpt-4o"),
 		"cacheRatioClaude":  routing.DefaultCacheRatioForModel("claude-3-5-sonnet"),
 	})
@@ -174,7 +174,7 @@ func (h *settingsHandler) updateRuntime(w http.ResponseWriter, r *http.Request) 
 		h.applySiteBrandingSettings,
 	} {
 		if err := apply(body); err != nil {
-			// Single funnel (scout §settings_apply): 400-class apply failures
+			// Single funnel: 400-class apply failures
 			// are user-side validation errors, so they carry the machine-
 			// readable invalidSettingsValue code; 5xx internals keep the raw
 			// message with no code (backend text stays the display fallback).
@@ -453,7 +453,7 @@ func stringSliceOrEmpty(in []string) []string {
 
 func logSettingsEvent(db *sqlx.DB, eventType, title, message, level, createdAt string) {
 	// read is a BOOLEAN column on PostgreSQL: bind FALSE, not the integer
-	// literal 0 (w18-pg-dialect: PG rejects integer literals for booleans).
+	// literal 0 (PG rejects integer literals for booleans).
 	query := db.Rebind(`INSERT INTO events (type, title, message, level, related_type, created_at, "read")
 		VALUES (?, ?, ?, ?, 'settings', ?, FALSE)`)
 	if _, err := db.Exec(query, eventType, title, message, level, createdAt); err != nil {

--- a/handler/admin/settings_apply.go
+++ b/handler/admin/settings_apply.go
@@ -453,7 +453,7 @@ func (h *settingsHandler) applyRoutingSettings(body map[string]any) *settingsApp
 		config.UpdateRuntime(func(r *config.RuntimeSettings) { r.TokenRouterFailureCooldownMaxSec = cooldownSec })
 		upsertSettingDB(h.db, "token_router_failure_cooldown_max_sec", cooldownSec)
 	}
-	// P1-2: operator-tunable status-code range policy. Empty specs are
+	// Operator-tunable status-code range policy. Empty specs are
 	// allowed (they restore the routing defaults at lookup time); anything
 	// non-empty must parse cleanly before it is persisted or applied.
 	if v, ok := body["proxyRetryStatusRanges"]; ok {
@@ -535,7 +535,7 @@ func (h *settingsHandler) applyRoutingSettings(body map[string]any) *settingsApp
 		}
 	}
 
-	// N7: prompt-cache ratio fallback overrides.
+	// Prompt-cache ratio fallback overrides.
 	if v, ok := body["cacheRatioDefault"]; ok {
 		if val, err := toFloat64Strict(v); err == nil && val >= 0 {
 			config.UpdateRuntime(func(r *config.RuntimeSettings) { r.CacheRatioDefault = val })

--- a/handler/admin/settings_backup.go
+++ b/handler/admin/settings_backup.go
@@ -24,7 +24,7 @@ func RegisterBackupRoutes(r chi.Router, db *sqlx.DB) {
 
 	r.Get("/api/settings/backup/export", handler.exportBackup)
 	r.Post("/api/settings/backup/import", handler.importBackup)
-	// F1: import plan preview before commit.
+	// Import plan preview before commit.
 	r.Post("/api/settings/backup/import/preview", handler.previewBackupImport)
 	r.Get("/api/settings/backup/webdav", handler.getWebdavConfig)
 	r.Put("/api/settings/backup/webdav", handler.saveWebdavConfig)
@@ -201,7 +201,7 @@ func (h *backupHandler) importTSV21Backup(w http.ResponseWriter, raw []byte) {
 	writeJSON(w, http.StatusOK, response)
 }
 
-// F1: preview backup import BEFORE committing. Reuses the
+// Preview a backup import BEFORE committing. Reuses the
 // same decode + validate path as importBackup but returns a plan — per-table
 // rows to insert, rows that would be skipped (runtime-local settings), and
 // rows whose PK (id, or key for settings) already exists in the target DB

--- a/handler/admin/settings_backup_test.go
+++ b/handler/admin/settings_backup_test.go
@@ -198,7 +198,7 @@ func TestExportBackupRejectsPayloadOverLimit(t *testing.T) {
 	}
 }
 
-// F1: import plan preview reports toInsert/duplicates
+// The import plan preview reports toInsert/duplicates
 // and writes nothing.
 func TestPreviewBackupImportReportsPlanWithoutWriting(t *testing.T) {
 	db := setupBackupTestDB(t)

--- a/handler/admin/settings_runtime_test.go
+++ b/handler/admin/settings_runtime_test.go
@@ -514,7 +514,7 @@ func TestSettingsRuntimeNotifyTogglesPersistAsJSONObject(t *testing.T) {
 
 // errorCode contract: the settings-apply validation funnel emits the
 // additive machine-readable invalidSettingsValue code on 400-class apply
-// failures (the largest single validation family — scout §settings_apply);
+// failures (the largest single validation family);
 // 5xx apply failures intentionally carry no code. The message text stays
 // the display fallback.
 func TestSettingsRuntimeApplyValidationCarriesCode(t *testing.T) {

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -60,7 +60,7 @@ func RegisterStatsRoutes(r chi.Router, db *sqlx.DB) {
 }
 
 // RegisterDownstreamPricingRoutes mounts the cross-site price catalog behind
-// downstream-key (ProxyAuth) auth, NOT admin auth. N2 productization: a
+// downstream-key (ProxyAuth) auth, NOT admin auth. Productized so that a
 // downstream consumer (中转站) holding a managed key can query effective
 // cross-site model pricing for its own planning — the aggregator's
 // transparent-pricing differentiator. Reuses modelPriceCompare so the data

--- a/handler/admin/stats_marketplace.go
+++ b/handler/admin/stats_marketplace.go
@@ -76,7 +76,7 @@ func (h *statsHandler) buildMarketplaceModels() ([]map[string]any, error) {
 		return acc
 	}
 
-	// Enabled, non-expired tokens for every account in ONE query (Wave 18
+	// Enabled, non-expired tokens for every account in ONE query (the
 	// N+1 fix): the previous shape re-ran the per-account token query inside
 	// the accountRows loop below — once per model×account availability row,
 	// i.e. hundreds of identical-round-trip queries per marketplace render.

--- a/handler/admin/stats_proxy_logs_cache_test.go
+++ b/handler/admin/stats_proxy_logs_cache_test.go
@@ -307,7 +307,7 @@ func TestStats_ProxyLogsAggregateSQL_NoJoinWithoutSiteID(t *testing.T) {
 	}
 
 	// With a siteId the WHERE references s.id, so the accounts/sites joins
-	// must stay — as INNER joins (Wave 18 index audit): s.id = ? already
+	// must stay — as INNER joins (index audit): s.id = ? already
 	// discards non-matching rows, and INNER lets the planner drive from the
 	// site's accounts into the proxy_logs indexes instead of scanning
 	// proxy_logs first. The dk join stays LEFT because only the search filter
@@ -378,7 +378,7 @@ func TestStats_SQLiteProxyLogsAggregatePlan_NoJoinWithoutSiteID(t *testing.T) {
 	}
 
 	// Sanity check the other direction: with a siteId the plan joins
-	// accounts/sites (INNER since the Wave 18 index audit) and keeps the
+	// accounts/sites (INNER since the index audit) and keeps the
 	// LEFT downstream_api_keys join.
 	planRows, err := queryRowsErr(db.DB, "EXPLAIN QUERY PLAN "+proxyLogsSummaryQuerySQL(proxyLogsAggregateFrom(1, ""), " WHERE s.id = 1"))
 	if err != nil {

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -1259,8 +1259,8 @@ func TestStats_SQLiteMarketplaceFromAvailability(t *testing.T) {
 	}
 }
 
-// TestStats_SQLiteMarketplaceTokensBatchedAcrossModels is the Wave 18 N+1
-// regression: enabled tokens must attach to every model entry of an account
+// TestStats_SQLiteMarketplaceTokensBatchedAcrossModels is the N+1 regression:
+// enabled tokens must attach to every model entry of an account
 // from ONE batched account_tokens load (the pre-fix shape fired one token
 // query per model×account availability row). The test pins the exact token
 // set and the legacy ordering (is_default DESC, id ASC), and proves

--- a/handler/admin/update_center.go
+++ b/handler/admin/update_center.go
@@ -11,7 +11,6 @@ import (
 // Known limitation:
 // - status is a local stub (never invent updateAvailable=true)
 // - deploy/rollback/task-stream surfaces are removed; product updates stay external.
-// See limitation-update-center.md.
 func RegisterUpdateCenterRoutes(r chi.Router) {
 	handler := &updateCenterHandler{}
 

--- a/handler/proxy/proxy_log.go
+++ b/handler/proxy/proxy_log.go
@@ -220,7 +220,7 @@ func writeSuccessProxyLog(
 	if selected.Site.Platform != "" {
 		platformName = selected.Site.Platform
 	}
-	// K1b: billing attribution uses the requested (canonical) name so a
+	// Billing attribution uses the requested (canonical) name so a
 	// redirect/rewrite to the upstream actual name never changes cost
 	// accounting — ratio lookups stay on the canonical model.
 	billing := EstimateBillingCostFromUsage(requestedModel, platformName, usage)

--- a/handler/proxy/surface.go
+++ b/handler/proxy/surface.go
@@ -121,7 +121,7 @@ func PrepareCtx(r *http.Request, cfg SurfConfig) (*Ctx, *SurfResult) {
 		return nil, &SurfResult{OK: false, Status: 400, Error: "model is required", ErrorType: "invalid_request_error"}
 	}
 
-	// N3 reasoning suffix: a suffix like -thinking/-high/
+	// Reasoning suffix: a suffix like -thinking/-high/
 	// -medium/-low requests a reasoning variant. Strip it so routing matches
 	// the base model; inject OpenAI reasoning_effort on OpenAI surfaces when
 	// the client didn't already set it. Non-OpenAI dialects strip for routing

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -117,7 +117,7 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 	if upstreamPath == "" {
 		upstreamPath = r.URL.Path
 	}
-	// Wave 4 security handoff T1: never forward a downstream path containing
+	// Never forward a downstream path containing
 	// ".." segments. Go's http.Client preserves ".." on the wire, and the
 	// upstream host would normalize it outside the site API prefix — letting
 	// any authenticated downstream key holder reach arbitrary upstream paths.
@@ -1092,7 +1092,7 @@ func recordUpstreamFailure(ctx context.Context, cfg *UpstreamConfig, selected *r
 
 // recordUpstreamSuccess feeds routing success stats. billingCostName is the
 // attribution (requested/canonical) model — the same name proxy_logs and
-// billing use, so a K1b redirect (canonical→actual) never skews channel cost
+// billing use, so a model redirect (canonical→actual) never skews channel cost
 // accumulation; modelName (actual) stays the health-stat label.
 func recordUpstreamSuccess(ctx context.Context, cfg *UpstreamConfig, selected *routing.SelectedChannel, billingCostName, modelName string, latencyMs int64, usage ParsedUsage) {
 	if cfg == nil || cfg.Router == nil || selected == nil {

--- a/handler/proxy/upstream_stream_honesty_test.go
+++ b/handler/proxy/upstream_stream_honesty_test.go
@@ -424,7 +424,7 @@ func TestShouldContinueEndpointFallbackSingleOwnerFourQuadrants(t *testing.T) {
 }
 
 // TestTransportErrorFallbackGoesThroughTheSingleDecisionFunction is the
-// end-to-end half of the F3 nail: a transport-level "connection refused" on the
+// end-to-end half of that nail: a transport-level "connection refused" on the
 // primary protocol path is covered by the same-site abort policy, so the
 // dispatcher must stop walking the protocol candidate list and report the
 // failure for the PRIMARY path. Historically transport errors bypassed the

--- a/handler/proxy/videos.go
+++ b/handler/proxy/videos.go
@@ -27,7 +27,6 @@ import (
 // restart can resolve publicId. GET/DELETE treat the store as an optional
 // rewrite aid, not a hard gate — missing entries still pass the client id
 // through to upstream. Sticky site/token pin remains a known limitation.
-// See limitation.md.
 type ProxyVideoTask struct {
 	PublicID        string `json:"publicId"`
 	UpstreamVideoID string `json:"upstreamVideoId"`

--- a/internal/golden/golden.go
+++ b/internal/golden/golden.go
@@ -1,5 +1,5 @@
 // Package golden is a test-only snapshot harness for the protocol-conversion
-// golden suites (P0-1). It is imported exclusively from _test.go files, so it
+// golden suites. It is imported exclusively from _test.go files, so it
 // never becomes part of the production dependency graph.
 //
 // Each golden case is a pair of checked-in files under the owning package's

--- a/proxy/path_traversal_test.go
+++ b/proxy/path_traversal_test.go
@@ -2,7 +2,7 @@ package proxy
 
 import "testing"
 
-// TestContainsPathTraversal covers the Wave 4 security handoff T1 helper:
+// TestContainsPathTraversal covers the path-traversal helper:
 // detection must catch every ".." segment shape that can arrive via
 // r.URL.Path (already percent-decoded by net/http) while leaving every
 // legitimate path untouched — the forwarding contract forbids altering

--- a/proxy/timeouts_test.go
+++ b/proxy/timeouts_test.go
@@ -30,7 +30,7 @@ func TestRequestCeiling_DoublesFirstByteWindowOnlyAboveDefault(t *testing.T) {
 	}
 }
 
-// TestWriteBudget_NeverInvertsRequestCeiling locks the audit T1 invariant: the
+// TestWriteBudget_NeverInvertsRequestCeiling locks the write-budget invariant: the
 // server-side write budget must always be at least the whole-request ceiling,
 // otherwise a buffered response arriving late is killed while being written.
 func TestWriteBudget_NeverInvertsRequestCeiling(t *testing.T) {

--- a/router/monitor_wiring_test.go
+++ b/router/monitor_wiring_test.go
@@ -38,7 +38,7 @@ func newMonitorWiringRouter(t *testing.T) http.Handler {
 	return New(cfg, web.Dist)
 }
 
-// TestMonitorProxyReachableWithoutBearerHeader is the Wave 4 S-line F1
+// TestMonitorProxyReachableWithoutBearerHeader is the monitor-auth
 // regression: /monitor-proxy/* serves the LDOH iframe and authenticates via
 // the HttpOnly meta_monitor_auth cookie, so it must not sit behind the Bearer
 // AdminAuth middleware. Cookie-only requests have to reach the monitor
@@ -97,8 +97,8 @@ func TestMonitorProxyReachableWithoutBearerHeader(t *testing.T) {
 	}
 }
 
-// TestMonitorAPIRoutesStayBehindBearerAuth pins the other half of the F1
-// fix: only /monitor-proxy/* leaves the AdminAuth group; the /api/monitor
+// TestMonitorAPIRoutesStayBehindBearerAuth pins the other half of the same
+// rule: only /monitor-proxy/* leaves the AdminAuth group; the /api/monitor
 // configuration surface stays Bearer-protected.
 func TestMonitorAPIRoutesStayBehindBearerAuth(t *testing.T) {
 	r := newMonitorWiringRouter(t)

--- a/router/router.go
+++ b/router/router.go
@@ -116,7 +116,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 		// Sites + Accounts + AccountTokens CRUD API
 		db := store.GetDB()
 		if db != nil {
-			// K1b: load the in-process redirect registry so routing eligibility
+			// Load the in-process redirect registry so routing eligibility
 			// and forward rewriting see canonical→actual mappings from boot.
 			service.ReloadRedirectRegistry(context.Background(), db.DB)
 			admin.RegisterSitesRoutes(r, db.DB)
@@ -171,12 +171,12 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 		}
 	})
 
-	// Wave 4 security handoff F1: the LDOH iframe proxy authenticates via the
+	// The LDOH iframe proxy authenticates via the
 	// HttpOnly meta_monitor_auth cookie — iframe sub-resource requests cannot
 	// carry an Authorization header, so this surface must stay OUTSIDE the
 	// Bearer AdminAuth group above (which answered 401 "Missing Authorization
 	// header" and broke the iframe). The handler enforces its own cookie auth
-	// (ensureMonitorAuth) and rejects ".." traversal paths (M1).
+	// (ensureMonitorAuth) and rejects ".." traversal paths.
 	if db := store.GetDB(); db != nil {
 		admin.RegisterMonitorProxyRoutes(r, db.DB, cfg)
 	}
@@ -193,7 +193,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 		r.Use(auth.ProxyAuth())
 		r.Use(auth.ProxyGlobalTokenRateLimit(cfg.ProxyGlobalTokenRPM))
 		proxyhandler.RegisterProxyRoutes(r)
-		// N2: downstream-key-visible cross-site price catalog (not admin auth).
+		// Downstream-key-visible cross-site price catalog (not admin auth).
 		// Mounted under /v1 so it inherits ProxyAuth; reuses the admin
 		// modelPriceCompare data surface (no separate catalog to drift).
 		if db := store.GetDB(); db != nil {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -87,7 +87,7 @@ func parseCSPDirectives(t *testing.T, csp string) map[string][]string {
 }
 
 // assertCSPPolicy pins the directive-level shape of the Content-Security-Policy
-// header (#1035 S2): the static directives keep their exact source lists, and
+// header (#1035): the static directives keep their exact source lists, and
 // style-src carries 'self' + exactly one per-request nonce + the sonner toast
 // hash — with 'unsafe-inline' gone from every directive.
 func assertCSPPolicy(t *testing.T, csp string) {

--- a/router/security.go
+++ b/router/security.go
@@ -50,7 +50,7 @@ func generateCSPNonce() string {
 
 // contentSecurityPolicy renders the CSP header value for one request.
 //
-// 'unsafe-inline' was removed from style-src (#1035 S2). The three runtime
+// 'unsafe-inline' was removed from style-src (#1035). The three runtime
 // <style> injectors in the SPA are covered individually:
 //
 //   - chart color variables (web/src/components/ui/chart.tsx): React renders

--- a/routing/cooldown_reason.go
+++ b/routing/cooldown_reason.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 )
 
-// ---- Structured cooldown reasons (P0-3) ----
+// ---- Structured cooldown reasons ----
 
 // Cooldown reason trigger codes. The code is persisted into
 // route_channels.cooldown_reason_code / oauth_route_unit_members and surfaced

--- a/routing/cooldown_reason_records_test.go
+++ b/routing/cooldown_reason_records_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // =============================================================================
-// P0-3 — RecordFailure / RecordProbeFailure persist structured cooldown
+// RecordFailure / RecordProbeFailure persist structured cooldown
 // reasons; success and clear paths reset them. Uses the isolationDB harness
 // (failure_isolation_test.go) and asserts on the captured update maps, which
 // are the exact payloads ProxyRoutingStore writes to route_channels /

--- a/routing/cooldown_reason_test.go
+++ b/routing/cooldown_reason_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // =============================================================================
-// P0-3 — structured cooldown reason classification
+// Structured cooldown reason classification
 // =============================================================================
 
 func TestClassifyCooldownReason_StatusClasses(t *testing.T) {

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -186,7 +186,8 @@ func ChannelSupportsRequestedModel(channelSourceModel *string, requestedModel st
 	return false
 }
 
-// ChannelSupportsRequestedModelWithRedirects is the K1b variant: besides the
+// ChannelSupportsRequestedModelWithRedirects is the redirect-aware variant:
+// besides the
 // base checks it consults the in-process redirect registry, so a channel whose
 // source_model is an upstream `actual` name (e.g. claude-3-5-sonnet-20241022)
 // becomes eligible for a request of its `canonical` (claude-3-5-sonnet) on the
@@ -395,7 +396,7 @@ func NormalizeChannelSourceModel(channelSourceModel *string) string {
 // ResolveActualModelForSelectedChannel resolves the actual model to forward.
 // Resolution order (first match wins):
 // 1. display-name hit → the channel's own source model (existing behavior);
-// 2. K1b: per-account redirect (canonical → actual) when no route-level
+// 2. Per-account redirect (canonical → actual) when no route-level
 // model mapping already rewrote the name — the upstream only knows the
 // dated/versioned actual name;
 // 3. route-level model mapping (existing fallback).

--- a/routing/matcher_test.go
+++ b/routing/matcher_test.go
@@ -478,7 +478,7 @@ func TestResolveActualModelForSelectedChannel(t *testing.T) {
 		t.Errorf("expected mapped model 'gpt-4-0613', got %q", result)
 	}
 
-	// K1b: per-account redirect rewrites canonical → actual when no route
+	// Per-account redirect rewrites canonical → actual when no route
 	// mapping rewrote the name (mapped == requested).
 	srcActual := "claude-3-5-sonnet-20241022"
 	SetModelRedirects(map[int64]map[string]string{

--- a/routing/pricing_cost.go
+++ b/routing/pricing_cost.go
@@ -37,7 +37,7 @@ const (
 	oneHubPerCallRatio = 0.002
 )
 
-// N7: admin-overridable cache-ratio fallbacks. The consts above remain the
+// Admin-overridable cache-ratio fallbacks. The consts above remain the
 // code defaults; an operator can tune these via settings (keys
 // cache_ratio_default / cache_ratio_claude) without a code change. NaN/Inf
 // and non-positive overrides are ignored (fall back to the const).

--- a/routing/redirects.go
+++ b/routing/redirects.go
@@ -5,12 +5,11 @@ import (
 	"sync"
 )
 
-// ---- K1b: in-process model redirect registry ----
+// ---- In-process model redirect registry ----
 
-// Design: k1-model-redirect-design-2026-08-01.md §7. Per-account
-// canonical→actual redirects (from model_name_redirects) are loaded into a
-// lock-free-swap registry so the hot path (eligibility + forward rewrite) is
-// an O(1) map lookup with no DB access.
+// Per-account canonical→actual redirects (from model_name_redirects) are
+// loaded into a lock-free-swap registry so the hot path (eligibility +
+// forward rewrite) is an O(1) map lookup with no DB access.
 
 // A redirect says: when a client requests `canonical` on this account, the
 // upstream actually exposes it as `actual`. Registry consumers:

--- a/routing/redirects_test.go
+++ b/routing/redirects_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/store"
 )
 
-// ---- K1b: redirect registry integration ----
+// ---- Redirect registry integration ----
 
 // End-to-end selector behavior: a channel whose source_model is the upstream
 // actual name (claude-3-5-sonnet-20241022) becomes eligible for a canonical
@@ -78,7 +78,7 @@ func TestSelectChannel_RedirectRegistryEnablesActualChannel(t *testing.T) {
 	}
 
 	// Direct actual-name request does NOT match the canonical route pattern —
-	// clients are expected to request canonical names; K1b only forwards
+	// clients are expected to request canonical names; the registry only forwards
 	// canonical → actual on the wire. Verify no crash and no selection.
 	sel, err = selector.SelectChannel(context.Background(), actualSource, DownstreamRoutingPolicy{})
 	if err != nil {

--- a/routing/router_records.go
+++ b/routing/router_records.go
@@ -429,7 +429,7 @@ func (tr *TokenRouter) RecordFailure(ctx context.Context, channelID int64, failu
 			consecutiveFailCount, cooldownLevel, failCount, nowMs, tr.configuredMaxSec)
 	}
 
-	// P1-2 operator-tunable auto-disable: when the failing status falls in
+	// Operator-tunable auto-disable: when the failing status falls in
 	// the configured disable ranges (default: none — historical behavior),
 	// the channel is disabled outright on top of the cooldown escalation.
 	// manual_override shields it from route rebuilds; the operator

--- a/scripts/go-race.sh
+++ b/scripts/go-race.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Per-package budget for the race gate. Default 900s: handler/admin -race was
 # measured at 217-364s on contended dev hosts (8GB WSL VM, /mnt/d 9p) across
-# six Wave 18 lanes, and CI gives each package ~10 min (Go's default test
+# six parallel race lanes, and CI gives each package ~10 min (Go's default test
 # timeout). Override with METAPI_RACE_TIMEOUT_SECONDS=<seconds>; see
 # docs/testing.md "Race-detector budget".
 timeout_seconds="${METAPI_RACE_TIMEOUT_SECONDS:-900}"

--- a/scripts/verify-cascade-prod.sh
+++ b/scripts/verify-cascade-prod.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# verify-cascade-prod.sh — P0-585 production multi-channel cascade verification.
+# verify-cascade-prod.sh — production multi-channel cascade verification.
 #
 # Connects to a running metapi instance (any reachable host — set METAPI_URL)
 # and captures honest, READ-ONLY evidence of the multi-channel cascade
@@ -72,10 +72,10 @@ else
 	C_GREEN=""; C_RED=""; C_YELLOW=""; C_DIM=""; C_RESET=""
 fi
 
-log()      { printf '%s[p0585]%s %s\n' "$C_DIM" "$C_RESET" "$*"; }
-log_ok()   { printf '%s[p0585] OK   %s%s\n'  "$C_GREEN" "$C_RESET" "$*"; }
-log_warn() { printf '%s[p0585] WARN %s%s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
-log_err()  { printf '%s[p0585] ERR  %s%s\n'  "$C_RED" "$C_RESET" "$*" >&2; }
+log()      { printf '%s[cascade]%s %s\n' "$C_DIM" "$C_RESET" "$*"; }
+log_ok()   { printf '%s[cascade] OK   %s%s\n'  "$C_GREEN" "$C_RESET" "$*"; }
+log_warn() { printf '%s[cascade] WARN %s%s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
+log_err()  { printf '%s[cascade] ERR  %s%s\n'  "$C_RED" "$C_RESET" "$*" >&2; }
 
 # ---------------------------------------------------------------------------
 # Preflight
@@ -109,7 +109,7 @@ report_init() {
 		--arg timestamp "$TIMESTAMP_ISO" \
 		--arg url "$METAPI_URL" \
 		'{
-			feature: "P0-585 multi-channel cascade failover",
+			feature: "multi-channel cascade failover",
 			timestamp: $timestamp,
 			instanceUrl: $url,
 			verdict: "partial",
@@ -128,7 +128,7 @@ report_save_raw() { cp "$1" "$RAW_DIR/$2" 2>/dev/null || true; }
 
 report_init
 
-log "verifying P0-585 cascade against $METAPI_URL (report: $REPORT_JSON)"
+log "verifying cascade against $METAPI_URL (report: $REPORT_JSON)"
 
 # ---------------------------------------------------------------------------
 # HTTP helpers (curl with auth + timeout, capturing status + body)
@@ -151,7 +151,7 @@ curl_proxy_json() {
 	curl -sS -D "$RAW_DIR/$2.headers" -o "$RAW_DIR/$2.body" -w '%{http_code}' \
 		-H "Authorization: Bearer ${METAPI_PROXY_TOKEN}" \
 		-H "Content-Type: application/json" \
-		-H "X-Metapi-Verify: cascade-p0585" \
+		-H "X-Metapi-Verify: cascade-verify" \
 		-X POST --data "$3" \
 		--max-time "$METAPI_REQUEST_TIMEOUT" \
 		"${METAPI_URL}${1}" 2>"$RAW_DIR/$2.err" || true
@@ -291,7 +291,7 @@ if [ -z "$probe_model" ]; then
 	report_push_residual "live probe skipped — no model resolved (set METAPI_TEST_MODEL)"
 else
 	log "  probing model: $probe_model"
-	probe_body="{\"model\":\"${probe_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"p0585 cascade verify (read-only)\"}],\"max_tokens\":1,\"stream\":false}"
+	probe_body="{\"model\":\"${probe_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"cascade verify (read-only)\"}],\"max_tokens\":1,\"stream\":false}"
 	probe_status="$(curl_proxy_json /v1/chat/completions probe.json "$probe_body")"
 	if [ -f "$RAW_DIR/probe.json.headers" ]; then
 		probe_request_id="$(awk -F': ' 'tolower($1)=="x-request-id"{gsub(/\r/,"",$2); print $2; exit}' "$RAW_DIR/probe.json.headers" 2>/dev/null || true)"
@@ -430,7 +430,7 @@ fi
 report_set '.verdict' "$(jq -n --arg v "$verdict" '$v')"
 
 echo ""
-echo "================ P0-585 cascade verification report ================"
+echo "================ cascade verification report ================"
 echo " Instance      : $METAPI_URL"
 echo " Timestamp     : $TIMESTAMP_ISO"
 echo " Verdict       : $verdict"

--- a/service/account_model_refresh.go
+++ b/service/account_model_refresh.go
@@ -15,7 +15,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/store"
 )
 
-// Account model refresh (#1005 Wave 15): the single-account refresh core
+// Account model refresh (#1005): the single-account refresh core
 // moved here from handler/admin/model_refresh.go so the admin handler, the
 // periodic model-sync scheduler and future callers share one owner and one
 // data flow. The handler keeps the accountModelRefresher seam and shapes the
@@ -227,7 +227,7 @@ func RefreshAccountModels(ctx context.Context, db *sqlx.DB, accountID int64, all
 	if redirectErr != nil {
 		slog.Warn("model-refresh: redirect generation failed", "account_id", accountID, "error", redirectErr)
 	} else {
-		// K1b: keep the in-process hot-path registry in sync after generation.
+		// Keep the in-process hot-path registry in sync after generation.
 		ReloadRedirectRegistry(context.Background(), db)
 		result.RedirectsCreated = redirectsCreated
 	}

--- a/service/account_model_refresh_test.go
+++ b/service/account_model_refresh_test.go
@@ -310,7 +310,7 @@ func TestResolveAccountTokenID_NoRows(t *testing.T) {
 	}
 }
 
-// TestSyncAllAccountModels_BatchSemantics is the Wave 15 #1005 acceptance
+// TestSyncAllAccountModels_BatchSemantics is the #1005 acceptance
 // proof: sequential per-account refreshes skip their own rebuild, and the
 // whole pass triggers exactly one route rebuild + one routing-cache
 // invalidation when at least one account succeeded. Candidate filtering

--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -520,7 +520,7 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 		return CheckinResult{Success: false, Status: CheckinFailed, Message: "failed to persist checkin log: " + err.Error()}
 	}
 
-	// 10. Write events (structured, F5): the registry definition renders the
+	// 10. Write structured events: the registry definition renders the
 	// legacy English title/message for non-UI consumers while the UI gets
 	// titleKey + params to render in the viewer's locale.
 	if !options.SkipEvent {

--- a/service/events/checkin.go
+++ b/service/events/checkin.go
@@ -1,7 +1,7 @@
 package events
 
-// Checkin event definitions — batch 1 of the structured-event migration
-// (F5). The TitleEn / MessageEn / Type values replicate the historical
+// Checkin event definitions — first batch of the structured-event migration.
+// The TitleEn / MessageEn / Type values replicate the historical
 // producer output byte-for-byte so migrated rows are identical for legacy
 // consumers (notifications, CSV export, history fallback).
 func init() {

--- a/service/events/events.go
+++ b/service/events/events.go
@@ -1,5 +1,5 @@
 // Package events is the single source of truth for structured event
-// emission (F5). Every event definition lives in this registry; producers
+// emission. Every event definition lives in this registry; producers
 // reference a definition by Key and pass typed params, and WriteEvent
 // renders the English fallback title/message for legacy consumers (notify /
 // CSV export / history) while storing the structured titleKey + params the

--- a/service/model_redirects_test.go
+++ b/service/model_redirects_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/store"
 )
 
-// ---- K1b: registry reload from model_name_redirects ----
+// ---- Registry reload from model_name_redirects ----
 
 func TestReloadRedirectRegistry_LoadsFromDB(t *testing.T) {
 	db, err := store.Open(store.DialectSQLite, ":memory:", false)

--- a/service/resin.go
+++ b/service/resin.go
@@ -35,8 +35,6 @@ import (
 // Account identity rules (Resin splits proxy-auth on first '.' and last ':'):
 //   - Stable (post-creation):  acc-{Account.ID}
 //   - Pre-account (verify/login/create):  tmp-{sha1(siteID:token)[:16]}
-//
-// See doc/integration-prompt.md in the resin repo for the full contract.
 
 // resinAccountPrefixStable is the prefix for stable post-creation identities.
 const resinAccountPrefixStable = "acc-"

--- a/service/routing_store.go
+++ b/service/routing_store.go
@@ -660,7 +660,7 @@ var routeChannelUpdateColumns = map[string]string{
 	"cooldownReasonCode":   "cooldown_reason_code",
 	"cooldownReason":       "cooldown_reason",
 	"cooldownReasonAt":     "cooldown_reason_at",
-	// P1-2: the failure-recording path may disable a channel outright when
+	// The failure-recording path may disable a channel outright when
 	// its failing status falls in the operator-configured disable ranges.
 	"enabled":        "enabled",
 	"manualOverride": "manual_override",

--- a/store/additive.go
+++ b/store/additive.go
@@ -118,7 +118,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		},
 	},
 	{
-		// N1 security: per-downstream-key IP allowlist/blocklist.
+		// Security: per-downstream-key IP allowlist/blocklist.
 		// ip_allowlist: newline/comma-separated CIDR or exact IPs; empty = unrestricted.
 		// ip_blocklist: same format; deny first (blocklist wins over allowlist).
 		// Enforced at the ProxyAuth edge via auth.parseAllowlist/isIPAllowed.
@@ -146,7 +146,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		},
 	},
 	{
-		// 13-report §4 / plan.md §5.5.5: wire the existing ClassifyFailureReason
+		// Wire the existing ClassifyFailureReason
 		// (service/checkin/failure_reason.go) into the production checkin path.
 		// Stores the serialized FailureReason JSON so the UI can render the
 		// structured "分类" column instead of a phantom always-`-` value.
@@ -344,7 +344,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		},
 	},
 	{
-		// P0-3: structured cooldown/breaker reasons. Answers "why is this channel
+		// Structured cooldown/breaker reasons. Answers "why is this channel
 		// cooling" without log archaeology: classification code + truncated error
 		// summary + recorded-at. NULL on rows cooled before this step ran — the UI
 		// reports that honestly instead of guessing.
@@ -382,7 +382,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		},
 	},
 	{
-		// Wave 18 index audit (admin high-frequency read paths). Pure additive
+		// Admin high-frequency read-path index audit. Pure additive
 		// indexes on base-schema columns, measured on a 300k-proxy_logs audit
 		// fixture before adoption (SQLite EXPLAIN QUERY PLAN + timing):
 		//   - proxy_logs_channel_id_created_at_idx: the proxy-logs page
@@ -423,16 +423,16 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		},
 	},
 	{
-		// F5: structured events. New events carry a stable titleKey + JSON
+		// Structured events. New events carry a stable titleKey + JSON
 		// params so the UI renders them in the viewer's locale; legacy rows
 		// keep NULL and fall back to the stored English title/message.
 		Version:     "sc2_028_events_structured",
-		Description: "events.title_key TEXT NULL + events.params TEXT NULL — structured event rendering (F5); NULL = legacy row rendered as-is",
+		Description: "events.title_key TEXT NULL + events.params TEXT NULL — structured event rendering; NULL = legacy row rendered as-is",
 		Apply: func(db *DB) error {
 			// Production schemas always carry events (TS-era table); the
 			// legacy-schema upgrade test fixture deliberately omits it, so
 			// guard for a missing table the same way EnsureColumn guards a
-			// missing column — an install without events cannot use F5.
+			// missing column — an install without events cannot use structured events.
 			exists, err := tableExists(db, "events")
 			if err != nil {
 				return fmt.Errorf("store: probe events table: %w", err)

--- a/store/additive_test.go
+++ b/store/additive_test.go
@@ -350,7 +350,7 @@ func TestPostgresEnsureColumnAndMigrations(t *testing.T) {
 	}
 }
 
-// TestSC2027AdminReadPathIndexes verifies the Wave 18 admin read-path indexes
+// TestSC2027AdminReadPathIndexes verifies the admin read-path indexes
 // land on a fresh SQLite install via AutoMigrate (which runs the additive
 // registry after buildIndexes) and survive a second AutoMigrate run unchanged
 // — the CREATE INDEX IF NOT EXISTS + schema_migrations bookkeeping must make

--- a/store/additive_upgrade_test.go
+++ b/store/additive_upgrade_test.go
@@ -70,7 +70,7 @@ func additiveColumns() []additiveColumnSpec {
 		{"account_tokens", "token_group"},
 		{"account_tokens", "value_status"},
 		{"model_availability", "is_manual"},
-		// P0-3 structured cooldown reasons.
+		// Structured cooldown reasons.
 		{"route_channels", "cooldown_reason_code"},
 		{"route_channels", "cooldown_reason"},
 		{"route_channels", "cooldown_reason_at"},

--- a/store/boolean_bind_test.go
+++ b/store/boolean_bind_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Incident class under test (w18-pg-dialect audit): a shared statement binds
+// Incident class under test: a shared statement binds
 // the INTEGER literal 0/1 to a BOOLEAN column. SQLite declares its boolean
 // columns as INTEGER (see schema_ddl.go), so the literal is silently accepted;
 // PostgreSQL uses native BOOLEAN and rejects the row with

--- a/store/cooldown_reason_schema_test.go
+++ b/store/cooldown_reason_schema_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // =============================================================================
-// P0-3 — structured cooldown reason columns must exist in BOTH dialects.
+// Structured cooldown reason columns must exist in BOTH dialects.
 // SQLite runs for real below; PostgreSQL is asserted statically on the DDL
 // string (CI has no PG server in this lane; PG_TEST_DSN runs cover it when
 // set).

--- a/store/like_case_test.go
+++ b/store/like_case_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// Dialect divergence under test (w18-pg-dialect audit): SQLite LIKE matches
+// Dialect divergence under test: SQLite LIKE matches
 // case-insensitively for ASCII, PostgreSQL LIKE is case-sensitive. Shared
 // filters therefore must normalize both sides with LOWER() — otherwise the
 // same admin query returns rows on SQLite and nothing on PostgreSQL.

--- a/store/postgres_test.go
+++ b/store/postgres_test.go
@@ -203,7 +203,7 @@ func TestPostgresIndexesCreated(t *testing.T) {
 		"accounts_site_id_idx",
 		"proxy_logs_created_at_idx",
 		"events_created_at_idx",
-		// Wave 18 admin read-path indexes (additive step sc2_027): asserting
+		// Admin read-path indexes (additive step sc2_027): asserting
 		// them here proves the step's plain CREATE INDEX form applies on the
 		// PostgreSQL dialect too.
 		"proxy_logs_channel_id_created_at_idx",

--- a/store/schema.go
+++ b/store/schema.go
@@ -299,7 +299,7 @@ type OAuthRouteUnitMember struct {
 	ConsecutiveFailCount int64    `db:"consecutive_fail_count" json:"consecutiveFailCount"`
 	CooldownLevel        int64    `db:"cooldown_level" json:"cooldownLevel"`
 	CooldownUntil        *string  `db:"cooldown_until" json:"cooldownUntil"`
-	// Structured cooldown reason — same contract as RouteChannel (P0-3).
+	// Structured cooldown reason — same contract as RouteChannel.
 	CooldownReasonCode *string `db:"cooldown_reason_code" json:"cooldownReasonCode"`
 	CooldownReason     *string `db:"cooldown_reason" json:"cooldownReason"`
 	CooldownReasonAt   *string `db:"cooldown_reason_at" json:"cooldownReasonAt"`
@@ -372,7 +372,7 @@ type RouteChannel struct {
 	ConsecutiveFailCount int64    `db:"consecutive_fail_count" json:"consecutiveFailCount"`
 	CooldownLevel        int64    `db:"cooldown_level" json:"cooldownLevel"`
 	CooldownUntil        *string  `db:"cooldown_until" json:"cooldownUntil"`
-	// Structured reason for the active cooldown (P0-3): classification code,
+	// Structured reason for the active cooldown: classification code,
 	// truncated upstream error summary, and the time the triggering failure was
 	// recorded. All NULL for rows that cooled down before this schema existed
 	// — the UI renders that honestly as "reason not recorded".

--- a/store/settings.go
+++ b/store/settings.go
@@ -168,7 +168,7 @@ var nonHydratedSettingKeys = map[string]string{
 	// Catalog auto-sync toggle, read at use time by its own store on every
 	// sync pass; a snapshot copy would only be a stale second owner.
 	"catalog_auto_sync_enabled": "read at use time by service/catalogsync.Store.AutoSyncEnabled",
-	// Removed setting (Wave 8 Lane D): it was stored but never rendered.
+	// Removed setting: it was stored but never rendered.
 	// Legacy rows are intentionally ignored, and listed here so they do not
 	// trip the unknown-key warning on every boot.
 	"home_page_content": "setting removed; legacy rows intentionally ignored",
@@ -236,7 +236,7 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 				slog.Warn("settings: ignoring invalid admin_ip_allowlist value")
 			}
 
-		// Proxy retry/disable status-code range policy (P1-2): blank keeps
+		// Proxy retry/disable status-code range policy: blank keeps
 		// the routing defaults (historical behavior).
 		case "proxy_retry_status_ranges":
 			rt.ProxyRetryStatusRanges = parseJSONSettingString(value)
@@ -508,7 +508,7 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 					describeJSONSettingValue(cfg.OpenAiServiceTierRules))
 			}
 
-		// N7: prompt-cache ratio fallback overrides (0 = use code default).
+		// Prompt-cache ratio fallback overrides (0 = use code default).
 		case "cache_ratio_default":
 			rt.CacheRatioDefault = parseFloatSetting(value, 0)
 		case "cache_ratio_claude":

--- a/web/config/build-shared.ts
+++ b/web/config/build-shared.ts
@@ -3,7 +3,7 @@
 //   - vitest.config.ts   → unit tests
 //
 // Keeping devProxy, the METAPI_WEB_VERSION define and the '@' alias here
-// guarantees the three consumers cannot drift apart (issue #1035 S1).
+// guarantees the three consumers cannot drift apart (issue #1035).
 
 import { readFileSync } from 'node:fs'
 import path from 'node:path'

--- a/web/rsbuild.config.ts
+++ b/web/rsbuild.config.ts
@@ -4,7 +4,7 @@ import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss'
 import { tanstackRouter } from '@tanstack/router-plugin/rspack'
 
 // devProxy, version define and '@' alias live in one shared module so the
-// dev/build and vitest paths cannot drift (issue #1035 S1).
+// dev/build and vitest paths cannot drift (issue #1035).
 import {
   createDevProxy,
   srcAlias,
@@ -55,7 +55,7 @@ export default defineConfig(({ envMode }) => {
           priority: 0,
           enforce: true,
         },
-        // Issue #1035 S9: the audit's "vendor-i18n" blob was the unnamed
+        // Issue #1035: the "vendor-i18n" blob was the unnamed
         // chunk 6432 — a grab-bag of i18next, icon libraries and small
         // utilities. Split the coherent families into named chunks so the
         // i18n runtime is cache-stable on its own.

--- a/web/scripts/check-boundaries.mjs
+++ b/web/scripts/check-boundaries.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// metapi-go/web — package boundary gate (S5).
+// metapi-go/web — package boundary gate.
 //
 // Mechanically enforces the import rules of
 // docs/internal/web-package-boundaries.md:

--- a/web/scripts/verify-route-tree.mjs
+++ b/web/scripts/verify-route-tree.mjs
@@ -2,8 +2,7 @@
 // Verifies src/routeTree.gen.ts is in sync with src/routes/** before vitest
 // runs. Vitest does NOT run @tanstack/router-plugin (the rsbuild config is the
 // only consumer that regenerates the tree), so a stale routeTree.gen.ts would
-// silently test yesterday's routing table (issue #1035 S1, prerequisite guard
-// for S9).
+// silently test yesterday's routing table (issue #1035).
 //
 // Checks both directions:
 //   1. every route file under src/routes/ is imported by routeTree.gen.ts

--- a/web/scripts/visual-regression.spec.mjs
+++ b/web/scripts/visual-regression.spec.mjs
@@ -28,7 +28,7 @@ const PAGES = [
   ['token-routes', '/token-routes'],
   ['accounts', '/accounts'],
   ['sites', '/sites'],
-  // Wave 11 expansion — same contract, audited on a fresh DB:
+  // Later expansion — same contract, audited on a fresh DB:
   // models/channels/oauth render empty tables with no timestamp columns when
   // the DB is empty (date fields only appear on data rows).
   ['models', '/models'],

--- a/web/src/components/common/__tests__/probe-health-bar.test.tsx
+++ b/web/src/components/common/__tests__/probe-health-bar.test.tsx
@@ -1,4 +1,4 @@
-// metapi-go/components/common — probe health bar states (P0-2).
+// metapi-go/components/common — probe health bar states.
 // Covers the honest empty state, the pending placeholder, chronological bar
 // ordering with status colors, the success-rate/latency tooltip and the
 // screen-reader summary.

--- a/web/src/components/common/__tests__/use-probe-history.test.ts
+++ b/web/src/components/common/__tests__/use-probe-history.test.ts
@@ -1,4 +1,4 @@
-// metapi-go/components/common — probe history envelope parsing (P0-2).
+// metapi-go/components/common — probe history envelope parsing.
 // The parser turns the backend `{limit, items}` envelope into the row-id map
 // the table cells consume; a malformed body must throw (fail the query
 // explicitly) instead of masquerading as an empty history.

--- a/web/src/components/common/probe-health-bar.tsx
+++ b/web/src/components/common/probe-health-bar.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/only-export-components -- summary helper + shared types are co-located with the component that owns them */
-// metapi-go/components/common — row-level probe history health bar (P0-2).
+// metapi-go/components/common — row-level probe history health bar.
 // Renders the recent background model-probe results of one channel/account
 // as a compact strip of vertical bars (one per probe, chronological
 // left-to-right), with a tooltip carrying the success rate and average

--- a/web/src/components/layout/__tests__/attention-bell.test.tsx
+++ b/web/src/components/layout/__tests__/attention-bell.test.tsx
@@ -311,7 +311,7 @@ describe('attention bell', () => {
   })
 
   it('re-localizes labels through attention params in the active language', async () => {
-    // F3: the backend keeps an English label for API compat and ships params
+    // The backend keeps an English label for API compat and ships params
     // so the bell renders the same item in the operator's language.
     mockGetAttention.mockResolvedValue({
       items: [

--- a/web/src/features/channels/__tests__/cooldown-reason-dialog.test.tsx
+++ b/web/src/features/channels/__tests__/cooldown-reason-dialog.test.tsx
@@ -1,4 +1,4 @@
-// Behavior tests for the cooldown root-cause dialog (P0-3): reason rendering,
+// Behavior tests for the cooldown root-cause dialog: reason rendering,
 // honest legacy-data state, remaining-time countdown, and the route-scoped
 // clear action reuse.
 

--- a/web/src/features/channels/components/channel-detail-sheet.tsx
+++ b/web/src/features/channels/components/channel-detail-sheet.tsx
@@ -200,7 +200,7 @@ export function ChannelDetailSheet({
                 <DetailField label={t('channels.detail.cooldownUntil')}>
                   {formatDateTime(channel.cooldownUntil, locale)}
                 </DetailField>
-                {/* Structured cooldown reason (P0-3): inline summary; the full
+                {/* Structured cooldown reason: inline summary; the full
                     root-cause dialog (countdown + clear) opens from the status
                     badge on the channels table. */}
                 <DetailField label={t('channels.reason.fieldLabel')} full>

--- a/web/src/features/channels/components/channels-columns.tsx
+++ b/web/src/features/channels/components/channels-columns.tsx
@@ -29,7 +29,7 @@ import type { ChannelRow, ChannelStatus } from '../types'
 
 export type ChannelsColumnActions = {
   onView: (channel: ChannelRow) => void
-  /** Opens the cooldown root-cause dialog (P0-3); badge click on failing rows. */
+  /** Opens the cooldown root-cause dialog; badge click on failing rows. */
   onShowReason?: (channel: ChannelRow) => void
 }
 

--- a/web/src/features/channels/components/cooldown-reason-dialog.tsx
+++ b/web/src/features/channels/components/cooldown-reason-dialog.tsx
@@ -1,4 +1,4 @@
-// metapi-go/features/channels/components — cooldown root-cause dialog (P0-3).
+// metapi-go/features/channels/components — cooldown root-cause dialog.
 //
 // Opens from the status badge of a cooling / breaker-open channel. Renders the
 // structured reason recorded when the cooldown triggered (trigger code,

--- a/web/src/features/channels/types.ts
+++ b/web/src/features/channels/types.ts
@@ -24,7 +24,7 @@ export type ChannelRow = {
   responseMs: number | null
   cooldownUntil: string | null
   /**
-   * Structured cooldown reason (P0-3). All three fields are null when the
+   * Structured cooldown reason. All three fields are null when the
    * channel cooled down before the reason columns existed — the UI reports
    * that honestly as "reason not recorded" instead of guessing.
    */

--- a/web/src/features/dashboard/components/__tests__/chart-data-table.test.tsx
+++ b/web/src/features/dashboard/components/__tests__/chart-data-table.test.tsx
@@ -1,5 +1,5 @@
 // Component-level axe gate + semantics for the sr-only chart data summary
-// table (S10 chart accessibility alternative layer, #1035). Pins the
+// table (the chart accessibility alternative layer, #1035). Pins the
 // screen-reader contract: captioned table, column/row headers, visually
 // hidden, zero axe violations.
 import '@testing-library/jest-dom/vitest'

--- a/web/src/features/dashboard/components/chart-data-table.tsx
+++ b/web/src/features/dashboard/components/chart-data-table.tsx
@@ -1,6 +1,6 @@
 // metapi-go/features/dashboard — sr-only data summary table for charts.
 //
-// S10 chart-a11y alternative layer (#1035): recharts renders SVG that screen
+// Chart-a11y alternative layer (#1035): recharts renders SVG that screen
 // readers cannot walk, so each main dashboard chart also exposes its
 // already-loaded series data as a visually hidden table in a simple
 // "series x key points" shape. Read-only presentation layer — it never

--- a/web/src/features/dashboard/components/chart-shell.tsx
+++ b/web/src/features/dashboard/components/chart-shell.tsx
@@ -31,7 +31,7 @@ type ChartShellProps = {
   children: ReactNode
   /**
    * Optional screen-reader-only data summary rendered next to the chart
-   * viewport (S10, #1035). Hidden until loading finishes, same as the chart.
+   * viewport (#1035). Hidden until loading finishes, same as the chart.
    */
   summary?: ReactNode
   className?: string

--- a/web/src/features/dashboard/sections/models/__tests__/models-section-chart-summary.test.tsx
+++ b/web/src/features/dashboard/sections/models/__tests__/models-section-chart-summary.test.tsx
@@ -1,4 +1,4 @@
-// S10 (#1035): the model-cost donut and both latency charts expose sr-only
+// #1035: the model-cost donut and both latency charts expose sr-only
 // data summary tables built from the already-loaded rows (series x key
 // points; histogram → bucket x count, trend → series x latest/window avg).
 import '@testing-library/jest-dom/vitest'
@@ -89,7 +89,7 @@ function renderSection() {
   )
 }
 
-describe('ModelsSection cost data summary (S10)', () => {
+describe('ModelsSection cost data summary', () => {
   it('exposes an sr-only summary table for the cost donut', async () => {
     renderSection()
 
@@ -124,7 +124,7 @@ describe('ModelsSection cost data summary (S10)', () => {
   })
 })
 
-describe('ModelsSection latency chart summaries (S10)', () => {
+describe('ModelsSection latency chart summaries', () => {
   it('exposes bucket × count rows for the latency histogram', async () => {
     mockHistogram.mockResolvedValue({
       buckets: [

--- a/web/src/features/dashboard/sections/models/models-section.tsx
+++ b/web/src/features/dashboard/sections/models/models-section.tsx
@@ -46,7 +46,7 @@ function ChartEmpty({ message }: { message: string }) {
 
 /** Gate the sr-only summary exactly like the chart body: no summary while
  * the owning query is loading or failed; the builder itself returns
- * undefined when the loaded data is empty (S10, #1035). */
+ * undefined when the loaded data is empty (#1035). */
 function summaryWhenLoaded(
   query: { isLoading: boolean; isError: boolean },
   summaryNode: ReactNode
@@ -89,7 +89,7 @@ export function ModelsSection() {
     [costData]
   )
 
-  // S10 (#1035): sr-only data summary table for the cost donut — recharts
+  // #1035: sr-only data summary table for the cost donut — recharts
   // SVG is opaque to screen readers, so the already-loaded per-model rows
   // are re-presented as a simple series x key-points table. Read-only
   // presentation layer; no extra requests.
@@ -154,7 +154,7 @@ export function ModelsSection() {
     return rows
   }, [trendQuery.data, metricAvg, metricP95])
 
-  // S10 (#1035): sr-only summaries for the two latency charts — same contract
+  // #1035: sr-only summaries for the two latency charts — same contract
   // as the cost donut above (bucket bars → bucket x count; dual-line trend →
   // series x latest/window-average).
   const histogramSummary = useMemo(() => {

--- a/web/src/features/dashboard/sections/traffic/__tests__/traffic-section-chart-summary.test.tsx
+++ b/web/src/features/dashboard/sections/traffic/__tests__/traffic-section-chart-summary.test.tsx
@@ -1,4 +1,4 @@
-// S10 (#1035): traffic charts expose sr-only data summary tables built from
+// #1035: traffic charts expose sr-only data summary tables built from
 // the already-loaded query data, so screen-reader users get the key series
 // values instead of opaque recharts SVG. Uses the real ChartShell so the
 // summary slot is exercised end-to-end (charts themselves stay stubbed).
@@ -110,7 +110,7 @@ function renderSection() {
   )
 }
 
-describe('TrafficSection chart data summaries (S10)', () => {
+describe('TrafficSection chart data summaries', () => {
   it('exposes one sr-only summary table per loaded chart', async () => {
     renderSection()
 

--- a/web/src/features/dashboard/sections/traffic/traffic-section.tsx
+++ b/web/src/features/dashboard/sections/traffic/traffic-section.tsx
@@ -89,7 +89,7 @@ function ChartEmpty({ message }: { message: string }) {
 
 /** Gate the sr-only summary exactly like the chart body: no summary while
  * the owning query is loading or failed; the builders themselves return
- * undefined when the loaded data is empty (S10, #1035). */
+ * undefined when the loaded data is empty (#1035). */
 function summaryWhenLoaded(
   query: { isLoading: boolean; isError: boolean },
   summaryNode: ReactNode
@@ -178,7 +178,7 @@ export function TrafficSection() {
   )
 
   // ---------------------------------------------------------------------
-  // S10 (#1035): sr-only data summary tables. recharts SVG is opaque to
+  // #1035: sr-only data summary tables. recharts SVG is opaque to
   // screen readers, so each chart's already-loaded data is re-presented as
   // a simple series x key-points table. Read-only presentation layer — no
   // extra requests, no data-semantics changes.

--- a/web/src/features/settings/__tests__/program-event-normalize.test.ts
+++ b/web/src/features/settings/__tests__/program-event-normalize.test.ts
@@ -76,7 +76,7 @@ describe('eventTitleSlug (shared lib/event-titles map)', () => {
     expect(eventTitleSlug('checkin failed (cloudflare challenge)')).toBe(
       'checkinFailedCloudflare'
     )
-    // Daily-frequency producers pinned by the F3 scout inventory.
+    // Daily-frequency producers, pinned against the events registry.
     expect(eventTitleSlug('checkin success')).toBe('checkinSuccess')
     expect(eventTitleSlug('Site enabled')).toBe('siteEnabled')
     expect(eventTitleSlug('Account token sync completed')).toBe(

--- a/web/src/features/settings/sections/operations/components/program-logs-section.tsx
+++ b/web/src/features/settings/sections/operations/components/program-logs-section.tsx
@@ -66,7 +66,7 @@ function levelVariant(level?: string): 'default' | 'secondary' | 'destructive' {
 }
 
 /**
- * Localized event title. Structured rows (F5) render straight from their
+ * Localized event title. Structured rows render straight from their
  * registry titleKey; legacy rows match the persisted English title against
  * the historical slug map, and unknown titles render as-is (honest residual).
  */
@@ -102,7 +102,7 @@ function EventMessage({ event }: { event: ProgramEvent }) {
   const panel =
     parts.panelPath !== null ? parsePanelPath(parts.panelPath) : null
   const hasEnrichment = routes.length > 0 || sites.length > 0 || panel !== null
-  // Structured rows (F5): the message renders from the `events.messages.*`
+  // Structured rows: the message renders from the `events.messages.*`
   // locale template with the event's typed params interpolated by i18next;
   // legacy rows keep the parsed-text path below.
   const structuredMessage =

--- a/web/src/features/settings/sections/operations/lib/__tests__/events-structured.test.ts
+++ b/web/src/features/settings/sections/operations/lib/__tests__/events-structured.test.ts
@@ -1,4 +1,4 @@
-// F5 structured events — registry/locale consistency.
+// Structured events — registry/locale consistency.
 //
 // The Go events registry (service/events) and the frontend locale both
 // enumerate event keys. The register() helper panics on duplicate keys;
@@ -12,7 +12,7 @@ import { describe, expect, it } from 'vitest'
 
 import i18n from '@/i18n/config'
 
-/** Mirror of service/events registry keys (checkin family, batch 1 of F5). */
+/** Mirror of service/events registry keys (checkin family, first batch). */
 const REGISTRY_KEYS = [
   'checkinSuccess',
   'checkinFailed',
@@ -20,7 +20,7 @@ const REGISTRY_KEYS = [
   'checkinSkipped',
 ]
 
-describe('F5 structured events — registry/locale consistency', () => {
+describe('structured events — registry/locale consistency', () => {
   it('declares every registry key under events.titles in both locales', () => {
     for (const key of REGISTRY_KEYS) {
       expect(i18n.exists(`events.titles.${key}`), `titles.${key}`).toBe(true)

--- a/web/src/features/settings/sections/operations/lib/event-normalize.ts
+++ b/web/src/features/settings/sections/operations/lib/event-normalize.ts
@@ -26,7 +26,7 @@ export type ProgramEvent = {
   read?: boolean
   createdAt?: string
   /**
-   * Structured-event fields (F5): rows emitted through the events registry
+   * Structured-event fields: rows emitted through the events registry
    * carry a stable titleKey plus typed params; legacy rows have neither and
    * render through the historical title-match path.
    */

--- a/web/src/features/site-announcements/__tests__/site-announcements-actions.test.tsx
+++ b/web/src/features/site-announcements/__tests__/site-announcements-actions.test.tsx
@@ -1,4 +1,4 @@
-// Behavior tests for the site-announcements actions (#986 Lane C):
+// Behavior tests for the site-announcements actions (#986):
 // mark-read / mark-all-read, the ConfirmDialog guard on the destructive
 // clear, and the sync-now background task observed through api.getTask.
 

--- a/web/src/features/site-announcements/__tests__/site-announcements-page.test.tsx
+++ b/web/src/features/site-announcements/__tests__/site-announcements-page.test.tsx
@@ -1,4 +1,4 @@
-// Behavior tests for the site-announcements list page (#986 Lane C):
+// Behavior tests for the site-announcements list page (#986):
 // row rendering with the site-name join, read/unread distinction, and the
 // truthful loading / empty / error states.
 

--- a/web/src/features/site-announcements/__tests__/site-announcements-untrusted-content.test.tsx
+++ b/web/src/features/site-announcements/__tests__/site-announcements-untrusted-content.test.tsx
@@ -1,4 +1,4 @@
-// Security tests for the site-announcements page (#986 Lane C): announcement
+// Security tests for the site-announcements page (#986): announcement
 // title / content / source are UNTRUSTED upstream data. The body must render
 // as plain text (no HTML injection, no markdown). External navigation may
 // only use a same-origin URL resolved from the trusted local Site URL.

--- a/web/src/i18n/__tests__/i18n-keys.test.ts
+++ b/web/src/i18n/__tests__/i18n-keys.test.ts
@@ -371,7 +371,7 @@ describe('i18n key coverage', () => {
     expect([...enKeys].filter((k) => !zhKeys.has(k))).toEqual([])
   })
 
-  // S10 bilingual CI: key-set parity alone cannot catch a translation that
+  // Bilingual CI: key-set parity alone cannot catch a translation that
   // drops an interpolation variable (e.g. zh rendering "余额不足：relay ()"
   // because {{amount}} was lost). Every leaf present in both locales must
   // declare the same placeholder set, so a dropped variable fails CI.

--- a/web/src/lib/__tests__/attention-label.test.ts
+++ b/web/src/lib/__tests__/attention-label.test.ts
@@ -1,4 +1,4 @@
-// metapi-go/lib — attention-label tests (F3).
+// metapi-go/lib — attention-label tests.
 //
 // The backend keeps an English `label` for API compat and ships structured
 // `params` so the SPA can re-localize. These tests pin the re-localization

--- a/web/src/lib/api/settings.ts
+++ b/web/src/lib/api/settings.ts
@@ -154,7 +154,7 @@ export const settingsApi = {
       body: JSON.stringify({ data }),
       skipErrorHandler: true,
     }),
-  // F1: import plan preview before commit.
+  // Import plan preview before commit.
   previewBackupImport: (data: unknown) =>
     request('/api/settings/backup/import/preview', {
       method: 'POST',

--- a/web/src/lib/attention-label.ts
+++ b/web/src/lib/attention-label.ts
@@ -1,4 +1,4 @@
-// metapi-go/lib — shared attention-item label localization (F3).
+// metapi-go/lib — shared attention-item label localization.
 //
 // The backend attention API (`GET /api/stats/attention`) keeps an English
 // `label` for API compat and ships structured `params` alongside (username /

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 
 // METAPI_WEB_VERSION define and '@' alias come from the shared build module
 // (single source of truth with rsbuild.config.ts) so tests resolve exactly
-// the same compile-time constants as dev/build (issue #1035 S1).
+// the same compile-time constants as dev/build (issue #1035).
 import { srcAlias, versionDefines } from './config/build-shared.ts'
 
 export default defineConfig({


### PR DESCRIPTION
## 用户任务与改动摘要

非修复项：公开面口吻收口。#1328 只扫了 `web/src` + `docs`，遗漏了 `*.go`、`web/scripts/*.mjs`、`web/*.config.ts`、`scripts/*.sh`、`.gitignore`。本 PR 把内部工作计划代号从**整个已发布树**清干净，并加一道机械门禁防止它回来。

清掉的类别（156 处命中 / 121 文件，全部为注释与散文，另有一处标识符改名）：

- 计划批次标签：`Wave 4/8/11/12/15/17/18/21`、`Wave 8 Lane D`、`Lane B/C`、`Milestone C1`、`S-line`
- 私有 backlog 优先级：`P0-1/P0-2/P0-3/P0-585`、`P1-2/P1-3`
- 私有设计文档条目号：`K1b`（model redirect registry，16 处）
- 私有审计条目号：`F1/F3/F5`、`M1`、`T1`、`N1/N2/N3/N7`、`S1/S2/S4/S5/S9/S10`、`w18-pg-dialect`、`scout §settings_apply`
- 指向**不在本仓**的计划文档：`plan.md §5.5.5`、`13-report §4`、`limitation.md`、`limitation-update-center.md`、`p3-sites-accounts(.md)`、`doc/integration-prompt.md`、`k1-model-redirect-design-2026-08-01.md §7`、`test.yml:134-148`

每处改成陈述行为本身；有公开 issue 号的一律保留（`#986`/`#998`/`#1005`/`#1035`）。

`P0-585` 是唯一烧进**标识符**的代号，一并改名：`e2e/e2e_p0585_production_test.go` → `e2e_cascade_production_test.go`、`TestP0585_ProductionCascade_Staging` → `TestProductionCascade_Staging`、marker header `cascade-p0585-staging` → `cascade-staging-verify`、`scripts/verify-cascade-prod.sh` 日志前缀 `[p0585]` → `[cascade]` 与 report `feature` 字段、fixture id `chatcmpl-p0585` → `chatcmpl-cascade`、`docs/testing.md` 的句子。

## 复现、根因与同类影响

根因：这些注释记录的是「哪一轮计划要求这么做」，而计划文档从未进公开仓、且已归档。读者解析不了标签 ⇒ 本该给理由的位置只剩噪音；计划一归档，标签就永久失效。

把注释逐条对着代码读，发现**两处陈述本身就是错的**，本 PR 一并修正：

1. `docs/package_boundary_test.go` 头部引用 `docs/architecture.md` 的 `§5.1/§5.2/§5.3/§5.4/§5.11/§3.2` —— architecture.md 是**无编号**的 boundary map，这些小节**不存在**。例外边现在把理由写在同一行。
2. 同一处头部与 `BACKEND.md §2.2` 都说 scheduler 通过「`app` facade（`app.RecordDBConnError` 委派给 `handler/shared`）」记 DB 连接错误。**该 facade 不存在**：`scheduler/lease.go` 直接调 `app/observability.RecordDBConnError()`，那是 stdlib-only 叶子包，`handler/shared` 反过来 import 它。两处散文 + rule 6 的失败消息都改成事实。

相邻路径已检查并**保留**（都是仓内可解析的编号，不是计划代号）：`config/config.go` 的 `§1.x/§3.x` 自身分节、`scheduler/scheduler_test.go` 的 `§1..§20`、`handler/proxy/responses_ws*.go` 与 `auth/{downstream,proxy}.go` 的 `C1/C2/C3` WS scope（在 `responses_ws.go` 头部就地定义）、`store/*` 的 `sc2_027` 迁移 id、`AGENTS.md` → `git-workflow.md §6.1`、`store/settings.go` → `config.Load §3.14`。

## 验证证据

- 最终源码：PR head `4471d4e5`；`git status` clean，无未提交差异。
- 门禁（本机 Linux 2C/4G，go1.26.6，`GOMAXPROCS=2`）：
  - `go build ./cmd/server` OK · `go vet ./...` OK · `go vet -tags=staging ./e2e/` OK（覆盖改名后的 staging 测试）
  - `GOMAXPROCS=2 go test ./... -count=1 -race -p 1 -timeout=30m` ⇒ **44 ok / 0 FAIL / rc=0**
  - `go test ./docs -count=1` OK（含新门禁）
  - 前端 pin 工具链（vitest **5.0.0** == `bun.lock`；`package.json`/`bun.lock` 本 PR 未改）：`bun run lint` rc=0（boundaries 689/0、FormControl 140/0）· `bun run format:check` rc=0（732 files）· `bun run test --maxWorkers=1` rc=0 ⇒ **264 files / 1722 tests passed**
  - `gofmt -l` 与 master 的差集为空（go1.26.6 对本仓 118 个既有文件另有意见，属既存状态，本 PR 未新增）
  - `bash -n scripts/verify-cascade-prod.sh` OK
- 确定性 fixture / 门禁自证：新门禁做了**变异验红** —— 在 `routing/redirects.go` 追加一行含 `Wave 99` 的注释 ⇒ `TestNoInternalProgrammeCodesInShippedSources` FAIL 并指名 file:line；还原后 OK。`TestProgrammeCodeGateRegexpSanity` 双向钉住：14 个正样本必须命中、8 个近似负样本（`common M2 coding models`、`"T00:00:00Z"`、`…T15:04:05.500Z`、`P2P`、`docs/architecture.md`、`config.Load §3.14`、小写 `wave`）必须不命中。
- 真实模型中继：**不适用** —— 无代理行为、协议或路由改动。
- 下游客户端 / 用户任务 E2E：**不适用** —— 无 wire / schema / 契约改动。
- 未验证项与剩余风险：本机 `tsgo -b`（`bun run typecheck`）结构性被 host OOM SIGKILL（往轮已多次取证），交 CI `frontend` 终审；本 PR 前端改动为纯注释 + 2 个 `describe()` 显示串，无类型面。`sc2_028` 迁移的 `Description` 去掉了 `(F5)`：applied 判定只看 `Version`，`Description` 仅用于日志与首次落库，已装库保留旧文本，无行为影响。

## 自查

- [x] 无凭据、私有主机、内部路径或用户敏感数据泄漏（`leak_guard.py --range master..HEAD` RC=0；本 PR 删掉的正是指向私有文档的指针）
- [x] 行为变化已更新必要测试与现役文档（无行为变化；`Makefile` 的 `docs-hygiene`、`.github/workflows/main.yml` 的 `docs-hygiene` 步骤、`CONTRIBUTING.md` 两处说明已同步）
- [x] 用户可见文案已走 i18n（不适用：无 UI 文案改动）
