### PR TITLE
docs(web): make the settings and dashboard design comments match the tree

### DIFF
--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -592,6 +592,38 @@ var programmeCodeRE = regexp.MustCompile(strings.Join([]string{
 	`\b\d+-report §`,
 }, "|"))
 
+// webPhaseRE matches a delivery-phase label ("Phase 3", "phase 2", "phase-1")
+// in web product sources. It is narrower than programmeCodeRE and scoped to one
+// subtree, for two measured reasons:
+//
+//   - `Phase \d` stays legal in the Go e2e tests, where it labels steps inside a
+//     single file (`Phase 1: Setup`). A component or a type declaration has no
+//     steps to label, so the same shape in a web product source is always a
+//     stale plan label. Web test files keep the exemption for the same reason
+//     the Go side has it.
+//   - `phase` without a digit is a live product identifier: model-verify-dialog
+//     and site-probe-panel both drive a `phase` state machine (`RunPhase`,
+//     `setPhase`, `phase === 'running'`). Only the digit form may match.
+//
+// Both halves are pinned by TestProgrammeCodeGateRegexpSanity.
+var webPhaseRE = regexp.MustCompile(`\b[Pp]hase[ -]\d`)
+
+// isWebProductSource reports whether rel is a hand-authored web source file
+// that is not a test — the scope webPhaseRE applies to.
+func isWebProductSource(rel string) bool {
+	if !strings.HasPrefix(rel, "web/src/") {
+		return false
+	}
+	switch {
+	case strings.Contains(rel, "/__tests__/"):
+		return false
+	case strings.HasSuffix(rel, ".test.ts"), strings.HasSuffix(rel, ".test.tsx"),
+		strings.HasSuffix(rel, ".spec.ts"), strings.HasSuffix(rel, ".spec.tsx"):
+		return false
+	}
+	return true
+}
+
 // hygieneSourceExt lists the extensions whose text is authored by hand and can
 // therefore carry a programme code. "" covers extension-less files that are
 // still prose-bearing (.gitignore, Makefile, Dockerfile, LICENSE).
@@ -605,6 +637,7 @@ func TestNoInternalProgrammeCodesInShippedSources(t *testing.T) {
 	root := repoRoot(t)
 	var findings []string
 	scanned := 0
+	webScopedScanned := 0
 
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
@@ -638,10 +671,18 @@ func TestNoInternalProgrammeCodesInShippedSources(t *testing.T) {
 		}
 		scanned++
 		rel := filepath.ToSlash(mustRel(t, root, path))
+		webScoped := isWebProductSource(rel)
+		if webScoped {
+			webScopedScanned++
+		}
 		for i, line := range strings.Split(string(data), "\n") {
 			if programmeCodeRE.MatchString(line) {
 				findings = append(findings, formatFinding(rel, i+1,
 					"internal programme code: state what the code does, not which plan asked for it", line))
+			}
+			if webScoped && webPhaseRE.MatchString(line) {
+				findings = append(findings, formatFinding(rel, i+1,
+					"delivery-phase label in a web product source: state what the code does, not which phase shipped it", line))
 			}
 		}
 		return nil
@@ -655,6 +696,12 @@ func TestNoInternalProgrammeCodesInShippedSources(t *testing.T) {
 	// silence, so the scan itself is asserted to be non-empty.
 	if scanned == 0 {
 		t.Fatal("gate would pass vacuously: no source files were scanned")
+	}
+	// The phase arm is path-scoped, so it can go quiet on its own: if web/src
+	// moves or isWebProductSource stops matching, the arm covers nothing while
+	// the walk still reports files scanned.
+	if webScopedScanned == 0 {
+		t.Fatal("gate would pass vacuously: no web/src product sources were in scope for the phase-label rule")
 	}
 	if len(findings) > 0 {
 		t.Fatalf("internal programme codes in the published tree (%d files scanned):\n%s",
@@ -707,6 +754,59 @@ func TestProgrammeCodeGateRegexpSanity(t *testing.T) {
 	for _, sample := range mustNotMatch {
 		if programmeCodeRE.MatchString(sample) {
 			t.Errorf("gate fired on product text it must leave alone: %q", sample)
+		}
+	}
+
+	phaseMustMatch := []string{
+		"// Phase 3: wires api.getDashboardSnapshot() for the live stat numbers",
+		"/** Optional lucide icon for the sidebar (phase 2 may leave unset). */",
+		"// (`/dashboard/overview`), replacing the phase-1 stub.",
+		"// Skeleton: 2 languages. Phase 4 will add fr/ru/ja/vi/zhTW.",
+	}
+	for _, sample := range phaseMustMatch {
+		if !webPhaseRE.MatchString(sample) {
+			t.Errorf("phase gate missed a delivery-phase label it exists to catch: %q", sample)
+		}
+	}
+	phaseMustNotMatch := []string{
+		"const [phase, setPhase] = useState<'idle' | 'running' | 'done' | 'error'>(",
+		"{phase === 'running' && <Spinner />}",
+		"type RunPhase = 'idle' | 'running' | 'stopped' | 'error'",
+		"// from the idle phase instead of showing the previous run.",
+		"// `gaveUp` only marks the slow-retry phase for the UI",
+		"// phased rollout of a feature flag", // no digit: ordinary prose
+	}
+	for _, sample := range phaseMustNotMatch {
+		if webPhaseRE.MatchString(sample) {
+			t.Errorf("phase gate fired on a product identifier it must leave alone: %q", sample)
+		}
+	}
+
+	// The scope predicate is what keeps `Phase 1: Setup` legal in an e2e test
+	// and illegal in a component, so it is pinned directly rather than through
+	// the regex.
+	inScope := []string{
+		"web/src/features/settings/types.ts",
+		"web/src/features/dashboard/sections/overview/overview-section.tsx",
+		"web/src/i18n/languages.ts",
+		"web/src/routes/_authenticated/index.tsx",
+	}
+	for _, rel := range inScope {
+		if !isWebProductSource(rel) {
+			t.Errorf("phase gate scope missed a web product source: %q", rel)
+		}
+	}
+	outOfScope := []string{
+		"web/src/features/downstream-keys/components/__tests__/keys-section.test.tsx",
+		"web/src/lib/format.test.ts",
+		"web/scripts/check-boundaries.mjs",
+		"e2e/e2e_flow_test.go",
+		"docs/testing.md",
+		"handler/admin/accounts_test.go",
+	}
+	for _, rel := range outOfScope {
+		if isWebProductSource(rel) {
+			t.Errorf("phase gate scope claimed a file it must leave alone: %q", rel)
 		}
 	}
 }

--- a/web/src/components/layout/config/system-settings.config.ts
+++ b/web/src/components/layout/config/system-settings.config.ts
@@ -1,8 +1,8 @@
 // metapi-go/layout — the Settings drill-in view: its back target and its
 // navigation groups.
 //
-// Settings is five subareas (general / downstream / models / content /
-// system-info), each rendered as a `NavCollapsible` whose sub-items are that
+// Settings is five subareas (basic / proxy-models / downstream / content /
+// operations), each rendered as a `NavCollapsible` whose sub-items are that
 // subarea's sections, read from the shared section-registry manifest so a
 // section added by a feature appears in the sidebar without an edit here.
 //

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -4,10 +4,10 @@
 // success rate / today's proxy requests) + AnnouncementBanner. The legacy
 // SchedulerStatusPanel is merged in here (a compact scheduled-tasks card).
 //
-// Phase 3: wires api.getDashboardSnapshot() (view=summary) for the live stat
-// numbers, api.getBalanceHistory(0, 8) for the account sparkline (aggregate
-// balance over the last 8 captured points), and api.getSchedulerStatus() for
-// the scheduled-tasks table.
+// Wires api.getDashboardSnapshot() (view=summary) for the live stat numbers,
+// api.getBalanceHistory(0, 8) for the account sparkline (aggregate balance over
+// the last 8 captured points), and api.getSchedulerStatus() for the
+// scheduled-tasks table.
 
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { Link, type LinkProps } from '@tanstack/react-router'

--- a/web/src/features/dashboard/types.ts
+++ b/web/src/features/dashboard/types.ts
@@ -1,9 +1,10 @@
 // metapi-go/features/dashboard — shared types for the 4-section Dashboard
 // workspace. The dashboard is split into overview / traffic /
 // models / availability; each section owns a lazy builder (`build`) returning
-// its content ReactNode. Phase 2 ships chart wiring + stub data; phase 3
-// swaps in real API data from lib/api.ts (getDashboardSnapshot /
-// getBalanceIncomeOutcome / getSiteTrend / getActiveAnnouncements etc.).
+// its content ReactNode and fetches through TanStack Query over the
+// stats/dashboard API surface (`src/lib/api/stats.ts`: getDashboardSnapshot,
+// getBalanceIncomeOutcome, getBalanceHistory, getSiteTrend,
+// getActiveAnnouncements).
 
 import type { ReactNode } from 'react'
 

--- a/web/src/features/settings/sections/basic/components/authentication-section.tsx
+++ b/web/src/features/settings/sections/basic/components/authentication-section.tsx
@@ -44,8 +44,8 @@ import {
   type RuntimeSettings,
 } from '../../../lib/runtime-settings'
 
-const ALLOWLIST_FORM_ID = 'settings-general-auth-allowlist-form'
-const TOKEN_FORM_ID = 'settings-general-auth-token-form'
+const ALLOWLIST_FORM_ID = 'settings-basic-auth-allowlist-form'
+const TOKEN_FORM_ID = 'settings-basic-auth-token-form'
 
 const tokenSchema = z
   .object({

--- a/web/src/features/settings/sections/basic/components/site-section.tsx
+++ b/web/src/features/settings/sections/basic/components/site-section.tsx
@@ -40,7 +40,7 @@ import {
   type RuntimeSettings,
 } from '../../../lib/runtime-settings'
 
-const FORM_ID = 'settings-general-site-form'
+const FORM_ID = 'settings-basic-site-form'
 
 const siteSchema = z.object({
   systemName: z.string().optional(),

--- a/web/src/features/settings/sections/operations/components/database-section.tsx
+++ b/web/src/features/settings/sections/operations/components/database-section.tsx
@@ -47,7 +47,7 @@ import {
   type RuntimeDatabaseConfig,
 } from './database-shared'
 
-const SAVE_FORM_ID = 'settings-system-info-database-form'
+const SAVE_FORM_ID = 'settings-operations-database-form'
 
 const databaseSchema = z.object({
   dialect: z.enum(['sqlite', 'postgres']),

--- a/web/src/features/settings/sections/operations/components/scheduling-section.tsx
+++ b/web/src/features/settings/sections/operations/components/scheduling-section.tsx
@@ -56,7 +56,7 @@ import {
   specToLegacyMode,
 } from '../../../lib/schedule'
 
-const FORM_ID = 'settings-general-scheduling-form'
+const FORM_ID = 'settings-operations-scheduling-form'
 
 const scheduleSpecSchema = z.discriminatedUnion('kind', [
   z.object({

--- a/web/src/features/settings/sections/proxy-models/components/allowlist-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/allowlist-section.tsx
@@ -48,7 +48,7 @@ import {
   type RuntimeSettings,
 } from '../../../lib/runtime-settings'
 
-const ALLOWLIST_FORM_ID = 'settings-models-allowlist-form'
+const ALLOWLIST_FORM_ID = 'settings-proxy-models-allowlist-form'
 
 const allowlistSchema = z.object({
   globalAllowedModels: z.string().optional(),

--- a/web/src/features/settings/sections/proxy-models/components/proxy-transport-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/proxy-transport-section.tsx
@@ -44,7 +44,7 @@ import {
   type RuntimeSettings,
 } from '../../../lib/runtime-settings'
 
-const FORM_ID = 'settings-general-proxy-transport-form'
+const FORM_ID = 'settings-proxy-models-proxy-transport-form'
 
 // payloadRules is a Record<string, unknown> on the wire; the textarea holds a
 // JSON string. Zod refines it to a parseable object so we can show a friendly

--- a/web/src/features/settings/sections/proxy-models/components/routing-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/routing-section.tsx
@@ -38,7 +38,7 @@ import {
   type RuntimeSettings,
 } from '../../../lib/runtime-settings'
 
-const FORM_ID = 'settings-general-routing-form'
+const FORM_ID = 'settings-proxy-models-routing-form'
 
 // Loose client-side shape guard: comma-separated codes ("401") and
 // inclusive ranges ("500-599"). Range bounds and order are validated

--- a/web/src/features/settings/types.ts
+++ b/web/src/features/settings/types.ts
@@ -1,8 +1,8 @@
 // metapi-go/features/settings — shared types for the 5-subarea drill-in
-// Settings workspace. Settings is split into general /
-// downstream / models / content / system-info; each subarea owns a
-// section-registry that drives both the in-page settings sidebar and the
-// content dispatcher (SettingsPage).
+// Settings workspace. The subareas are basic / proxy-models / downstream /
+// content / operations (`SettingsSubareaId` below, assembled by
+// config/settings-config.ts); each owns a section-registry that drives both the
+// in-page settings sidebar and the content dispatcher (SettingsPage).
 
 import type { LinkProps } from '@tanstack/react-router'
 import type { ElementType, ReactNode } from 'react'
@@ -10,9 +10,11 @@ import type { ElementType, ReactNode } from 'react'
 /**
  * A single settings section — the leaf unit of the Settings workspace.
  *
- * Each section is a lazy builder (`build`) returning its content ReactNode.
- * Phase 2 stubs return a `StubSection`; phase 3 will swap in real forms wired
- * to the runtime-settings API (`GET/PUT /api/settings/runtime`).
+ * Each section is a lazy builder (`build`) returning its content ReactNode, so
+ * a section's form and table dependencies land in their own chunk. The editable
+ * ones read and write the runtime-settings API
+ * (`GET/PUT /api/settings/runtime`) through `hooks/use-settings-form`; the
+ * read-only ones set `readonly` and get a nav badge instead of a save button.
  */
 type SettingsSection = {
   /** Stable id used in the URL (`/settings/<subarea>/<id>`). */
@@ -21,11 +23,9 @@ type SettingsSection = {
   title: string
   /** Short description shown under the page header (optional). */
   description?: string
-  /** Optional lucide icon for the sidebar (phase 2 may leave unset). */
-  icon?: ElementType
   /** Read-only / external surface (rates, audit, update center) - shown as a badge. */
   readonly?: boolean
-  /** Lazy content builder. Receives nothing in phase 2; phase 3 adds settings. */
+  /** Lazy content builder for the section body. */
   build: () => ReactNode
 }
 
@@ -60,8 +60,8 @@ type SettingsSectionNavItem = {
  *                                 maintenance, program-logs, audit-logs,
  *                                 update-center, danger-zone
  * Old URLs (`/settings/general/*`, `/settings/models/*`,
- * `/settings/system-info/*`) are redirected by the legacy route map
- * (lib/legacy-redirects.ts).
+ * `/settings/system-info/*`) are redirected by this feature's legacy route map
+ * (`./lib/legacy-redirects`).
  */
 type SettingsSubareaId =
   | 'basic'
@@ -86,7 +86,7 @@ export type SettingsSubarea = {
   description?: string
   /** Optional lucide icon shown on the settings overview + main sidebar. */
   icon?: ElementType
-  /** Base path, e.g. '/settings/general'. Section URLs become `${basePath}/${id}`. */
+  /** Base path, e.g. '/settings/basic'. Section URLs become `${basePath}/${id}`. */
   basePath: string
   /** Section navigated to when no `$section` param is present. */
   defaultSection: string

--- a/web/src/i18n/languages.ts
+++ b/web/src/i18n/languages.ts
@@ -1,5 +1,7 @@
 // metapi-go/i18n — language list + detection helpers.
-// Skeleton: 2 languages (en + zhCN). Phase 4 will add fr/ru/ja/vi/zhTW.
+// Two interface languages ship — en and zhCN (`locales/en.json`,
+// `locales/zh-CN.json`) — and `i18n/__tests__/i18n-keys.test.ts` requires their
+// key sets, and every referenced key, to exist in both.
 
 /**
  * Map a browser-detected locale onto the interface language codes this project

--- a/web/src/lib/section-registry.ts
+++ b/web/src/lib/section-registry.ts
@@ -47,7 +47,7 @@ export type SectionRegistryConfig<
 > = {
   sections: readonly TSection[]
   defaultSection: TSectionId
-  /** Base path, e.g. '/settings/general'. */
+  /** Base path, e.g. '/settings/basic'. */
   basePath: string
   /**
    * 'path' (default): section URLs are `${basePath}/${id}`.

--- a/web/src/routes/_authenticated/index.tsx
+++ b/web/src/routes/_authenticated/index.tsx
@@ -1,9 +1,8 @@
 // metapi-go/routes — authenticated index (→ dashboard).
 //
 // `/` (the authenticated root) redirects to the dashboard's default section
-// (`/dashboard/overview`), replacing the phase-1 stub. The dashboard
-// `$section` route validates the section param, so an unknown section still
-// falls back to the default.
+// (`/dashboard/overview`). The dashboard `$section` route validates the section
+// param, so an unknown section still falls back to the default.
 
 import { createFileRoute, redirect } from '@tanstack/react-router'
 


### PR DESCRIPTION
## 用户任务与改动摘要

Closes #1340。延续 #1339 的「散文必须与树一致」审计，这批落在**两个 workspace 的设计面类型文件**与一个 layout config 上：其中 **5 处不是口吻问题，是假的**。

1. **两处 subarea 清单与代码相反**：`features/settings/types.ts` 开头写「Settings is split into **general / downstream / models / content / system-info**」，而同文件 45 行之下的 `SettingsSubareaId` 是 `basic | proxy-models | downstream | content | operations`，`config/settings-config.ts` 组装的正是后五个 ⇒ **五个名字里三个是重组前的旧名**。`components/layout/config/system-settings.config.ts` 把同一份错清单又写了一遍，而它正是**从 `getSettingsSubareas()` 渲染侧栏**的那个 config。
2. **`StubSection` 不存在**：`settings/types.ts` 把 section 契约描述成「Phase 2 stubs return a `StubSection`; phase 3 will swap in real forms wired to the runtime-settings API」。`git grep StubSection` ⇒ **全树只有这条注释命中**；21 个 section 全部是跑在 `GET/PUT /api/settings/runtime` 上的真实表单。
3. **`dashboard/types.ts` 自相矛盾**：头部说「Phase 2 ships chart wiring + **stub data**; phase 3 swaps in real API data」，而同文件 20 行之下的 `DashboardSection` 文档说「fed by TanStack Query hooks over the stats/dashboard API surface」，代码里四个 section 全都在 fetch。它点名的 5 个 API 方法**确实存在**（`src/lib/api/stats.ts`）⇒ 保留接线清单、删掉 phase 框架。
4. **两处 `basePath` 示例指向已退役的 URL**：`settings/types.ts` 与通用的 `lib/section-registry.ts` 都写 `e.g. '/settings/general'`，而 `/settings/general` 是 `features/settings/lib/legacy-redirects.ts` **重定向掉**的旧地址 ⇒ 改为真实存在的 `/settings/basic`。
5. **删掉一个死类型成员 `SettingsSection.icon`**：5 个 `sections/*/section-registry.ts` 里的 `icon:` **全部是 `SettingsSubarea` 字段**，没有任何 section 设过它；读 `.icon` 的三处（`settings-overview.tsx`、`system-settings.config.ts`、`nav-group.tsx`）读的都是 subarea 或 nav item；它继承的通用 `SectionDefinition` **本来就没有这个字段**。它的 doc comment「(phase 2 may leave unset)」在「一直没人设」这个意义上是准确的。`readonly` **保留**（`section-registry.ts:109` 会把它转进 nav item）。
6. **7 个 `<form id>` 常量仍带退役 subarea 名**（`settings-general-*` ×5、`settings-system-info-database-form`、`settings-models-allowlist-form`）⇒ 改成各自真实所属的 subarea。每个只在自己文件内使用，且 `web/scripts`、`e2e/`、`scripts/` 里**没有任何按 form id 的选择器**（`getElementById` / `[form=` / `formId` 均 0 命中）。**这会改变 DOM id 的值**，所以明确写出来，不混进「只改注释」。
7. **新门禁（path-scoped）**：`Phase \d` 之所以**故意不在** `programmeCodeRE` 里，是因为 Go e2e 测试用 `Phase 1: Setup` 当**文件内步骤标签**；但这个理由**不适用于 web 产品源码**（组件和类型声明没有「步骤」可标），而 `phase` 不带数字时是活的标识符（`model-verify-dialog.tsx` 与 `site-probe-panel.tsx` 都在驱动一个 `phase` 状态机）⇒ `TestNoInternalProgrammeCodesInShippedSources` 增加一条**限定路径**的臂：`webPhaseRE`（`\b[Pp]hase[ -]\d`）只作用于 `web/src` 的**非测试**文件（`isWebProductSource`）。

改动面：**15 文件 / +137−35**（14 个 `web/src` + `docs/doc_hygiene_test.go`）。

## 复现、根因与同类影响

**根因**：设计面类型文件的头注释是**重构时最不会被顺手更新**的地方 —— 改 `SettingsSubareaId` 的人不会想到 45 行之上的散文里还有一份手写的清单；把 stub 换成真表单的人不会想到契约注释还在描述 stub。它不会被编译器、类型检查器或测试碰到，只会被下一个读者当成事实。

**改前先量了门禁的爆炸半径（这一步决定了规则能不能写）**：`web/src` 里 `phase` 一共 33 处命中，其中 **26 处是活的产品标识符**（`RunPhase`、`setPhase`、`phase === 'running'`、「the idle phase」、「slow-retry phase」），只有 **7 处**是 `\b[Pp]hase[ -]\d` 形态的交付档标签，且**7 处全部**就是本 PR 要删的那些 ⇒ 只匹配带数字的形态、且只作用于非测试产品源码，**零假阳性**。

**同类影响（已检查）**：
- Go 侧 `stub` 的 10+ 处命中**全部保留**：那里的 `stub` 是「显式未实现面返回 501 / 不伪造成功」的**诚实残差**语义（`handler/admin/update_center.go`「status is a local stub (never invent updateAvailable=true)」、`error_codes.go`「a known unimplemented feature — never a fake stub success」），与「计划里的占位实现」是两回事；`AGENTS.md` 的 Honesty 条与 `METAPI_ENABLE_PROXY_STUB` 都是这个语义。
- `docs/` 里 `Phase`/`stub` 的命中只有：`doc_hygiene_test.go` 解释**为什么** `Phase \d` 被排除（+ 它的 fixture，该文件本身就是唯一豁免且由 sanity 测试反向钉住）· `CHANGELOG.md` 的历史条目 · 两份 env 文档里的 `METAPI_ENABLE_PROXY_STUB` ⇒ 全部保留。
- **有意不做门禁**的一类：「字符串里不得出现退役 subarea 名」无法写安全 —— `models` 与 `general` 是普通英文词，而 `system-info` **合法地**出现在 legacy-redirect 映射表与一个 attention-bell 测试夹具里。手工改完，复发交 review。

## 验证证据

- 最终源码：PR head `001e61e9d5e6754e6c6f56139f176513a92b60f8`；`git status` clean。
- **issue 的 Done-when 逐条机械核**：
  - `git grep -nIE "[Pp]hase[ -][0-9]" -- web/src` ⇒ **0 命中**
  - `git grep -nI "StubSection\|settings-general-\|settings-system-info-\|settings-models-"` ⇒ **0 命中**
  - 两份 subarea 清单 == `SettingsSubareaId` == `settings-config.ts` 组装的五项（逐字比对）
- **门禁（新臂两向变异验红）**：
  - 注入 `// Phase 5: swap the dispatcher for a modal.` 到 `web/src/features/settings/types.ts` ⇒ `--- FAIL: TestNoInternalProgrammeCodesInShippedSources`，输出 `web/src/features/settings/types.ts:6: delivery-phase label in a web product source: state what the code does, not which phase shipped it`；精确还原后 ok。
  - 注入 `// Phase 1: Setup — mocks and query client.` 到 `web/src/features/downstream-keys/components/__tests__/keys-section.test.tsx` ⇒ **ok**（这正是 `isWebProductSource` 存在要保住的豁免；只验红不验绿就等于没验作用域）。
  - **改前的红是真实的**：只加门禁不改代码时，它精确点出上面 7 处（1795 文件扫描，无第 8 处）⇒ 规则不是为空树写的。
  - sanity 测试双向扩充：`webPhaseRE` 正样本 4 条（含 `phase-1` 连字符形态与 `phase 2 may leave unset` 的小写形态）、负样本 6 条（`useState<'idle' | 'running' …>`、`{phase === 'running' && <Spinner />}`、`type RunPhase = …`、「the idle phase」、「slow-retry phase」、「phased rollout」）；**作用域谓词本身**也被钉住（4 个必须在内 / 6 个必须在外，含 `web/scripts/check-boundaries.mjs`、`e2e/e2e_flow_test.go`、`docs/testing.md`）。
  - **vacuity 守卫**：`webScopedScanned == 0` 即 FAIL ⇒ `web/src` 挪位或谓词失配不会让这条臂静默失效（与本文件其它门禁同一不变式）。
- 本机门禁（Linux 2C/4G，node v22.14.0，vitest **5.0.0** == `bun.lock`；`package.json`/`bun.lock` 未改）：
  - `go test ./docs/...` **ok**（含 `-race`）· `go vet ./docs/...` rc=0 · `go build ./cmd/server` rc=0 · `gofmt -l docs/doc_hygiene_test.go` **空**
  - `bun run lint` rc=0（oxlint 0 error、既有 warning 无新增；boundaries `693 files / 0 cross-layer / 0 deep import / features: 48 barrel edge / 0 deep / 0 feature exception / 0 registered exception / 6 barrel doc-example symbol resolved`；FormControl **140 sites / 0 exception**）
  - `format:check` rc=0（**736** files）· `knip` rc=0（删掉 `SettingsSection.icon` 后无新的未用导出）
  - `bun run test --maxWorkers=1` ⇒ `routes:verify` **28/28**；**265 files / 1724 tests passed，`test_rc=0`**（与基线逐数字相同 ⇒ 一行测试未改）（**一行测试未改**；唯一 `.go` 改动是 `docs/doc_hygiene_test.go`）
- Go 全量 race / `go vet ./...`：本 PR 的 `.go` 改动只有 `docs/doc_hygiene_test.go`（**纯测试文件，所在包无产品代码**）⇒ 全仓 race 不可能受影响；已跑 `go vet ./docs/...` + `go test ./docs/... -race`，全量 `vet` 与 `test-pg`/`test-sqlite` 4 shard 交 CI（每轮均绿）。
- 真实模型中继 / 下游客户端 E2E：**不适用**（无运行时行为改动；DOM form id 的**值**变了，但全仓无按 id 的选择器，且 `formId`/`id` 配对在各自文件内同步改名）。
- 未验证项与剩余风险：① 本机 `tsgo -b` 结构性 OOM ⇒ 类型面交 CI `frontend` 终审；本 PR 删了一个类型成员（`SettingsSection.icon`），**若有测试夹具以对象字面量构造 `SettingsSection` 并带 `icon`，会因 excess-property 检查失败** —— 已核 `settings-page-header.test.tsx` 的夹具不含 `icon`，且全量 vitest 本地绿，但仍以 CI 为准；② 视觉面：7 个 form id 是属性值不是文案，`visual-regression` + `ui-screenshots` + `a11y` 作机械确认（a11y 尤其相关：`formId` 与 `<form id>` 的配对若断掉，提交按钮的可及名会变）。

## 自查

- [x] 无凭据、私有主机、内部路径或用户敏感数据泄漏（`leak_guard.py --range master..HEAD` RC=0）
- [x] 行为变化已更新必要测试与现役文档（无行为变化；门禁与其 sanity 样本同 PR 落地；#1340 由本 PR 关闭）
- [x] 用户可见文案已走 i18n（不适用：无 UI 文案改动，i18n 键与译文未动）
