### PR TITLE
docs: drop the remaining plan labels and one false claim

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -250,7 +250,7 @@ PROMPT_FILTER_DENY_PATTERNS=
 # ---- Resin sticky proxy pool (#693) ----
 # Resin pins an OAuth account to a stable residential/ISP proxy lease so
 # platforms that fingerprint IP continuity (Anthropic, Google) stop forcing
-# re-auth on every rotation. Env-only — no DDL for Tier 1.
+# re-auth on every rotation. Env-only — no schema change.
 # RESIN_URL carries the base URL + token, e.g. http://resin.local:2260/my-token.
 # RESIN_PLATFORM_NAME is the Platform identity (falls back to site.Platform).
 # RESIN_ENABLED is the global opt-in (default false). Per-site resin_enabled

--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,7 @@ type Config struct {
 	// nothing would ever be pruned.
 	LogCleanupEnvEnabled bool
 
-	// Resin sticky proxy pool (3 fields, env-only — no DDL for Tier 1).
+	// Resin sticky proxy pool (3 fields, env-only — no schema change).
 	// RESIN_URL carries the base URL + token, e.g. http://resin.local:2260/my-token.
 	// RESIN_PLATFORM_NAME is the Platform identity (falls back to site.Platform).
 	// RESIN_ENABLED is the global opt-in (default false).
@@ -109,7 +109,7 @@ type Config struct {
 	ResinPlatformName string
 	ResinEnabled      bool
 
-	// uTLS TLS fingerprint masking (1 field, env-only — no DDL for Tier 1).
+	// uTLS TLS fingerprint masking (1 field, env-only — no schema change).
 	// UTLS_ENABLED is the global opt-in (default false). When true, all
 	// outbound platform requests use a uTLS Chrome-ClientHello transport
 	// instead of Go's default crypto/tls ClientHello, masking the JA3/JA4

--- a/config/config_race_test.go
+++ b/config/config_race_test.go
@@ -92,8 +92,8 @@ func TestSetRuntimePublishesCopies(t *testing.T) {
 	}
 }
 
-// TestRuntimeWriteRace_TornReadReproduction reproduces the concurrency-audit
-// finding against the FIXED access shape: writers publish
+// TestRuntimeWriteRace_TornReadReproduction reproduces the torn-read race
+// against the FIXED access shape: writers publish
 // correlated field tuples through UpdateRuntime while readers take atomic
 // snapshots. Each published generation g carries ProxyToken "sk-gen-g",
 // ProxyRetryStatusRanges "g-g" and NotifyCooldownSec g; a reader that ever

--- a/config/video_task_retention_default_test.go
+++ b/config/video_task_retention_default_test.go
@@ -2,7 +2,7 @@ package config
 
 import "testing"
 
-// TestLoadProxyVideoTaskRetentionDefaults pins the audit-driven default: video
+// TestLoadProxyVideoTaskRetentionDefaults pins the shipped default: video
 // task mappings (publicId -> upstream video id) are short-lived, so retention
 // must be on out of the box. The same knob drives the proxy_video_tasks pruner
 // and the TTL of the process-local rewrite cache in handler/proxy.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # docs/ — Metapi Go documentation map
 
-**Last updated**: 2026-09-03
+**Last updated**: 2026-09-12
 **Purpose**: one-screen orientation for users and contributors.
 
 This directory is split into **public docs** (written for users and
@@ -9,7 +9,7 @@ residual caveats). Maintainer process/history/research — product state,
 roadmap, progress log, audits, benchmarks — live outside this public repo
 (open work in GitHub issues; version narrative in `CHANGELOG.md`). User-facing
 documents never deep-link into `internal/` — they state the fact directly.
-`docs/doc_hygiene_test.go` enforces both rules in CI.
+`docs/doc_hygiene_test.go` enforces these rules in CI.
 
 ## Public docs
 
@@ -32,10 +32,10 @@ documents never deep-link into `internal/` — they state the fact directly.
 
 | Path                                             | Role                                                        |
 | :----------------------------------------------- | :---------------------------------------------------------- |
-| [`internal/git-workflow.md`](internal/git-workflow.md) | 分支模型 / PR / 保护规则                              |
-| [`internal/design/`](internal/design/)           | 设计系统 SSOT（BACKEND / DESIGN / a11y / components / state-stability） |
-| [`internal/web-package-boundaries.md`](internal/web-package-boundaries.md) | 前端分层门禁契约（`web/scripts/check-boundaries.mjs` 机器执行） |
-| [`internal/responses-websocket-residual.md`](internal/responses-websocket-residual.md) | Responses WS 501 residual 说明 |
+| [`internal/git-workflow.md`](internal/git-workflow.md) | Branch model, PR flow, protection rules, release cadence |
+| [`internal/design/`](internal/design/)           | Design source of truth (BACKEND / DESIGN / a11y / components / state-stability) |
+| [`internal/web-package-boundaries.md`](internal/web-package-boundaries.md) | Frontend layering contract (`web/scripts/check-boundaries.mjs` enforces it) |
+| [`internal/responses-websocket-residual.md`](internal/responses-websocket-residual.md) | Why the Responses WebSocket surface answers 501 |
 
 ## Layout
 
@@ -65,8 +65,17 @@ docs/
 
 - Prefer **merge/update** over new parallel analysis files.
 - Absolute dates, not "recently".
-- Public docs state facts for users; process context (waves, gaps, audit
-  rounds) belongs in `internal/`.
-- `docs/doc_hygiene_test.go` enforces public markdown hygiene (no local
-  paths / no credential DSNs / no false Redis sticky claims) and the
-  README → `internal/` link boundary.
+- Public docs state facts for users. `internal/` holds contributor *design*
+  notes and residual caveats — it is tracked and public, so maintainer
+  process context (product state, roadmap, progress log, audits,
+  benchmarks) belongs outside this repository entirely: open work lives in
+  GitHub issues, the version narrative in `CHANGELOG.md`.
+- Work-programme vocabulary does not belong in the published tree either:
+  the batch, priority and audit labels of an internal plan, or a citation of
+  a plan file that was never published. A comment states what the code does,
+  not which plan asked for it — the label is unresolvable for anyone outside
+  that plan and rots the day the plan is archived.
+- `docs/doc_hygiene_test.go` enforces all of the above in CI: public markdown
+  hygiene (no local paths / no credential DSNs / no false Redis sticky claims
+  / no AI citation artifacts), the README → `internal/` link boundary, and
+  the work-programme vocabulary ban.

--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -24,7 +24,7 @@ var (
 
 // storefrontMarkdown names the README files: the public storefront of the
 // repository. They must never deep-link into docs/internal/ — maintainer
-// process context (roadmap, audit waves, state tables) stays internal and
+// process context (roadmap, progress log, state tables) stays internal and
 // user-facing facts are stated inline instead.
 var storefrontMarkdown = map[string]bool{
 	"README.md":    true,
@@ -559,14 +559,27 @@ func hygieneSkipFile(name string) bool {
 // should be. Public-tree comments describe the product; the plan that produced
 // a line stays with the plan.
 //
-// Deliberately out of scope: bare single-letter audit item codes ("S10", "F5",
-// "M1"). They cannot be told apart from model-family names (MiniMax-M2) or
-// RFC 3339 fragments ("…T15:04:05Z") without a context rule more fragile than
-// the codes themselves. The vocabulary below is what actually recurs. Matching
-// is case-sensitive on purpose: the labels are proper nouns of a plan, while
-// the same word in lower case is ordinary prose.
+// Deliberately out of scope, both for the same reason — the shape collides
+// with product vocabulary and only a context rule could tell them apart, which
+// would be more fragile than the codes themselves:
+//
+//   - bare single-letter audit item codes ("S10", "F5", "M1") vs model-family
+//     names (MiniMax-M2) and RFC 3339 fragments ("…T15:04:05Z");
+//   - "Tier N" vs the tiers this product really has (`OPENAI_SERVICE_TIER_*`,
+//     routing/context_tier.go, prompt-cache tiers, destructive-action tiers).
+//     The Resin/uTLS delivery-tier labels that used this shape were removed by
+//     hand; a future one is review's job, not the gate's.
+//
+// In-file structure labels are fine and stay: `Phase 1: Setup` inside an e2e
+// test, `§3.14` inside config.go, and the channels-cache test's cold/warm
+// passes — those were `Round 1`/`Round 2` until the words were made to name
+// the cache state instead of a plan round. Matching is case-sensitive on
+// purpose: the labels are proper nouns of a plan, while the same word in
+// lower case is ordinary prose.
 var programmeCodeRE = regexp.MustCompile(strings.Join([]string{
 	`\bWave \d+\b`,
+	`\bRound \d+\b`,
+	`\b[A-Z]-domain\b`,
 	`\bS-line\b`,
 	`\bMilestone [A-Z]\d\b`,
 	`\bLane [A-Z]\b`,
@@ -667,6 +680,8 @@ func TestProgrammeCodeGateRegexpSanity(t *testing.T) {
 		"// see plan.md §5.5.5",
 		"// Design: k1-model-redirect-design-2026-08-01.md §7",
 		"// 13-report §4",
+		"// Regression for the Round 3 contract audit",
+		"// Round 3 audit (H-domain performance): the pipeline served",
 		"// See limitation-update-center.md.",
 		"// spec p3-sites-accounts.md lines 528-542",
 	}
@@ -684,6 +699,10 @@ func TestProgrammeCodeGateRegexpSanity(t *testing.T) {
 		"// see docs/architecture.md and docs/testing.md",
 		"// config.Load §3.14 defines this key",
 		"// milestone releases are tagged v*",
+		`want := "Checkin round 2026-08-15T03:00:00Z: 3 ok, 2 failed"`, // product string
+		"// Phase 1: Setup — in-memory SQLite + AutoMigrate",           // in-file test step
+		"// see routing/round_robin.go and routing/context_tier.go",    // tier as a product word
+		"// OPENAI_SERVICE_TIER_RULES injects service_tier per model",
 	}
 	for _, sample := range mustNotMatch {
 		if programmeCodeRE.MatchString(sample) {

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -171,8 +171,8 @@ func TestTokens_List_AllWithoutFilter(t *testing.T) {
 
 // TestTokens_List_WireContractCamelCase verifies the GET /api/account-tokens
 // response carries the camelCase wire contract fields and does not leak raw
-// snake_case DB column names. Regression for the Round 3 D-domain contract
-// audit: MapScan exposed `account_id`, `token_group`, `is_default`, ... while
+// snake_case DB column names. Regression for the API contract audit:
+// MapScan exposed `account_id`, `token_group`, `is_default`, ... while
 // the frontend accountTokenSchema requires `accountId`, `tokenGroup`,
 // `isDefault`, `createdAt`, `updatedAt`.
 func TestTokens_List_WireContractCamelCase(t *testing.T) {

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -1506,7 +1506,7 @@ func TestAccounts_Update(t *testing.T) {
 // TestAccounts_Update_PersistsTagsAndPlatformUserId verifies the account
 // edit form fields `tags` (accounts.tags JSON column) and `platformUserId`
 // (extraConfig) are persisted instead of silently dropped. Regression for
-// the Round 3 contract audit.
+// the API contract audit.
 func TestAccounts_Update_PersistsTagsAndPlatformUserId(t *testing.T) {
 	db, r, _ := setupAccountsTest(t)
 	_, accountID := setupAccountFixtureWithSite(t, db, r, "UpdateContract", "https://api.openai.com")

--- a/handler/admin/channels_cache_test.go
+++ b/handler/admin/channels_cache_test.go
@@ -84,11 +84,11 @@ func TestChannels_SnapshotCache_PagedKeysDoNotEvictEachOther(t *testing.T) {
 		page2 = "/api/channels?page=2&pageSize=50"
 	)
 
-	// Round 1: both keys are cold → miss (and populate).
+	// Cold: both keys miss (and populate).
 	firstP1 := requireCacheState(t, r, page1, "miss")
 	firstP2 := requireCacheState(t, r, page2, "miss")
 
-	// Round 2: both keys are warm and inside the 10s TTL → hit.
+	// Warm: both keys are inside the 10s TTL → hit.
 	secondP1 := requireCacheState(t, r, page1, "hit")
 	secondP2 := requireCacheState(t, r, page2, "hit")
 

--- a/handler/admin/channels_test.go
+++ b/handler/admin/channels_test.go
@@ -116,7 +116,7 @@ func TestChannels_ManuallyDisabledStatus(t *testing.T) {
 // longer hard-truncates at the default pageSize of 50 when the client omits
 // pagination params: the channels page paginates client-side, so a fleet
 // larger than 50 must come back in full. Explicit ?page/?pageSize still opts
-// into server-side paging. Regression for the Round 3 contract audit.
+// into server-side paging. Regression for the API contract audit.
 func TestChannels_List_UnboundedReturnsAllRows(t *testing.T) {
 	db, r := setupTokenRoutesTest(t)
 	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -143,7 +143,7 @@ func TestSites_CreateWithExplicitPlatform(t *testing.T) {
 
 // TestSites_Create_PersistsResinEnabledAndUseUtls verifies the create form
 // fields resinEnabled/useUtls are persisted instead of silently dropped.
-// Regression for the Round 3 contract audit (site update/create handlers
+// Regression for the API contract audit (site update/create handlers
 // dropped fields).
 func TestSites_Create_PersistsResinEnabledAndUseUtls(t *testing.T) {
 	_, r := setupSitesTest(t)

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -1606,7 +1606,7 @@ func TestRedactSearchSecrets(t *testing.T) {
 
 // TestRouteChannels_IncludeRuntimeCounters verifies GET /api/routes/{id}/channels
 // returns each channel's success/fail hit counts and persisted cooldown — the
-// fields the route detail sheet renders. Regression for the Round 3 contract
+// fields the route detail sheet renders. Regression for the API contract
 // audit: the enriched map dropped successCount/failCount/cooldownUntil even
 // though rc.* carried them.
 func TestRouteChannels_IncludeRuntimeCounters(t *testing.T) {

--- a/router/gzip.go
+++ b/router/gzip.go
@@ -1,8 +1,8 @@
 // gzip.go — gzip response compression for the embedded SPA static assets.
 //
-// Round 3 audit (H-domain performance): the SPA static asset pipeline served
-// every JS/CSS/HTML/SVG payload uncompressed. This middleware compresses
-// compressible text responses when the client advertises gzip support.
+// The SPA static asset pipeline used to serve every JS/CSS/HTML/SVG payload
+// uncompressed. This middleware compresses compressible text responses when
+// the client advertises gzip support.
 //
 // The compression decision is made lazily in WriteHeader based on the
 // Content-Type the inner handler set (http.FileServer / ServeContent set it

--- a/router/router.go
+++ b/router/router.go
@@ -156,7 +156,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 			admin.RegisterChannelTestRoutes(r, db.DB, cfg)
 			admin.RegisterUpdateCenterRoutes(r)
 			admin.RegisterOauthRoutes(r, db.DB)
-			// Resin Tier 2 (#678): observability status endpoint for the
+			// Resin (#678): observability status endpoint for the
 			// sticky-proxy-pool integration. Read-only surface.
 			admin.RegisterResinRoutes(r, db.DB, cfg)
 		} else {

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -310,11 +310,14 @@ func BuildPlatformProxyConfig(cfg *config.Config, account *store.Account, site *
 // BuildPlatformProxyConfig for verify-token / login / create flows where no
 // Account row exists yet. It derives a deterministic temp Resin identity from
 // (siteID, rawToken) so all pre-account requests for the same token share an
-// egress IP, then (in Tier 2) inherit-lease can transfer the lease to the
-// stable acc-{id} identity after INSERT.
+// egress IP. Nothing carries that assignment over to the stable acc-{id}
+// identity used once the Account row exists: the forward-proxy cache and the
+// lease tracker are both keyed by identity, and the tracker is
+// observability-only — resin.go is explicit that there is no TCP lease to
+// release, so there is nothing to hand over.
 //
 // Precedence matches BuildPlatformProxyConfig with the temp identity filling
-// the resin tier: site.ProxyURL > resin(temp) > system > direct.
+// the resin slot: site.ProxyURL > resin(temp) > system > direct.
 func BuildPlatformProxyConfigForToken(cfg *config.Config, site *store.Site, rawToken string) *platform.ProxyConfig {
 	// When the site has an explicit ProxyURL, that beats resin — delegate
 	// entirely so headers/cookies/UA are assembled by the shared path.

--- a/service/oauth/grok.go
+++ b/service/oauth/grok.go
@@ -226,7 +226,7 @@ type grokIDTokenClaims struct {
 // TODO: flow.go currently drives completion via HandleCallback, which requires
 // a redirect `code`. Device OAuth has no callback — completion must instead be
 // triggered by a poll-based status endpoint that calls this function until it
-// resolves. Wiring that poll trigger is intentionally out of Tier 1 scope.
+// resolves. Wiring that poll trigger is intentionally not done yet.
 func exchangeGrokAuthorizationCode(ctx context.Context, input ExchangeCodeInput) (*TokenSet, error) {
 	state := strings.TrimSpace(input.State)
 	if state == "" {

--- a/service/resin.go
+++ b/service/resin.go
@@ -14,7 +14,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/store"
 )
 
-// This file implements the Resin sticky-proxy-pool integration (Tier 1).
+// This file implements the Resin sticky-proxy-pool integration.
 //
 // Resin is an external proxy pool that gives each business identity a stable
 // outbound IP. metapi-go routes its outbound traffic through Resin so each
@@ -114,7 +114,7 @@ func ClearResinLeasesForTest() {
 // Precedence:
 //  1. site.ResinEnabled non-nil → explicit per-site override wins (true =
 //     force-enable even when global is off; false = force-disable even when
-//     global is on). This is the Tier 2 per-site override (#678).
+//     global is on). This is the per-site override (#678).
 //  2. site.ResinEnabled nil → fall back to the global RESIN_ENABLED flag,
 //     which itself requires a non-empty RESIN_URL.
 //

--- a/service/resin_pool_test.go
+++ b/service/resin_pool_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/deliciousbuding/metapi-go/store"
 )
 
-// TestResinForwardProxyURL_StableCacheKey verifies the Tier 2 (#678) "client
-// connection pooling" invariant for the Resin forward proxy.
+// TestResinForwardProxyURL_StableCacheKey verifies the client-connection
+// pooling invariant from #678 for the Resin forward proxy.
 //
 // The pooled-transport cache in platform.getCachedTransport uses
 // (proxyURL, insecureSkipTLS) as its key (see platform.transportCacheKey +

--- a/store/additive.go
+++ b/store/additive.go
@@ -171,7 +171,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		},
 	},
 	{
-		// Tier 2 (#678): per-site Resin override. NULL = inherit global
+		// Per-site Resin override (#678). NULL = inherit global
 		// RESIN_ENABLED flag; true/false = explicit per-site opt-in/opt-out.
 		// This is observability-only on the storage side; service.ResinEnabled
 		// resolves site-level precedence at request time.
@@ -182,7 +182,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		},
 	},
 	{
-		// Tier 1 (#672): per-site uTLS TLS fingerprint masking override.
+		// Per-site uTLS TLS fingerprint masking override (#672).
 		// NULL = inherit global UTLS_ENABLED flag; true/false = explicit
 		// per-site opt-in/opt-out. Uses INTEGER/BOOLEAN (not TEXT) so the
 		// *bool struct field scans correctly via database/sql, matching the

--- a/web/src/features/dashboard/components/stat-card-sparkline.tsx
+++ b/web/src/features/dashboard/components/stat-card-sparkline.tsx
@@ -1,12 +1,11 @@
 // metapi-go/features/dashboard/components — lazy-loaded sparkline renderer.
 //
-// Round 3 audit (H-domain performance): the dashboard shipped ~332KB of
-// recharts on first paint even when no chart was rendered, because
-// stat-card.tsx imported it statically. This module is the only dashboard
-// file that recharts can reach through the eager overview section; it is
-// loaded via React.lazy + dynamic import() from StatCard and only mounts
-// when a stat card actually has sparkline data, so the recharts chunk is
-// fetched on demand instead of up front.
+// The dashboard used to ship ~332KB of recharts on first paint even when no
+// chart was rendered, because stat-card.tsx imported it statically. This
+// module is the only dashboard file that recharts can reach through the eager
+// overview section; it is loaded via React.lazy + dynamic import() from
+// StatCard and only mounts when a stat card actually has sparkline data, so
+// the recharts chunk is fetched on demand instead of up front.
 
 import { Area, AreaChart } from 'recharts'
 


### PR DESCRIPTION
## 用户任务与改动摘要

非修复项（含一处**事实错误**修正）：#1330 清掉了 wave/lane/priority 词汇，本 PR 是**同一类的剩余部分**，用更宽的网重扫后补齐。20 文件 / +83−53，除注释与散文外无一行代码逻辑改动。

1. **`Round 3 contract audit` 与其审计域字母（`D-domain` / `H-domain`）—— 7 处**。这些测试仍然说清了自己钉住什么（camelCase wire 契约、channels 无界列表、表单字段落库、SPA 管道 gzip、recharts 懒加载 chunk），那才是读者能用上的部分。
2. **Resin / uTLS 的 `Tier 1` / `Tier 2` 交付范围标签 —— 9 处**，含**用户可见的 `.env.example`**：`Env-only — no DDL for Tier 1.` → `Env-only — no schema change.`；per-site override 保留公开 issue 号（#672 / #678）。
3. **`docs/README.md` 自相矛盾**：开头说维护者过程史**在本仓之外**，Hygiene rules 却让贡献者把过程上下文放进 `internal/` —— 而 `internal/` 是**被跟踪的公开目录**。规则改为陈述仓库实际做法，并补上「工作计划词汇禁令」与门禁实际覆盖项；同时把 internal-docs 表里 4 个中文单元格改为英文（该文档其余部分全英文）；`Last updated` 2026-09-03 → 2026-09-12。
4. **门禁扩面**：`programmeCodeRE` 增加 `\bRound \d+\b` 与 `\b[A-Z]-domain\b`，双向补 sanity fixture。

## 复现、根因与同类影响

**根因**：同 #1330 —— 注释记录「哪一轮审计/哪一档交付要求这么做」，而计划文档从未进公开仓。标签对读者不可解析，且计划一归档就永久失效。

**把注释对着代码读，发现一处不是标签问题、而是陈述为假**（本 PR 唯一的事实修正）：

`service/account_service.go` 的 `BuildPlatformProxyConfigForToken` 声称「then (in Tier 2) **inherit-lease** can transfer the lease to the stable `acc-{id}` identity after INSERT」。取证：

- `git grep -nI "inherit-lease|InheritLease|inheritLease"` ⇒ **全仓仅这一行注释命中**，没有任何实现。
- 而且**没有可转移的东西**：`service/resin.go:53` 明写 lease tracker 是 `observability-only: there is no actual TCP lease to release`。
- forward-proxy 缓存与 lease tracker **都以 identity 为键**（`service/resin.go:57`、`TouchResinLease(accountID string)`）⇒ `tmp-{hash}` 的池分配不会延续到 `acc-{id}`。

注释改为陈述事实：分配**不会**带过去，并指明原因；顺带把 precedence 那行的 `filling the resin tier` 改为 `filling the resin slot`（避免与已删的 Tier 标签混淆）。

**同类影响已检查**：
- `Phase \d`（`e2e/*_test.go` 共 17 处）与 `scheduler_test.go` 的 `§1..§20`、`config.go` 的 `§1.x/§3.x` 是**文件内结构标签**，就地可解析 ⇒ 保留、不进门禁。
- `audit` 一词的其余 20+ 处是**产品词汇**（audit log / audit event / audit actor）⇒ 保留；只改掉两处把 shipped 行为说成「审计驱动」的框定（`concurrency-audit finding` → `torn-read race`、`audit-driven default` → `shipped default`）。
- `sweep` / `hardening pass` 全部是通用英文（cache sweep、expiry sweep）⇒ 保留。
- **`Tier \d+` 有意不进门禁**：`tier` 在本仓是**活的产品词**（`OPENAI_SERVICE_TIER_*`、`routing/context_tier.go`、prompt-cache tiers、`DESIGN.md` 的 destructive-action tiers、`STATUS_TIERS`），`Tier 1` 与产品档位无法机械区分；理由与既有的「单字母审计号排除」并列写在 pattern 的 doc comment 上。
- `channels_cache_test.go` 的 `Round 1/Round 2` 改为 `Cold:/Warm:` —— 那里指的是缓存状态而非计划轮次，改名后 `\bRound \d+\b` 才能无歧义进门禁；`service/checkin/round_aggregation_test.go` 的产品串 `"Checkin round 2026-08-15T03:00:00Z: …"` 是小写 ⇒ 不受影响（已作为负样本钉住）。

## 验证证据

- 最终源码：PR head `74ba9637`；`git status` clean，无未提交差异（race 套件在该 commit 上重跑，避免 mid-run 编辑污染证据）。
- 门禁（本机 Linux 2C/4G，go1.26.6，vitest 5.0.0 == lock）：
  - `go build ./cmd/server` OK · `go vet ./...` rc=0 · `gofmt -l` 与 master **差集为空**
  - `GOMAXPROCS=2 go test ./... -count=1 -race -p 1 -timeout=30m` ⇒ **44 ok / 0 FAIL / rc=0**（在 head commit 上重跑；证据 `race_rc=0`）
  - `go test ./docs -run 'Hygiene|ProgrammeCode' -count=1` ⇒ **ok**（含扩面后的门禁与 sanity）
  - web：`bun run lint` rc=0（boundaries **689/0 cross-layer + 1 barrel rule held by 17 consumers + 0 deep import**、FormControl **140/0**）· `bun run format:check` rc=0（732 files）· `bun run knip` rc=0
- **变异验红**：向 `router/gzip.go` 追加 `// Round 7 audit (Q-domain perf) …` ⇒ `TestNoInternalProgrammeCodesInShippedSources` **FAIL** 并指名 `router/gzip.go:130`；精确还原（按追加的字节串切除，**不用 `git checkout --`**，因为该文件本轮有未提交改动）后复跑 **ok**。
- **sanity 双向**：正样本 +2（`Regression for the Round 3 contract audit`、`Round 3 audit (H-domain performance)`）；负样本 +4（产品串 `Checkin round 2026-08-15T03:00:00Z`、文件内步骤 `Phase 1: Setup`、`routing/round_robin.go` + `routing/context_tier.go`、`OPENAI_SERVICE_TIER_RULES`）。
- 真实模型中继：**不适用**（无代理行为改动；Resin/uTLS 只改注释，`.env.example` 只改说明文字，键名与默认值未动）。
- 下游客户端 / 用户任务 E2E：**不适用**（无 wire / schema / 契约改动；`store/additive.go` 只改迁移步骤的注释，`Version` 与 `Description` 均未动）。
- 未验证项与剩余风险：本机 `tsgo -b` 结构性 OOM（往轮多次取证）⇒ 类型面交 CI `frontend`；本 PR 前端改动是 1 个文件的**纯注释**重排。风险点是门禁误报，已由 4 条新负样本 + 全树 rc=0 覆盖。

## 自查

- [x] 无凭据、私有主机、内部路径或用户敏感数据泄漏（`leak_guard.py --range master..HEAD` RC=0；本 PR 删的正是内部标签与指向未公开计划文档的引用）
- [x] 行为变化已更新必要测试与现役文档（无行为变化；`docs/README.md` 的矛盾规则、门禁覆盖说明、internal-docs 表语言已同步；`docs/doc_hygiene_test.go` 的 pattern doc comment 记录了 `Tier N` 与单字母号的排除理由）
- [x] 用户可见文案已走 i18n（不适用：`.env.example` 是注释说明而非 UI 文案，无 i18n 键变动）
