### PR TITLE
docs(web): make barrel headers true and gate the example import

### DIFF
--- a/docs/internal/web-package-boundaries.md
+++ b/docs/internal/web-package-boundaries.md
@@ -77,6 +77,19 @@ Rule numbers in the script's header and failure messages are this document's
 (3 = feature barrels, 6 = subsystem barrels): `src/lib/*.ts` cites them by
 number, so the script must not carry a second numbering of its own.
 
+One piece of prose is checked too. A barrel header that documents
+`import { X } from '@/features/<name>'` states what that barrel exports, and
+nothing type-checks a comment — so the gate parses those examples out of the
+header (comment lines are concatenated first, because an example may span
+several of them) and requires every named symbol to be in the target barrel's
+export set. It fails vacuously if it finds no example at all, which is the
+"resolution stopped matching" case rather than a clean tree. The rest of a
+barrel's header — who consumes it, why a page is absent — is review-only; this
+is the one claim a machine can settle. Exported names are collected from
+`export { … }` lists and the barrel's own declarations, with line comments
+stripped from a brace body *before* it is split on commas (a comment inside the
+braces can contain one).
+
 ## Registered exceptions
 
 **Layer rules (`EXCEPTIONS`)**: none. The shell inversion is complete: `layout/lib/settings-nav-registry.ts`
@@ -131,6 +144,18 @@ out of `settings/sections/downstream/`) was retired by moving the keys UI into
   several claimed a page component was "the primary surface" while exporting
   none, pointed at route files as future work when those routes already ship,
   and carried empty section headings.
+- **2026-09-12** — barrel headers were re-read against the tree (#1338) and
+  four claims were false: `token-routes`' example import named `RoutesPage` and
+  `RouteSummaryRow`, which that barrel does not export; its rebuild-handoff
+  note credited a settings section with writing the reference when the writer is
+  the feature's own `api.ts`; `settings` still said the standalone
+  downstream-keys page lazy-loads one of its sections, which stopped being true
+  an hour earlier when the keys UI moved home; `observability` listed Proxy Logs
+  as one of its sections when it is a separate workspace the sidebar deep-links
+  out to. Six doc comments in `models/api.ts`, `models/types.ts` and
+  `settings/config/settings-config.ts` described symbols that no longer exist
+  and were deleted. The example-import claim is the part that can rot silently
+  and still compile nowhere, so it is now gated (see Gate mechanics).
 - **2026-09-12** — the downstream-keys UI moved home (#1335). `keys-section`,
   `key-sheet-form`, `key-cells`, `key-scope-cell`, `key-form-shared`,
   `key-created-toast`, `credential-ref-picker` and `lib/credential-{refs,display}`

--- a/web/scripts/check-boundaries.mjs
+++ b/web/scripts/check-boundaries.mjs
@@ -18,6 +18,11 @@
 // point downward through the layer table; the edges above are the two hard
 // upward edges the gate closes today.
 //
+// The gate also checks one piece of prose: a symbol named in a barrel header's
+// documented example import must be in that barrel's export set (see "barrel
+// doc examples" below). That is the only part of the boundaries doc's contract
+// a comment can state and a machine can verify.
+//
 // Not enforced (documented residuals in the boundaries doc — widening the
 // gate needs its own issue): lib → components/i18n (lib/router.ts fallback
 // pages, http-client/assert-business-ok i18n), hooks/use-sidebar-* →
@@ -250,6 +255,100 @@ for (const file of files) {
   })
 }
 
+// --- barrel doc examples ---------------------------------------------------------
+// A barrel header that documents `import { X } from '@/features/<name>'` makes
+// a claim about that barrel's own export set, and nothing type-checks a
+// comment. token-routes' example named `RoutesPage` and `RouteSummaryRow`,
+// neither of which the barrel exports (the page is loaded by its route file,
+// the type lives in lib/helpers/token-route-contract.ts) — so the one line
+// whose job is to show the sanctioned way in taught a contributor to write
+// code that does not compile. Every symbol named in a documented example
+// import must therefore be in the target barrel's export set.
+const BARREL_FILE_RES = /^(?:features|components)\/[^/]+\/index\.ts$/
+
+/** Names a barrel publishes: re-export lists plus its own declarations. */
+function barrelExports(text) {
+  const names = new Set()
+  const listRes = /^export\s+(?:type\s+)?\{([^}]*)\}/gm
+  const declRes =
+    /^export\s+(?:declare\s+)?(?:async\s+)?(?:function|const|let|var|class|type|interface|enum)\s+([A-Za-z0-9_$]+)/gm
+  let match
+  while ((match = listRes.exec(text)) !== null) {
+    // Strip line comments from the whole brace body BEFORE splitting: a comment
+    // inside the braces can contain a comma (token-routes documents why
+    // `useRoutes` is shared), which would otherwise split mid-sentence and
+    // swallow the symbol that follows it.
+    const body = match[1].replace(/\/\/[^\n]*/g, '')
+    for (const part of body.split(',')) {
+      const named =
+        /^\s*(?:type\s+)?([A-Za-z0-9_$]+)(?:\s+as\s+([A-Za-z0-9_$]+))?\s*$/.exec(
+          part
+        )
+      if (named) names.add(named[2] ?? named[1])
+    }
+  }
+  while ((match = declRes.exec(text)) !== null) names.add(match[1])
+  return names
+}
+
+/**
+ * The barrel's header prose, as one string. Comment lines are concatenated so
+ * an example import split across several `//` lines still parses; oxfmt does
+ * not reformat comment bodies, so this cannot rely on the one-line `from`
+ * clause assumption the edge scan above uses.
+ */
+function commentProse(text) {
+  return text
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trimStart()
+      if (trimmed.startsWith('//')) return trimmed.slice(2)
+      if (trimmed.startsWith('*')) return trimmed.slice(1)
+      return ''
+    })
+    .join('\n')
+}
+
+const DOC_EXAMPLE_RES =
+  /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g
+
+const barrelFiles = files
+  .map((file) => file.slice(SRC.length + 1).replaceAll('\\', '/'))
+  .filter((rel) => BARREL_FILE_RES.test(rel))
+const barrelSources = new Map(
+  barrelFiles.map((rel) => [rel, readFileSync(join(SRC, rel), 'utf8')])
+)
+const barrelExportSets = new Map(
+  [...barrelSources].map(([rel, text]) => [rel, barrelExports(text)])
+)
+const docExampleViolations = []
+let docExamples = 0
+
+for (const [rel, text] of barrelSources) {
+  const prose = commentProse(text)
+  const fileDirRel = dirname(rel)
+  DOC_EXAMPLE_RES.lastIndex = 0
+  let match
+  while ((match = DOC_EXAMPLE_RES.exec(prose)) !== null) {
+    const target = resolveSpecifier(match[2], fileDirRel)
+    const targetBarrel = target === null ? null : `${target}/index.ts`
+    if (target === null || !barrelExportSets.has(targetBarrel)) continue
+    const exported = barrelExportSets.get(targetBarrel)
+    for (const part of match[1].split(',')) {
+      const named =
+        /^\s*(?:type\s+)?([A-Za-z0-9_$]+)(?:\s+as\s+([A-Za-z0-9_$]+))?\s*$/.exec(
+          part
+        )
+      if (!named) continue
+      const symbol = named[2] ?? named[1]
+      docExamples += 1
+      if (!exported.has(symbol)) {
+        docExampleViolations.push({ location: rel, symbol, targetBarrel })
+      }
+    }
+  }
+}
+
 // --- verdict --------------------------------------------------------------------------
 let failed = false
 
@@ -283,6 +382,27 @@ for (const violation of featureViolations) {
       `    not a path below it. Export the symbol from that feature's index.ts;\n` +
       `    if two features need the same contract, it belongs in the feature that\n` +
       `    owns the domain (or in src/lib/ when neither does).`
+  )
+}
+
+for (const violation of docExampleViolations) {
+  failed = true
+  console.error(
+    `✗ barrel doc example does not resolve: ${violation.location}\n` +
+      `    documents '${violation.symbol}', which src/${violation.targetBarrel} does not export.\n` +
+      `    A comment is the only place this can rot silently: fix the example, or\n` +
+      `    export the symbol if a consumer genuinely needs it.`
+  )
+}
+
+if (docExamples === 0) {
+  failed = true
+  console.error(
+    `✗ barrel doc-example check would pass vacuously: no documented example\n` +
+      `    import was found in any src/{features,components}/*/index.ts header.\n` +
+      `    Either the examples were removed or DOC_EXAMPLE_RES stopped matching\n` +
+      `    (comment prose is concatenated before matching, so a multi-line\n` +
+      `    example must still parse).`
   )
 }
 
@@ -351,5 +471,6 @@ console.log(
     `${barrelEdges} deep import(s), ` +
     `features: ${featureBarrelEdges} barrel edge(s) / ${featureDeepEdges} deep, ` +
     `${FEATURE_EXCEPTIONS.length} feature exception(s) all matched, ` +
-    `${EXCEPTIONS.length} registered exception(s) all matched`
+    `${EXCEPTIONS.length} registered exception(s) all matched, ` +
+    `${docExamples} barrel doc-example symbol(s) resolved`
 )

--- a/web/src/features/models/api.ts
+++ b/web/src/features/models/api.ts
@@ -113,16 +113,3 @@ export function useModels(
     ...queryOptions,
   })
 }
-
-/**
- * Resolve a single model's capability summary (endpoint types + tags) from
- * the pricing-hydrated marketplace cache. Returns `undefined` while loading
- * or when the model is not in the marketplace. The detail sheet uses this to
- * avoid a dedicated per-model endpoint; because the query key matches a list
- * already fetched with `includePricing`, no extra network request fires.
- */
-
-/**
- * Collect the unique capability facets (endpoint types) across a model list,
- * sorted for a stable faceted-filter dropdown.
- */

--- a/web/src/features/models/types.ts
+++ b/web/src/features/models/types.ts
@@ -101,11 +101,6 @@ export type ModelsMarketplaceResponse = {
 }
 
 /**
- * Derived capability view used by the detail sheet: the union of
- * `supportedEndpointTypes` and `tags`, deduped and sorted for display.
- */
-
-/**
  * TanStack Query key factory. Centralised so invalidation is grep-able and
  * the keys stay stable across hooks. The marketplace options (`refresh`,
  * `includePricing`) are part of the key so a pricing-hydrated fetch does

--- a/web/src/features/observability/index.ts
+++ b/web/src/features/observability/index.ts
@@ -1,8 +1,14 @@
 // metapi-go/features/observability — public barrel.
 //
-// Public API for the Observability workspace (Overview / Health / Proxy
-// Logs). Consumers (route file, sidebar, drill-in registry) import from
-// `@/features/observability`.
+// Public API for the Observability workspace: two sections (Overview, Health)
+// behind one page. Proxy logs is not one of them — it is a separate workspace
+// at `/proxy-logs` that this feature's sidebar view deep-links out to
+// (`config/observability-nav.ts`).
+//
+// Both consumers are route files, which is why nothing here is a page-less
+// surface: `routes/_authenticated/observability.tsx` (page + section-id type +
+// search schema) and `routes/_authenticated/route.tsx` (registers
+// `OBSERVABILITY_VIEW` with the sidebar view registry).
 
 export { ObservabilityPage } from './components/observability-page'
 

--- a/web/src/features/settings/config/settings-config.ts
+++ b/web/src/features/settings/config/settings-config.ts
@@ -20,15 +20,6 @@ const SETTINGS_SUBAREAS: readonly SettingsSubarea[] = [
   operationsSubarea,
 ]
 
-/** Stable id list for route validation. */
-
-/**
- * All 5 settings subareas in main-sidebar order
- * (matches components/layout/config/system-settings.config.ts).
- */
-
-/** Stable id list for route validation. */
-
 /**
  * All 5 settings subareas in main-sidebar order.
  * Consumed by the settings overview landing and the layout drill-in sidebar so

--- a/web/src/features/settings/index.ts
+++ b/web/src/features/settings/index.ts
@@ -1,8 +1,7 @@
 // metapi-go/features/settings — public barrel.
 //
 // Public API for the 5-subarea drill-in Settings workspace: the route files
-// and the sidebar read the subarea manifest from here, and the standalone
-// downstream-keys page lazy-loads one section.
+// and the sidebar read the subarea manifest from here.
 //
 // Cross-feature consumers import from here and not from a subdirectory: what
 // is exported below is frozen against their call sites, and what is not

--- a/web/src/features/token-routes/index.ts
+++ b/web/src/features/token-routes/index.ts
@@ -1,9 +1,14 @@
 // metapi-go/features/token-routes — public barrel.
 //
 // Consumers should import only from here:
-//   import { RoutesPage, useRoutes, type RouteSummaryRow } from '@/features/token-routes'
+//   import { useRoutes, useRebuildRoutes, routesSearchSchema } from '@/features/token-routes'
 //
-// `export type` is used for all type-only re-exports (isolatedModules-safe).
+// `RoutesPage` is deliberately not exported: `routes/_authenticated/token-routes.tsx`
+// loads it directly (route files are the composition root), so a feature that
+// only needs the contract below does not pull the page into its own chunk.
+// `RouteSummaryRow` and the other route-decision types are not here either —
+// lib helpers need them too, so they live in
+// `@/lib/helpers/token-route-contract`.
 
 export {
   routeQueryKeys,
@@ -17,9 +22,13 @@ export {
 } from './api'
 export { routesSearchSchema } from './lib/routes-schema'
 
-// Rebuild handoff: a settings section that changes model availability triggers
-// a rebuild and remembers the reference here, so the routes page can pick it up
-// after navigation instead of showing a stale table.
+// Rebuild handoff: an acknowledged rebuild stores its task reference so the
+// routes page can pick the task up after navigation instead of showing a stale
+// table. The writer is this feature's own `api.ts` (via `useRebuildRoutes`
+// above), not the section that triggered the rebuild. These two symbols are
+// published because the settings allowlist section's test asserts and resets
+// the stored reference from outside the feature; no production code outside
+// `features/token-routes` reads the raw storage key.
 export {
   ROUTE_REBUILD_STORAGE_KEY,
   rememberRouteRebuild,


### PR DESCRIPTION
## 用户任务与改动摘要

Closes #1338。把 17 个 barrel 头注释**逐个对着实测的消费者表重读**，修掉 4 处与代码相反的陈述、删掉 6 处描述已不存在符号的孤儿 doc comment，并把其中**唯一可机械判定**的那类（barrel 头里「文档化的示例 import」）变成门禁。

改动面：**8 文件 / +171−38**（6 个 `web/src` 注释文件 + `web/scripts/check-boundaries.mjs` + `docs/internal/web-package-boundaries.md`）。**无行为变化、无 `.go` 改动**，且这一点是**机械证明**的而不是声称的：

```bash
git diff master...HEAD -- web/src | grep -E '^[-+]' | grep -vE '^(\+\+\+|---)' \
  | grep -vE '^[-+]\s*(//|/\*|\*|\*/)' | grep -vE '^[-+]\s*$'   # ⇒ 空
```

即 `web/src` 里**每一条增删行都是注释行或空行** —— 不可能有运行时或类型面变化。

1. **4 处 barrel 头陈述修正**（详见下节）：`token-routes` 的示例 import · `token-routes` 的 rebuild handoff 归因 · `settings` 的 downstream-keys 子句 · `observability` 的 section 清单与消费者清单。
2. **6 处孤儿 doc comment 删除**：`models/api.ts` ×2、`models/types.ts` ×1、`settings/config/settings-config.ts` ×3。**删而不是猜一个符号挂上去** —— 每个文件的真实导出列表就在下面几行。
3. **新门禁**：barrel 头注释里的示例 import 所点名的每个符号，必须真的在该 barrel 的导出集里。

## 复现、根因与同类影响

**根因**：注释是唯一不会被编译器、类型检查器或测试碰到的地方。barrel 头恰恰是「告诉贡献者怎么消费这个 feature」的那一行，所以它错的时候比没有更糟 —— `token-routes` 的示例 import 写着 `RoutesPage` 和 `type RouteSummaryRow`，而该 barrel **两个都不导出**（page 由 route 文件直连，这正是没有任何 barrel 再导出 page 的原因；`RouteSummaryRow` 因为 lib helper 也要用，住在 `lib/helpers/token-route-contract.ts`）。照文档抄 ⇒ 编译不过。

**四处逐条取证**：

| 文件 | 原陈述 | 实测 |
|---|---|---|
| `token-routes/index.ts:4` | `import { RoutesPage, useRoutes, type RouteSummaryRow } from '@/features/token-routes'` | barrel 只导出三者中的 `useRoutes`。改为真实示例 + 明说那两个符号在哪 |
| `token-routes/index.ts:21-23` | 「a settings section … **remembers the reference here**」 | `rememberRouteRebuild` 的调用点只有本 feature 的 `api.ts:471` 与 `lib/use-route-rebuild-task.ts:130`；settings section 调的是 `useRebuildRoutes`，从不碰 reference 模块。这两个符号被公开是因为 settings allowlist 的**测试**要从 feature 外断言并复位存储的 reference —— 真消费者，但不是注释描述的那个写入方 |
| `settings/index.ts:3-5` | 「the standalone downstream-keys page **lazy-loads one section**」 | #1337 之后为假：`grep -rn "@/features/settings" src/features/downstream-keys/` = **0 命中**。**这条是让它变假的那次合入一小时后才发现的** —— 这正是本 PR 的意义：这类陈述不会随时间自己变准 |
| `observability/index.ts:3-4` | 「Observability workspace (**Overview / Health / Proxy Logs**)」+ 消费者「route file, sidebar, drill-in registry」 | `OBSERVABILITY_SECTIONS` = `[overview, health]`；proxy logs 是 `/proxy-logs` 上**另一个** workspace，本 feature 的 sidebar view 只是深链出去（`config/observability-nav.ts:38-41` 自己的注释就这么写）。消费者实测是**两个 route 文件**（一个载 page + section-id 类型 + search schema，一个从 composition root 注册 `OBSERVABILITY_VIEW`） |

**核过为真、保留不动**：dashboard 确实是 4 个 section（`dashboard-config.ts` 恰好 4 个 `id:`）· settings 确实是 5 个 subarea（`SETTINGS_SUBAREAS` 恰好 5 项）。

**同类影响（孤儿 doc comment，已系统扫过）**：扫法是「block comment 结束后紧跟空行」（13 个候选），逐个读上下文排除 7 个假阳性（`src/lib/api/*.ts`、`src/lib/auth-session.ts` 的文件头 JSDoc 后面本来就是空行 + import；`src/lib/breakpoints.ts:29-35` 的 `/* … */` 记的是一个**产品决策**而不是某个符号）。真阳性 6 处：模型能力摘要解析器、能力 facet 收集器、派生能力视图类型（三个都已不存在），以及 `settings-config.ts` 里**两遍** `/** Stable id list for route validation. */`（该文件只导出 4 个函数，没有任何 id list）+ 一遍与下方真 JSDoc 近乎重复的「All 5 settings subareas」。

**为什么值得机械化（而不是只改一遍散文）**：#1336 已经修过 8 处 barrel 头的不实陈述，本轮又找到 4 处，其中 1 处是**本轮上一次合入自己造成的** ⇒ 这个类的失效率不是「历史遗留」而是「持续产生」。散文规则里**只有示例 import 这一条能被机器判定**（其余「谁在消费」「为什么 page 不在这里」只能靠 review），所以就机械化这一条，其余明确写成 review-only（`docs/internal/web-package-boundaries.md` 的 Gate mechanics 已如此说明）。按 `check-boundaries.mjs` 头部自己的要求「widening the gate needs its own issue」，**先开 #1338 再做**。

**门禁实现要点**：先把头注释的行拼接再匹配（示例可以跨多行，`downstream-keys` 就有一个），解析 specifier 定位到目标 barrel，逐个符号比对导出集。导出集 = `export { … }` 列表 + barrel 自己的声明；**括号体内的行注释必须先剥掉再按逗号切** —— 括号内的注释可以含逗号，而 `token-routes` 正是用这种注释解释 `useRoutes` 为什么共享；本检查的第一版就是在这里把注释后面的符号吞掉了（当场被自己的门禁逮到）。**找不到任何示例即判 vacuous FAIL**（那是匹配失效，不是树变干净）。今天：3 个示例 / 6 个符号。

## 验证证据

- 最终源码：PR head `cf7b49d05286a7aca3d11d8530df0f392eba0331`；`git status` clean，无未提交差异。
- 门禁（本机 Linux 2C/4G，node v22.14.0，vitest **5.0.0** == `bun.lock`；`package.json`/`bun.lock` 未改）：
  - `node scripts/check-boundaries.mjs` rc=0 ⇒ `693 files / 0 cross-layer edge / 1 barrel rule held by 17 consumers / 0 deep import / features: 48 barrel edge / 0 deep / **0 feature exception** / **0 registered exception** / **6 barrel doc-example symbol(s) resolved**`
  - `bun run lint` rc=0（oxlint 0 error、既有 warning 无新增；FormControl **140 sites / 0 exception**）· `format:check` rc=0（**736** files）· `knip` rc=0
  - `bun run test --maxWorkers=1` ⇒ `routes:verify` **28/28**；**265 files / 1724 tests passed，`test_rc=0`**（与 #1337 合入后的基线**逐数字相同** ⇒ 一行测试未改、一个用例未动）
  - `go test ./docs/...` **ok / rc=0**（markdown 卫生 + 相对链接可解析 + 内部计划代号门禁；本轮改了 1 个 `docs/**.md`）· `go build ./cmd/server` rc=0 · `.go` 改动 = **0**
- **变异验红（两向，都先红后绿）**：① 把 `downstream-keys/index.ts` 头注释示例里的 `downstreamKeysQueryKeys` 改成 `downstreamKeysQueryKeyz` ⇒ rc=1，报 `✗ barrel doc example does not resolve: features/downstream-keys/index.ts` + `documents 'downstreamKeysQueryKeyz', which src/features/downstream-keys/index.ts does not export.`；② 把 `DOC_EXAMPLE_RES` 换成永不匹配的正则 ⇒ **不是静默通过**，而是 `✗ barrel doc-example check would pass vacuously`。两次都精确还原后 rc=0（计数回到 6）。
- Go 产品门禁：**不适用**（无 `.go`/`go.mod`/workflow 改动），CI 复跑作终审。
- 真实模型中继 / 下游客户端 E2E：**不适用**（无运行时行为改动：全部是注释、一个门禁脚本、一份 boundaries 文档）。
- 未验证项与剩余风险：① 本机 `tsgo -b` 结构性 OOM ⇒ 类型面交 CI `frontend` 终审，但本 PR **不含任何类型或运行时代码改动**（6 个 `web/src` 文件只删/改注释），类型风险实际为零；② 视觉面同理（class 串与 JSX 一行未动），CI `visual-regression` + `ui-screenshots` + `a11y` 作机械确认；③ 门禁脚本本身在 oxlint 的 `ignorePatterns`（`scripts`）里，**没有 lint 覆盖**（既有状况，非本 PR 引入），所以它的正确性靠上面两向变异而不是靠 lint。

## 自查

- [x] 无凭据、私有主机、内部路径或用户敏感数据泄漏（`leak_guard.py --range master..HEAD` RC=0）
- [x] 行为变化已更新必要测试与现役文档（**无行为变化**；`docs/internal/web-package-boundaries.md` 的 Gate mechanics 补上这条检查的语义与 vacuity 行为、Precedent log 记本轮；#1338 由本 PR 关闭）
- [x] 用户可见文案已走 i18n（不适用：无 UI 文案改动，i18n 键与译文未动）
