### PR TITLE
refactor(web): drop ten props no caller ever passed

### DIFF
--- a/web/src/components/common/query-error-banner.tsx
+++ b/web/src/components/common/query-error-banner.tsx
@@ -17,8 +17,6 @@ type QueryErrorBannerProps = {
   error: Error | null
   /** i18n key whose template interpolates `{{message}}` (e.g. `accounts.page.loadError`). */
   messageKey: string
-  /** i18n key for the Retry button label; defaults to `common.retry`. */
-  retryKey?: string
   /** When provided, a Retry button renders and re-fetches the query. */
   onRetry?: () => void
   /** True while the retry request is in flight (disables the button + shows a spinner). */
@@ -31,7 +29,6 @@ type QueryErrorBannerProps = {
 export function QueryErrorBanner({
   error,
   messageKey,
-  retryKey = 'common.retry',
   onRetry,
   isRetrying = false,
   children,
@@ -56,7 +53,7 @@ export function QueryErrorBanner({
               disabled={isRetrying}
             >
               {isRetrying ? <Spinner /> : <RefreshCw className='size-3.5' />}
-              {t(retryKey)}
+              {t('common.retry')}
             </Button>
           )}
           {children}

--- a/web/src/components/data-table/core/badge-list-cell.tsx
+++ b/web/src/components/data-table/core/badge-list-cell.tsx
@@ -28,7 +28,6 @@ type BadgeListCellProps = {
   items: React.ReactNode[]
   /** How many to show inline before the "+N" chip. */
   max?: number
-  tooltipClassName?: string
 }
 
 /** Negative margin cancels the badge's own `px-1.5` so text lines up with the header. */
@@ -36,11 +35,7 @@ const CELL_CLASS = '-ml-1.5 max-w-full'
 const TOOLTIP_CLASS =
   'border-border bg-popover max-h-48 max-w-[320px] overflow-y-auto p-2'
 
-export function BadgeListCell({
-  items,
-  max = 2,
-  tooltipClassName,
-}: BadgeListCellProps) {
+export function BadgeListCell({ items, max = 2 }: BadgeListCellProps) {
   if (items.length === 0) {
     return <span className='text-muted-foreground text-xs'>—</span>
   }
@@ -60,10 +55,7 @@ export function BadgeListCell({
           </div>
         </TooltipTrigger>
         {overflow > 0 && (
-          <TooltipContent
-            side='top'
-            className={tooltipClassName ?? TOOLTIP_CLASS}
-          >
+          <TooltipContent side='top' className={TOOLTIP_CLASS}>
             <div className='flex flex-wrap gap-1'>{items}</div>
           </TooltipContent>
         )}

--- a/web/src/components/layout/components/app-header.tsx
+++ b/web/src/components/layout/components/app-header.tsx
@@ -17,12 +17,6 @@ import { metapiIdentity } from '@/lib/identity-branding'
 import { cn } from '@/lib/utils'
 
 type AppHeaderProps = {
-  /** Whether to show the light/dark theme toggle button. */
-  showThemeToggle?: boolean
-  /** Custom left content, overrides the brand if provided. */
-  leftContent?: React.ReactNode
-  /** Custom right content, overrides the default interface controls if provided. */
-  rightContent?: React.ReactNode
   /** Called when the global-search trigger is clicked. */
   onSearchClick?: () => void
 }
@@ -48,12 +42,7 @@ function SearchTrigger({ onClick }: { onClick?: () => void }) {
   )
 }
 
-export function AppHeader({
-  showThemeToggle = true,
-  leftContent,
-  rightContent,
-  onSearchClick,
-}: AppHeaderProps) {
+export function AppHeader({ onSearchClick }: AppHeaderProps) {
   return (
     <header
       className={cn(
@@ -63,36 +52,32 @@ export function AppHeader({
       )}
     >
       <SidebarTrigger className='md:hidden' />
-      {leftContent ?? (
-        // The brand is the only flexible header cell: on narrow viewports it
-        // truncates so the right-hand controls (search, attention bell,
-        // interface controls, user menu) keep their full hit targets.
-        // It is a home link: `/` redirects to the default dashboard section
-        // (same target as the sidebar "Dashboard" entry).
-        <Link
-          to='/'
-          className='flex min-w-0 items-center gap-2'
-          aria-label={metapiIdentity.name}
-        >
-          <img
-            src={metapiIdentity.logoPath}
-            alt=''
-            className='size-6 shrink-0 rounded-sm'
-          />
-          <span className='truncate text-sm font-semibold tracking-tight'>
-            {metapiIdentity.name}
-          </span>
-        </Link>
-      )}
+      {/* The brand is the only flexible header cell: on narrow viewports it
+          truncates so the right-hand controls (search, attention bell,
+          interface controls, user menu) keep their full hit targets. It is a
+          home link: `/` redirects to the default dashboard section (same
+          target as the sidebar "Dashboard" entry). */}
+      <Link
+        to='/'
+        className='flex min-w-0 items-center gap-2'
+        aria-label={metapiIdentity.name}
+      >
+        <img
+          src={metapiIdentity.logoPath}
+          alt=''
+          className='size-6 shrink-0 rounded-sm'
+        />
+        <span className='truncate text-sm font-semibold tracking-tight'>
+          {metapiIdentity.name}
+        </span>
+      </Link>
 
-      {rightContent ?? (
-        <div className='ms-auto flex shrink-0 items-center gap-1'>
-          <SearchTrigger onClick={onSearchClick} />
-          <AttentionBell />
-          <InterfaceControls showThemeToggle={showThemeToggle} />
-          <UserMenu />
-        </div>
-      )}
+      <div className='ms-auto flex shrink-0 items-center gap-1'>
+        <SearchTrigger onClick={onSearchClick} />
+        <AttentionBell />
+        <InterfaceControls />
+        <UserMenu />
+      </div>
     </header>
   )
 }

--- a/web/src/components/layout/components/interface-controls.tsx
+++ b/web/src/components/layout/components/interface-controls.tsx
@@ -17,8 +17,6 @@ import { cn } from '@/lib/utils'
 
 type InterfaceControlsProps = {
   className?: string
-  showCustomizer?: boolean
-  showThemeToggle?: boolean
 }
 
 function LanguageSwitcher() {
@@ -63,11 +61,7 @@ function LanguageSwitcher() {
   )
 }
 
-export function InterfaceControls({
-  className,
-  showCustomizer = true,
-  showThemeToggle = true,
-}: InterfaceControlsProps) {
+export function InterfaceControls({ className }: InterfaceControlsProps) {
   const { t } = useTranslation()
   const { resolvedTheme, setTheme } = useTheme()
 
@@ -78,18 +72,16 @@ export function InterfaceControls({
   return (
     <div className={cn('flex items-center gap-1', className)}>
       <LanguageSwitcher />
-      {showCustomizer && <ThemeCustomizer />}
-      {showThemeToggle && (
-        <Button
-          variant='ghost'
-          size='icon'
-          onClick={toggleTheme}
-          aria-label={t('theme.toggle')}
-        >
-          <Sun className='size-4 scale-100 rotate-0 transition-transform dark:scale-0 dark:-rotate-90' />
-          <Moon className='absolute size-4 scale-0 rotate-90 transition-transform dark:scale-100 dark:rotate-0' />
-        </Button>
-      )}
+      <ThemeCustomizer />
+      <Button
+        variant='ghost'
+        size='icon'
+        onClick={toggleTheme}
+        aria-label={t('theme.toggle')}
+      >
+        <Sun className='size-4 scale-100 rotate-0 transition-transform dark:scale-0 dark:-rotate-90' />
+        <Moon className='absolute size-4 scale-0 rotate-90 transition-transform dark:scale-100 dark:rotate-0' />
+      </Button>
     </div>
   )
 }

--- a/web/src/components/ui/count-up.tsx
+++ b/web/src/components/ui/count-up.tsx
@@ -19,10 +19,6 @@ type CountUpProps = {
   value: number
   /** Formats the animated numeric value. Defaults to locale string. */
   format?: (value: number) => string
-  /** First-mount animation duration in ms. */
-  initialDuration?: number
-  /** Subsequent value-change animation duration in ms. */
-  updateDuration?: number
   className?: string
 }
 
@@ -41,8 +37,6 @@ const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3)
 export function CountUp({
   value,
   format = (n) => n.toLocaleString(),
-  initialDuration = DEFAULT_INITIAL_DURATION,
-  updateDuration = DEFAULT_UPDATE_DURATION,
   className,
 }: CountUpProps) {
   const [display, setDisplay] = useState(() =>
@@ -63,7 +57,9 @@ export function CountUp({
       return undefined
     }
 
-    const duration = mountedRef.current ? updateDuration : initialDuration
+    const duration = mountedRef.current
+      ? DEFAULT_UPDATE_DURATION
+      : DEFAULT_INITIAL_DURATION
     mountedRef.current = true
     const start = performance.now()
 
@@ -85,7 +81,7 @@ export function CountUp({
       }
       previousValueRef.current = to
     }
-  }, [value, initialDuration, updateDuration])
+  }, [value])
 
   return (
     <span className={cn('tabular-nums', className)}>

--- a/web/src/features/dashboard/components/stat-card-sparkline.tsx
+++ b/web/src/features/dashboard/components/stat-card-sparkline.tsx
@@ -20,13 +20,11 @@ type SparklinePoint = {
 type StatCardSparklineProps = {
   data: SparklinePoint[]
   config: ChartConfig
-  accentClassName?: string
 }
 
 export default function StatCardSparkline({
   data,
   config,
-  accentClassName,
 }: StatCardSparklineProps) {
   return (
     <ChartContainer
@@ -42,7 +40,6 @@ export default function StatCardSparkline({
           fill='var(--color-value)'
           fillOpacity={0.16}
           isAnimationActive={false}
-          className={accentClassName}
         />
       </AreaChart>
     </ChartContainer>

--- a/web/src/features/dashboard/components/stat-card.tsx
+++ b/web/src/features/dashboard/components/stat-card.tsx
@@ -45,8 +45,6 @@ type StatCardProps = {
   hint?: string
   /** Sparkline samples (numeric). When omitted, no sparkline renders. */
   spark?: number[]
-  /** Tailwind class for the sparkline stroke (e.g. 'text-chart-1'). */
-  accentClassName?: string
   /** Render skeleton placeholders while the metric is still loading. */
   loading?: boolean
   /** Numeric value to animate (CountUp). When set, overrides the static value string. */
@@ -171,11 +169,7 @@ export function StatCard(props: StatCardProps) {
               ) : null}
               {data.length > 1 ? (
                 <Suspense fallback={null}>
-                  <LazyStatCardSparkline
-                    data={data}
-                    config={sparkConfig}
-                    accentClassName={props.accentClassName}
-                  />
+                  <LazyStatCardSparkline data={data} config={sparkConfig} />
                 </Suspense>
               ) : null}
             </div>

--- a/web/src/features/settings/components/settings-form-actions.tsx
+++ b/web/src/features/settings/components/settings-form-actions.tsx
@@ -14,7 +14,6 @@ type SettingsFormActionsProps = {
   isPending?: boolean
   onReset: () => void
   saveLabel?: string
-  savingLabel?: string
 }
 
 export function SettingsFormActions({
@@ -23,11 +22,9 @@ export function SettingsFormActions({
   isPending,
   onReset,
   saveLabel,
-  savingLabel,
 }: SettingsFormActionsProps) {
   const { t } = useTranslation()
   const label = saveLabel ?? t('settings.common.save')
-  const pendingLabel = savingLabel ?? t('settings.common.saving')
   return (
     // Full-width row with two fixed slots (status left, actions right) so the
     // "saved / unsaved" text swap never shifts the Reset/Save buttons
@@ -52,7 +49,7 @@ export function SettingsFormActions({
           size='sm'
           disabled={!isDirty || isPending}
         >
-          {isPending ? pendingLabel : label}
+          {isPending ? t('settings.common.saving') : label}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## 用户任务与改动摘要

非修复项：继续做减法（高内聚 / 不为假想调用者留兜底）。删掉 **10 个「零调用点」prop** —— 每一个都是「带默认值的可选项、组件内部读它、但没有任何调用方传过值」，即为不存在的调用者准备的配置面。删掉它们同时删掉了各自守着的**死分支**：

| 组件 | 删掉的 prop | 随之消失的死分支 |
|---|---|---|
| `AppHeader` | `leftContent` / `rightContent` / `showThemeToggle` | 两个 `?? (默认)` 插槽，实际只渲染过默认那半边 |
| `InterfaceControls` | `showCustomizer` / `showThemeToggle` | 两个默认 `true` 的条件渲染，永远走同一分支 |
| `CountUp` | `initialDuration` / `updateDuration` | 遮蔽两个具名常量；effect 依赖数组里的两项永不变化的值 |
| `BadgeListCell` | `tooltipClassName` | `?? TOOLTIP_CLASS` 永远命中默认 |
| `QueryErrorBanner` | `retryKey` | `= 'common.retry'` 默认值即唯一取值 |
| `SettingsFormActions` | `savingLabel` | 同上（`saveLabel` **保留**：3 个 section 在传） |
| `StatCard` + `StatCardSparkline` | `accentClassName` | 纯 pass-through：StatCard 把自己从没收到过的 prop 转给 sparkline |

净效果：8 文件 / +46−96。**渲染输出不变** —— 每个被删的 prop 本来就停在默认值上。

## 复现、根因与同类影响

根因：这类 prop 是「以后可能要配」的预留。它们不会被任何调用点或测试触达，所以既没有回归覆盖，也不会被 knip（只查未使用的**导出**）或 oxlint（`ignoreRestSiblings`）发现，只会在读代码时制造「这里是不是有两种形态」的假分支。

取证方法（沿用 #1325/#1326/#1327 的做法，**不用裸 grep 计数**）：

1. 从全部 `*Props` 类型/接口声明里抽出成员名（152 个，分布在 64 文件）。
2. 对每个名字在**整个 `web/src`**（含 `__tests__`）里数裸标识符出现；只出现在声明文件内部的 ⇒ 候选（14 个）。
3. 逐个读上下文排除假阳性 4 个：`onCommit` / `revertTick`（`route-channel-editor.tsx` 内部子组件，同文件 159/160/166/167 行确实在传）、`openMobile` / `toggleSidebar`（`sidebar.tsx` 的 context 成员，同文件经 `useSidebar()` 解构消费）。
4. 剩下 10 个逐个核对声明处 + 每个调用点，确认无 spread 传参掩盖（`AppHeader` 两个调用点都只传 `onSearchClick`，`InterfaceControls` 另一个调用点 `sign-in-page.tsx` 只传 `className`）。

同类影响已检查：删完后**全仓** `git grep` 这 10 个名字 = 0 命中（含测试、脚本、文档）；`pendingLabel` 中间变量一并删除。`saveLabel`（有人用）与 `className`（普遍使用）刻意保留。

## 验证证据

- 最终源码：PR head `3627058c`；`git status` clean，无未提交差异。改动面仅 `web/src/**` 8 个文件，**无 Go / 无契约 / 无 i18n 键 / 无 schema 变化**。
- 门禁（本机 Linux 2C/4G，vitest **5.0.0** == `bun.lock`，`package.json`/`bun.lock` 未改）：
  - `bunx vitest run --maxWorkers=1`（受影响范围：`components/layout` `components/ui/__tests__` `components/common` `features/dashboard` `i18n` `features/settings/components`）⇒ **49 files / 264 tests passed**
  - `bun run test --maxWorkers=1`（全量）⇒ **264 files / 1722 tests passed，rc=0**；`routes:verify` OK（28/28）
  - `bun run lint` rc=0 ⇒ oxlint 无新增告警（既有 8 条 warning 与本 PR 无关）· `check:boundaries` **689 files / 0 cross-layer edge** · `check:form-control` **140 sites / 0 exception**
  - `bun run format:check` rc=0（732 files；编辑后跑过 `bun run format` 再复核）
  - `bun run knip` rc=0（无未使用导出/依赖）
- Go 门禁：**不适用**（本 PR 未改任何 `.go` / `go.mod` / workflow），交 CI 复跑。
- 真实模型中继：**不适用**（无代理路径改动）。
- 下游客户端 / 用户任务 E2E：**不适用**（无 wire 契约改动）。
- 未验证项与剩余风险：本机 `tsgo -b`（`bun run typecheck`）结构性被 host OOM SIGKILL（往轮多次取证）⇒ 类型面交 CI `frontend` 终审。**视觉面是本 PR 唯一真实风险点**：删掉的是「永远走默认分支」的条件渲染，理论上 DOM 与计算样式逐字不变，但 `AppHeader` 的 `?? (...)` 展开与 JSX 注释位置调整属于结构改动 ⇒ 依赖 CI 的 `visual-regression`（golden 10/10）+ `ui-screenshots` + `a11y` 三项做机械确认，不靠肉眼断言。

## 自查

- [x] 无凭据、私有主机、内部路径或用户敏感数据泄漏（`leak_guard.py --range master..HEAD` RC=0）
- [x] 行为变化已更新必要测试与现役文档（**无行为变化**：渲染输出不变，故无测试需要改；这 10 个 prop 从未出现在任何测试或文档里，已机械核过）
- [x] 用户可见文案已走 i18n（不适用：`retryKey`/`savingLabel` 删除后改为直接写既有 i18n 键 `common.retry` / `settings.common.saving`，键与译文均未变）
