### PR TITLE
test(web): gate the data-table barrel rule

### DIFF
--- a/docs/internal/web-package-boundaries.md
+++ b/docs/internal/web-package-boundaries.md
@@ -1,7 +1,7 @@
 # Web package boundaries — frontend layering rules
 
 **Status**: machine-enforced since 2026-08-29 by `web/scripts/check-boundaries.mjs`
-**Date**: 2026-08-23 (updated 2026-08-29)
+**Date**: 2026-08-23 (updated 2026-09-12)
 **Gate**: `bun run lint` chains `oxlint && bun run check:boundaries`; pre-push
 and the CI `frontend` job both run `bun run lint`, so violations are caught
 locally and in CI.
@@ -38,15 +38,29 @@ defects unless registered as an exception below.
    feature. `sanitizeAuthRedirect` was moved from `features/auth/lib/` to
    `src/lib/helpers/` (2026-08-23); a later change extended the same rule to
    `ABOUT_INFO`, token-route summary types, and the model-pattern predicates.
+6. **A subsystem that publishes a barrel is imported through the barrel.**
+   Outside `src/components/data-table/`, only `@/components/data-table` may be
+   imported — never `core/`, `layout/`, `toolbar/` or `hooks/`. This is what
+   makes the subsystem's internals refactorable: `index.ts` states the deal
+   ("anything exported here is frozen against feature call sites; anything not
+   exported here is free to be reorganised"), and the promise is only worth
+   making while nothing outside reaches in. When a consumer needs a symbol the
+   barrel does not export, the fix is to export it, not to deep-import it. The
+   boundary gate enforces this for every layer, and asserts it is not passing
+   vacuously (the barrel must exist and have at least one external consumer).
 
 ## Gate mechanics
 
 `web/scripts/check-boundaries.mjs` statically scans all `.ts`/`.tsx` under
 `web/src/`, resolves `@/` and relative specifiers to their layer, and fails
-with file:line when a component or lib file imports `features/` or `routes/`.
-Exceptions are an explicit in-script registry with a required reason; a stale
-exception (no matching import) also fails, so whitelists cannot accumulate
-silently. Run directly with `bun run check:boundaries`.
+with file:line when a component or lib file imports `features/` or `routes/`,
+or when any file deep-imports a barrel subsystem (rule 6). Exceptions are an
+explicit in-script registry with a required reason; a stale exception (no
+matching import) also fails, so whitelists cannot accumulate silently. Both
+rule families also fail when they would pass vacuously — a barrel that no
+longer exists, or one nothing imports, means the check stopped covering
+anything rather than that the tree got clean. Run directly with
+`bun run check:boundaries`.
 
 ## Registered exceptions
 
@@ -82,3 +96,8 @@ stale entry is rejected by the gate.
     that the new gate exposed.
   - Added `web/scripts/check-boundaries.mjs` and chained it into `bun run
     lint` (pre-push + CI frontend gate).
+- **2026-09-12** — `features/proxy-logs` had deep-imported `DataTableRow` from
+  `components/data-table/core/data-table-row`; the two symbols it needed were
+  exported from the barrel instead. Rule 6 was then added to
+  `web/scripts/check-boundaries.mjs` so the next one is caught by a gate rather
+  than by review (#1332).

--- a/web/scripts/check-boundaries.mjs
+++ b/web/scripts/check-boundaries.mjs
@@ -6,6 +6,8 @@
 //
 //   rule 1: src/lib/ never imports from features/ or routes/.
 //   rule 2: src/components/ never imports from features/ or routes/.
+//   rule 3: a subsystem that publishes a barrel is imported through that
+//           barrel and never through a subdirectory (see BARRELS).
 //
 // Layers are classified by the first path segment under src/. Imports may
 // point downward through the layer table; the edges above are the two hard
@@ -23,7 +25,7 @@
 // cross-layer edges. Every entry must carry a reason AND match a real import
 // in the tree; stale entries fail the gate (no speculative whitelisting).
 
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -40,6 +42,21 @@ const FORBIDDEN = {
   components: new Set(['features', 'routes']),
   lib: new Set(['features', 'routes']),
 }
+
+// --- barrel rules --------------------------------------------------------------
+// A subsystem that publishes a barrel owns its internals: everything outside
+// the package imports the barrel and nothing deeper. That is the only thing
+// which makes the inside refactorable — data-table/index.ts states the deal
+// explicitly ("anything not exported here is free to be reorganised"), and it
+// holds only while no outside file reaches into core/, layout/, toolbar/ or
+// hooks/. It has been broken once already: features/proxy-logs deep-imported
+// DataTableRow from core/data-table-row.
+const BARRELS = [
+  {
+    package: 'components/data-table',
+    reason: 'index.ts is the whole public surface (data-table/README.md)',
+  },
+]
 
 // --- scanning ----------------------------------------------------------------------
 // Static + dynamic import specifiers. oxfmt keeps every import/export `from`
@@ -84,8 +101,14 @@ function resolveSpecifier(specifier, fileDirRel) {
 
 const files = walk(SRC, [])
 const violations = []
+const barrelViolations = []
 const matchedExceptions = new Set()
+// External files that import each barrel the sanctioned way. A barrel with no
+// consumer would make its rule untestable, so this is asserted below rather
+// than trusted.
+const barrelConsumers = new Map(BARRELS.map((b) => [b.package, new Set()]))
 let checkedEdges = 0
+let barrelEdges = 0
 
 function checkEdge(fileAbsRel, lineNumber, specifier, fileDirRel) {
   const sourceLayer = fileAbsRel.split('/')[0]
@@ -112,6 +135,36 @@ function checkEdge(fileAbsRel, lineNumber, specifier, fileDirRel) {
   })
 }
 
+/**
+ * Rule 3: outside a barrel's own package, only the barrel itself may be
+ * imported. Applies to every layer, unlike FORBIDDEN, which is keyed on the
+ * importing file's layer.
+ */
+function checkBarrelEdge(fileAbsRel, lineNumber, specifier, fileDirRel) {
+  const resolved = resolveSpecifier(specifier, fileDirRel)
+  if (resolved === null) return
+  for (const barrel of BARRELS) {
+    const inside = `${barrel.package}/`
+    const isBarrelItself =
+      resolved === barrel.package || resolved === `${barrel.package}/index`
+    // Inside the package the barrel re-exports its own subdirectories and
+    // siblings import each other directly: both are the point of a barrel.
+    if (fileAbsRel.startsWith(inside)) continue
+    if (isBarrelItself) {
+      barrelConsumers.get(barrel.package).add(fileAbsRel)
+      return
+    }
+    if (!resolved.startsWith(inside)) continue
+    barrelEdges += 1
+    barrelViolations.push({
+      location: `src/${fileAbsRel}:${lineNumber}`,
+      specifier,
+      resolved,
+      barrel,
+    })
+  }
+}
+
 for (const file of files) {
   const fileAbsRel = file.slice(SRC.length + 1).replace(/\\/g, '/')
   const fileDirRel = fileAbsRel.includes('/')
@@ -124,13 +177,18 @@ for (const file of files) {
     let match
     while ((match = FROM_RES.exec(line)) !== null) {
       checkEdge(fileAbsRel, lineNumber, match[1], fileDirRel)
+      checkBarrelEdge(fileAbsRel, lineNumber, match[1], fileDirRel)
     }
     DYNAMIC_RES.lastIndex = 0
     while ((match = DYNAMIC_RES.exec(line)) !== null) {
       checkEdge(fileAbsRel, lineNumber, match[1], fileDirRel)
+      checkBarrelEdge(fileAbsRel, lineNumber, match[1], fileDirRel)
     }
     match = SIDE_EFFECT_RES.exec(line)
-    if (match !== null) checkEdge(fileAbsRel, lineNumber, match[1], fileDirRel)
+    if (match !== null) {
+      checkEdge(fileAbsRel, lineNumber, match[1], fileDirRel)
+      checkBarrelEdge(fileAbsRel, lineNumber, match[1], fileDirRel)
+    }
   })
 }
 
@@ -145,6 +203,41 @@ for (const violation of violations) {
       `    rule: ${DOC}; if the edge is legitimate, register it in\n` +
       `    web/scripts/check-boundaries.mjs EXCEPTIONS with a reason.`
   )
+}
+
+for (const violation of barrelViolations) {
+  failed = true
+  console.error(
+    `✗ barrel violation: ${violation.location}\n` +
+      `    imports '${violation.specifier}' → src/${violation.resolved}\n` +
+      `    rule: import '@/components/data-table' instead — ${violation.barrel.reason}.\n` +
+      `    If the symbol is missing from the barrel, export it there; do not\n` +
+      `    reach into the subsystem, or its internals stop being refactorable.`
+  )
+}
+
+// Same invariant as the layer rules: a gate that scans nothing and reports no
+// violations is not a lenient gate, it is an absent one. Both ways this one can
+// go quiet are checked — the package disappearing (rename) and the rule losing
+// its only consumer (nothing left to protect).
+for (const barrel of BARRELS) {
+  const barrelFile = join(SRC, `${barrel.package}/index.ts`)
+  if (!existsSync(barrelFile)) {
+    failed = true
+    console.error(
+      `✗ barrel gate would pass vacuously: src/${barrel.package}/index.ts is\n` +
+        `    missing. Was the package renamed? Update BARRELS in this script.`
+    )
+  }
+  if (barrelConsumers.get(barrel.package).size === 0) {
+    failed = true
+    console.error(
+      `✗ barrel gate would pass vacuously: no file outside\n` +
+        `    src/${barrel.package}/ imports '@/components/data-table', so the rule\n` +
+        `    protects nothing. Either the barrel lost its consumers or the\n` +
+        `    specifier resolution in this script stopped matching it.`
+    )
+  }
 }
 
 EXCEPTIONS.forEach((entry, index) => {
@@ -163,5 +256,8 @@ if (failed) process.exit(1)
 console.log(
   `✓ package boundaries clean: ${files.length} files scanned, ` +
     `${checkedEdges} cross-layer edge(s) checked, ` +
+    `${BARRELS.length} barrel rule(s) held by ` +
+    `${[...barrelConsumers.values()].reduce((n, s) => n + s.size, 0)} consumer(s), ` +
+    `${barrelEdges} deep import(s), ` +
     `${EXCEPTIONS.length} registered exception(s) all matched`
 )


### PR DESCRIPTION
## 用户任务与改动摘要

关闭 #1332。`web/scripts/check-boundaries.mjs` 原本只锁两条**向上**边（`lib ↛ features/routes`、`components ↛ features/routes`）。第三条规则**已经写在两处散文里、却没有任何机器强制**：

- `web/src/components/data-table/README.md`：「`index.ts` is the whole public surface — feature code imports from `@/components/data-table` and never reaches into a subdirectory.」
- `web/src/components/data-table/index.ts`：「anything exported here is frozen against feature call sites; anything not exported here is free to be reorganised.」

第二句是 barrel 存在的全部意义 —— 它是「子系统内部可以随便重构」的前提，而这个前提**已经被破坏过一次**（`features/proxy-logs` 从 `core/data-table-row` 深取 `DataTableRow`）。本 PR 把它变成 rule 3：任何**在 `components/data-table/` 之外**的文件，import 解析到该包内部子目录即 FAIL，且对**所有层**生效（`FORBIDDEN` 表按「导入方所在层」索引，表达不了这条）。失败消息直接给出正确做法：把符号从 barrel 导出，而不是绕过去取。

改动面：2 文件 / +123−8（`web/scripts/check-boundaries.mjs` + `docs/internal/web-package-boundaries.md`）。**无 `web/src/**` 改动 ⇒ 运行时零影响。**

## 复现、根因与同类影响

根因：规则只以散文存在 ⇒ 靠 review 维持。散文规则的失效方式不是「报错」，而是「悄悄被违反」。

按本仓自己的门禁文化（`docs/package_boundary_test.go`：「A gate that scans nothing and reports no violations is not a lenient gate, it is an absent one」），**两种「静默变绿」都被断言**：

1. barrel 文件不存在（包被改名）⇒ FAIL，并提示更新 `BARRELS`；
2. barrel 没有任何**外部**消费者（说明 specifier 解析不再匹配，规则失去了保护对象）⇒ FAIL。

summary 行也扩了计数，让「0」可见而不是与「干净」混淆：
`✓ package boundaries clean: 689 files scanned, 0 cross-layer edge(s) checked, 1 barrel rule(s) held by 17 consumer(s), 0 deep import(s), 0 registered exception(s) all matched`

同类影响已检查：`BARRELS` 是一个数组，将来再有 barrel 子系统（例如 `components/charts`）只需加一条；`EXCEPTIONS` 注册表与 stale-exception 检查不变；rule 1/2 的行为与输出未动。当前树实测 **17 个 barrel 消费者、0 个深取**（另有 6 处 `components/data-table/...` 字样是测试里的**文件路径字符串/注释**，不是 import，故不计）。

## 验证证据

- 最终源码：PR head `b9377404`；`git status` clean，无未提交差异。
- 门禁（本机 Linux 2C/4G，node v22.14.0，vitest 5.0.0 == lock；`package.json`/`bun.lock` 未改）：
  - `node scripts/check-boundaries.mjs` ⇒ rc=0，输出如上（689 files / 17 consumers / 0 deep imports）
  - `bun run lint` rc=0（oxlint 无新增告警 + boundaries + FormControl **140 sites / 0 exception**）
  - `bun run format:check` rc=0（732 files，`.md` 也在 oxfmt 覆盖内）
  - `bun run knip` rc=0
- **变异验红（三向，全部先红后绿）**：
  1. 在 `features/proxy-logs/components/proxy-logs-page.tsx` 注入历史上那条 `import { DataTableRow } from '@/components/data-table/core/data-table-row'` ⇒ **rc=1**，报 `✗ barrel violation: src/features/proxy-logs/components/proxy-logs-page.tsx:5` + 解析后路径 + 「改用 barrel / 缺符号就导出」的补救指引。
  2. 把 `BARRELS[0].package` 改成 `components/data-table-x`（模拟包改名）⇒ **rc=1**，触发「barrel 文件缺失」vacuity 断言。
  3. 把 barrel 自身的匹配条件改成永不匹配（模拟 specifier 解析失效）⇒ **rc=1**，触发「无外部消费者」vacuity 断言。
  三次全部还原后复跑 rc=0。
- 前端测试：**不适用** —— `git diff --name-only` 只有 `web/scripts/check-boundaries.mjs` 与 `docs/internal/web-package-boundaries.md`，`web/src/**` 零改动，vitest 无从受影响；CI `frontend` 仍会全量复跑作为终审。
- Go 门禁：**不适用**（未改任何 `.go` / `go.mod` / workflow），CI 复跑。
- 真实模型中继 / 下游客户端 E2E：**不适用**（无运行时、无 wire、无 UI 改动）。
- 未验证项与剩余风险：本机 `tsgo -b` 结构性 OOM（往轮多次取证）⇒ 交 CI `frontend`；本 PR 未新增 `.ts` 类型面（改的是 `.mjs` 脚本与 `.md`）。风险点是「门禁误报把合法 import 判成深取」，已由三向变异 + 全树 rc=0 + 17 个真实消费者计数覆盖。

## 自查

- [x] 无凭据、私有主机、内部路径或用户敏感数据泄漏（`leak_guard.py --range master..HEAD` RC=0；新增文本只有仓内路径与公开 issue 号）
- [x] 行为变化已更新必要测试与现役文档（`docs/internal/web-package-boundaries.md` 补 rule 6、Gate mechanics 的 vacuity 行为、2026-09-12 precedent 条目；门禁自证走变异验红，与本仓 `check-form-control` / `package_boundary_test.go` 同一套做法）
- [x] 用户可见文案已走 i18n（不适用：无 UI 文案）
