### PR TITLE
docs: repair the mangled DESIGN.md tables and gate markdown table shape

### DIFF
--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -709,6 +709,148 @@ func TestNoInternalProgrammeCodesInShippedSources(t *testing.T) {
 	}
 }
 
+// markdownTableCells counts the pipe characters of a table row that act as cell
+// separators, treating `\|` as content. The leading and trailing pipes are
+// counted too, so a two-column row ("| a | b |") reports 3 — only equality
+// between a row and its header matters, not the absolute number.
+func markdownTableCells(line string) int {
+	n := 0
+	for i := 0; i < len(line); i++ {
+		if line[i] == '|' && (i == 0 || line[i-1] != '\\') {
+			n++
+		}
+	}
+	return n
+}
+
+// isMarkdownTableSeparator reports whether the row is the `| --- | :-: |` line
+// between a header and its body. It carries no content, so its cell count is
+// not compared.
+func isMarkdownTableSeparator(line string) bool {
+	if !strings.Contains(line, "-") {
+		return false
+	}
+	for _, r := range line {
+		switch r {
+		case '|', '-', ':', ' ', '\t':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// TestMarkdownTablesAreWellFormed proves every markdown table in the published
+// tree renders as the table its author wrote. A `|` inside an inline code span
+// still splits the cell unless it is escaped, so a row documenting a set of
+// alternatives ("none | sm | md") or a CSS selector (`:root[lang|='zh']`)
+// silently turns one cell into several. DESIGN.md §2.1 shipped that way: five
+// of its six body rows were split — one into seven columns — and the
+// pipe-splitting had eaten the surrounding whitespace as well, so the rendered
+// prose read "set byThemeProviderand the FOUC bootstrap".
+//
+// Column padding is deliberately not checked: the tree is not formatter-managed
+// and ragged source renders identically.
+func TestMarkdownTablesAreWellFormed(t *testing.T) {
+	root := repoRoot(t)
+	var findings []string
+	tables := 0
+	bodyRows := 0
+
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if skipHygieneDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".md" || hygieneSkipFile(entry.Name()) {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel := filepath.ToSlash(mustRel(t, root, path))
+		header := -1
+		for i, raw := range strings.Split(string(data), "\n") {
+			line := strings.TrimSpace(raw)
+			if !strings.HasPrefix(line, "|") || !strings.HasSuffix(line, "|") {
+				header = -1 // a blank or non-table line closes the current table
+				continue
+			}
+			if isMarkdownTableSeparator(line) {
+				continue
+			}
+			cells := markdownTableCells(line)
+			if header < 0 {
+				header = cells
+				tables++
+				continue
+			}
+			bodyRows++
+			if cells != header {
+				findings = append(findings, formatFinding(rel, i+1,
+					"markdown table row has "+itoa(cells)+" cell separators but its header has "+itoa(header)+
+						": an unescaped | inside a code span splits the cell, so write \\| (or list the values without pipes)",
+					line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same invariant as every other gate in this file: a check that scans
+	// nothing and reports nothing is absent, not lenient. Both counters are
+	// asserted, because a tree of header-only tables would satisfy `tables`.
+	if tables == 0 || bodyRows == 0 {
+		t.Fatalf("gate would pass vacuously: found %d table(s) and %d body row(s) in the published markdown",
+			tables, bodyRows)
+	}
+	if len(findings) > 0 {
+		t.Fatalf("malformed markdown tables in the published tree (%d tables / %d body rows scanned):\n%s",
+			tables, bodyRows, strings.Join(findings, "\n"))
+	}
+}
+
+// TestMarkdownTableGateHelpers pins the one subtlety the gate lives or dies on:
+// `\|` is content and a bare `|` is a separator, even inside a code span.
+func TestMarkdownTableGateHelpers(t *testing.T) {
+	cellCounts := []struct {
+		line string
+		want int
+	}{
+		{"| a | b |", 3},
+		{"| `<body data-theme-radius=\"none|sm|md\">` | x |", 5}, // unescaped: splits
+		{"| `:root[lang\\|='zh']` | x |", 3},                     // escaped: does not
+		{"| --- | :-: |", 3},
+	}
+	for _, tc := range cellCounts {
+		if got := markdownTableCells(tc.line); got != tc.want {
+			t.Errorf("markdownTableCells(%q) = %d, want %d", tc.line, got, tc.want)
+		}
+	}
+	separators := []struct {
+		line string
+		want bool
+	}{
+		{"| --- | --- |", true},
+		{"|:---|---:|", true},
+		{"| :-: | --- |", true},
+		{"| a | b |", false},
+		{"| --- | b |", false}, // contains a dash but also content
+	}
+	for _, tc := range separators {
+		if got := isMarkdownTableSeparator(tc.line); got != tc.want {
+			t.Errorf("isMarkdownTableSeparator(%q) = %v, want %v", tc.line, got, tc.want)
+		}
+	}
+}
+
 // TestProgrammeCodeGateRegexpSanity proves the gate above can actually fire and
 // that its near-misses stay quiet. A hygiene pattern that matches nothing is
 // indistinguishable from a clean tree; a pattern that matches product strings

--- a/docs/internal/design/BACKEND.md
+++ b/docs/internal/design/BACKEND.md
@@ -1,6 +1,6 @@
 # Backend Design Philosophy
 
-**Last updated**: 2026-09-04
+**Last updated**: 2026-09-12
 
 **Status**: contributor principles — how backend code should be written
 **Not the authority on import edges**: the boundary contract is
@@ -65,6 +65,7 @@ Rules of thumb:
 
 - Configuration is environment-driven (`config.Load` / `config.Get`).
 - Env var names match TS Metapi **without** a `METAPI_` (or similar) prefix: e.g. `AUTH_TOKEN`, `PROXY_TOKEN`, `DB_TYPE`, `DB_URL`, `PORT`.
+- A Go-only knob with no TS counterpart carries the `METAPI_` prefix **precisely so it cannot be mistaken for a parity name** (`METAPI_DB_PROFILE`, `METAPI_DB_APPLICATION_NAME`, `METAPI_ENABLE_PROXY_STUB`). `REDIS_URL` additionally accepts `METAPI_REDIS_URL` as an alias (`config/config.go`: `firstNonEmpty(get("REDIS_URL"), get("METAPI_REDIS_URL"))`).
 - Defaults live in `config`; production unsafety (default tokens, weak secrets) is warned/validated, not silently accepted as secure.
 - Runtime settings that belong in DB stay in `store` settings; do not invent a second config language.
 
@@ -102,7 +103,7 @@ Rules of thumb:
         │                       │                    │                 │
         │                    service ───────────────┘ (prefer not;     │
         │                       ▲                     transform is     │
-        │                       │                     leaf for now)    │
+        │                       │                     leaf today)      │
         │                  scheduler                                   │
         │                       ▲                                      │
         │                       │                                      │
@@ -121,7 +122,7 @@ Arrows mean **“may import”**. Edges not shown are forbidden unless listed un
 The diagram above is the *intent* — which direction is down. The contract is
 [`docs/architecture.md`](../../architecture.md) §"Ownership and boundary map": one row per
 package, the decision it owns, and what it must not import. Its executable form is
-[`docs/package_boundary_test.go`](../../package_boundary_test.go) — rules 1–8, every approved
+[`docs/package_boundary_test.go`](../../package_boundary_test.go) — rules 1–9, every approved
 exception with the reason it is approved, and an assertion that all twelve
 domains were really scanned, because a boundary gate that scans nothing and reports no
 violations is not a lenient gate but an absent one. That is not a hypothetical: it is the shape
@@ -210,5 +211,5 @@ Only `cmd/server` (and tests/e2e helpers) should construct the full graph: load 
 - [ ] Auth path fail-closed
 - [ ] Channel failure isolated (cooldown/breaker/failover) when touching routing/proxy
 - [ ] Dialect-safe SQL via `store`
-- [ ] Env names match TS, no new prefix scheme
+- [ ] Env names match TS for parity vars; a Go-only knob uses a `METAPI_` prefix so it cannot read as a parity name (§1.6)
 - [ ] Tests with `-race` for concurrent paths

--- a/docs/internal/design/DESIGN.md
+++ b/docs/internal/design/DESIGN.md
@@ -4,7 +4,7 @@
 **Scope**: Enterprise ops control plane (sites, accounts, tokens, routes, monitors, logs)
 **Visual language**: GCP cloud console density + frosted glass shell + Apple detail
 **Source of truth**: this document + `web/src/styles/theme.css` + `web/src/styles/theme-presets.css` + `web/src/lib/theme-customization.ts` + `web/src/components/ui/**`
-**Last updated**: 2026-09-08
+**Last updated**: 2026-09-12
 
 ---
 
@@ -28,7 +28,7 @@
 3. **Dual theme parity** — light and dark share the same semantic token names (`.dark` class on `<html>`).
 4. **Dense but breathing** — 14px body text by default, component-owned secondary text, clear table rhythm, and semibold page titles. The compact density axis scales text separately.
 5. **One glass system** — shell/modal/dropdown only; never blur table rows.
-6. **Progressive adoption** — primitives in `web/src/components/ui/**`; migrate pages gradually.
+6. **One primitive set** — UI starts from `web/src/components/ui/**` and nothing hand-rolls a parallel control. This used to be a migration in progress; it is now gated — `web/scripts/check-form-control.mjs` classifies every `<FormControl>` site and fails on a native control or on a shape it cannot read.
 7. **Console, not marketing** — pill nav, tabular nums, restrained card hover (no lift).
 8. **No gradients** — backgrounds, masks, charts, swatches, fallback avatars, and brand assets use solid colors only.
 
@@ -40,14 +40,14 @@ All values live in `web/src/styles/theme.css` under `:root` (light) and `.dark` 
 
 ### 2.1 Theme architecture
 
-| Layer        | Mechanism                                                                                                                                                                         |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Theme mode   | `<html class="dark                                                                                                                                                                | light">`(plus`data-theme`attr for compat) set by`ThemeProvider`and the FOUC bootstrap in`web/index.html`; cookie `vite-ui-theme`(1y), falls back to`prefers-color-scheme` |
+| Layer | Mechanism |
+| ----- | --------- |
+| Theme mode   | `<html>` carries `class="dark"` or `class="light"` plus a `data-theme` attribute (compat), set by `ThemeProvider` and the FOUC bootstrap in `web/index.html`; persisted in the `vite-ui-theme` cookie (1y) and falling back to `prefers-color-scheme` |
 | Preset       | `<body data-theme-preset>` — 10 shipped presets: default, anthropic, simple-large, underground, rose-garden, lake-view, sunset-glow, forest-whisper, ocean-breeze, lavender-dream |
-| Font axis    | `<body data-theme-font="sans                                                                                                                                                      | serif">`— swaps`--font-body`                                                                                                                                              |
-| Radius axis  | `<body data-theme-radius="none                                                                                                                                                    | sm                                                                                                                                                                        | md                                      | lg  | xl">`— overrides`--radius` |
-| Density axis | `<body data-theme-scale="sm                                                                                                                                                       | lg                                                                                                                                                                        | xl">`— rescales`--text-*`and`--spacing` |
-| Content axis | `<body data-theme-content-layout="full                                                                                                                                            | centered">`                                                                                                                                                               |
+| Font axis    | `<body data-theme-font>` — `sans` or `serif` (the `default` setting resolves to `sans`, see `public/theme-init.js`); swaps `--font-body` |
+| Radius axis  | `<body data-theme-radius>` — `default`, `none`, `sm`, `md`, `lg`, `xl`; overrides `--radius` |
+| Density axis | `<body data-theme-scale>` — `default`, `sm`, `lg`, `xl`; rescales `--text-*` and `--spacing` |
+| Content axis | `<body data-theme-content-layout>` — `full` or `centered` |
 
 Constants (allowed values, defaults, cookies `theme_preset` / `theme_font` / `theme_radius` / `theme_scale` / `theme_content_layout`): `web/src/lib/theme-customization.ts`.
 
@@ -78,7 +78,7 @@ Each maps a Tailwind alias `--color-*` (e.g. `--color-background: var(--backgrou
 | `--neutral`                                            | `oklch(0.708 0 0)`                                           | `oklch(0.76 0 0)`                                            | Cool gray secondary                 |
 | `--sidebar` / `--sidebar-primary` / `--sidebar-accent` | derived from background/primary                              | derived from background/primary                              | Sidebar canvas, brand, active tones |
 
-Presets replace `--primary`/`--background` per `data-theme-preset` (e.g. Anthropic clay `oklch(0.57 0.15 38)` on cream `oklch(0.984 0.005 95)`).
+Presets replace `--primary`/`--background` per `data-theme-preset` (e.g. Anthropic clay `oklch(0.57 0.15 38)` on cream `oklch(0.984 0.004 95)`).
 
 ### 2.4 Status semantics
 
@@ -120,10 +120,10 @@ Fallback: `supports-[backdrop-filter]` gates translucency so browsers without `b
 | Spacing          | Tailwind 4 scale — base `--spacing` (default 0.25rem; `data-theme-scale` overrides 0.225 / 0.28 / 0.3rem)                                                                                                                                                                                                                                           | `gap-*`, `p-*`, `m-*`, `space-y-*`; no custom `--space-*`                                                                                                                                        |
 | Radius           | `--radius: 0.625rem` (10px default) with `--radius-sm/md/lg/xl/2xl/3xl/4xl` derived; `data-theme-radius` overrides `--radius` (none 0 · sm 0.3 · md 0.5 · lg 0.75 · xl 1rem)                                                                                                                                                                                 | Controls/buttons `rounded-lg`; cards/sheets `rounded-xl`+                                                                                                                                        |
 | Shadow           | Tailwind default `shadow-*` + custom `--shadow-card-hover` (`0 4px 12px …`)                                                                                                                                                                                                                                                                         | Hover elevation on cards (`[data-card-hover]`); no lift on plain rows                                                                                                                            |
-| Motion           | `tw-animate-css` utilities (`animate-in/out`, `fade-in-*`, `zoom-in-*`) + keyframes in `styles/index.css` (table row stagger, landing, terminal demo)                                                                                                                                                                                               | Calm; every animation guarded by `prefers-reduced-motion`                                                                                                                                        |
-| Type             | `--font-sans` Public Sans Variable (Latin) + bundled Noto Sans SC Variable (CJK, unicode-range slices; platform CJK faces stay behind it as fetch-failure insurance) · `--font-serif` Lora Variable + CJK serif fallbacks (no bundled CJK serif — a second 4.3 MiB face for an opt-in axis did not survive the size decision) · `--font-mono` Cascadia/SFMono/Consolas · `--font-body` active face · `:root[lang|='zh']` zeroes `--tracking-tight` and the editorial tracking tokens (negative tracking is a Latin display convention; ideographs keep their side bearing)                                                                                                                     | `data-theme-font` swaps the body face; density axis rescales `--text-xs…3xl`; visible axis tick labels and body text minimum 10px — 9px only allowed for decorative labels with a `title`/`aria-label` fallback |
+| Motion           | `tw-animate-css` utilities (`animate-in/out`, `fade-in-*`, `zoom-in-*`) + the keyframes actually defined in `styles/index.css` (`tableRowEnter`, `sidebarViewEnter`, `slideDown`/`slideUp`, skeleton `shimmer`)                                                                                                                                                                                               | Calm; every animation guarded by `prefers-reduced-motion`                                                                                                                                        |
+| Type             | `--font-sans` Public Sans Variable (Latin) + bundled Noto Sans SC Variable (CJK, unicode-range slices; platform CJK faces stay behind it as fetch-failure insurance) · `--font-serif` Lora Variable + CJK serif fallbacks (no bundled CJK serif — a second 4.3 MiB face for an opt-in axis did not survive the size decision) · `--font-mono` Cascadia/SFMono/Consolas · `--font-body` active face · `:root[lang\|='zh']` zeroes `--tracking-tight` and the editorial tracking tokens (negative tracking is a Latin display convention; ideographs keep their side bearing)                                                                                                                     | `data-theme-font` swaps the body face; density axis rescales `--text-xs…3xl`; visible axis tick labels and body text minimum 10px — 9px only allowed for decorative labels with a `title`/`aria-label` fallback |
 | Page title scale | Landing/hub pages: `page-title-overview` (24px default); data/list pages: `page-title` (20px default). Both use semibold, relative snug leading and balanced wrapping | Exactly one h1 per page; Chinese tracking stays neutral; serif axis retains medium weight; title line-height follows density scaling |
-| Layout | `data-theme-content-layout="full|centered"`; centered clamps `[data-slot='sidebar-inset'] > *` to `--max-content-width` (1280px) at ≥1280px; utilities `max-w-container` 1280 / `max-w-container-lg` 1536 | Hi-res: `full` uses available width; `centered` keeps a comfortable reading width |
+| Layout | `data-theme-content-layout` set to `full` or `centered`; centered clamps `[data-slot='sidebar-inset'] > *` to `--max-content-width` (1280px) at ≥1280px; utilities `max-w-container` 1280 / `max-w-container-lg` 1536 | Hi-res: `full` uses available width; `centered` keeps a comfortable reading width |
 
 ### 3.1 Reading hierarchy and controls
 
@@ -147,11 +147,14 @@ Primitive ownership map: [`components.md`](./components.md). Component props and
 
 State-management rules for URL-synced tables and filters (single URL owner, stable callbacks, one-transaction updates): [`state-stability.md`](./state-stability.md).
 
-| Layer            | Prefix / classes                    | Where                                            |
-| ---------------- | ----------------------------------- | ------------------------------------------------ |
-| Base UI (shadcn) | `ui-*` components (data-slot attrs) | `web/src/components/ui/**`                       |
-| Shell layout     | `app-header` / `app-sidebar`        | `web/src/components/layout/**`                   |
-| Theme tokens     | OKLCH CSS variables                 | `web/src/styles/theme.css` + `theme-presets.css` |
+| Layer                     | Prefix / classes                    | Where                                            |
+| ------------------------- | ----------------------------------- | ------------------------------------------------ |
+| Base UI (shadcn)          | `ui-*` components (data-slot attrs) | `web/src/components/ui/**`                       |
+| Cross-feature composition | section card / error / skeleton, query-error banner, confirm dialog, HTTP status badge | `web/src/components/common/**` |
+| Table subsystem           | data-table barrel (`@/components/data-table`) | `web/src/components/data-table/**`     |
+| Form plumbing             | dirty-close guard                   | `web/src/components/form/**`                    |
+| Shell layout              | `app-header` / `app-sidebar`        | `web/src/components/layout/**`                   |
+| Theme tokens              | OKLCH CSS variables                 | `web/src/styles/theme.css` + `theme-presets.css` |
 
 New UI must start from shadcn Base UI primitives when possible. Import via `@/components/ui/*`.
 
@@ -182,7 +185,7 @@ Every destructive action maps to exactly one tier; never hand-roll a variant:
 2. `cd web && bun run typecheck` — TS gate
 3. `cd web && bun run lint` — oxlint
 4. `cd web && bun run build` — production bundle gate (`build:web`)
-5. `cd web && bun run a11y:scan` — axe-core serious/critical gate (needs the dev server; see `web/scripts/a11y-scan.mjs`). Also enforced in CI: the `a11y` job serves the real embedded SPA via the Go server (fresh sqlite runtime DB) and scans all 15 admin routes against it (`BASE_URL`-driven; `.github/workflows/main.yml`)
+5. `cd web && bun run a11y:scan` — axe-core serious/critical gate (needs the dev server; see `web/scripts/a11y-scan.mjs`). Also enforced in CI: the `a11y` job serves the real embedded SPA via the Go server (fresh sqlite runtime DB) and scans it in both shipped locales (`BASE_URL`-driven; `.github/workflows/main.yml`). The route list is `DESKTOP_ROUTES` in `web/scripts/route-smoke.mjs`, which `a11y-scan.mjs` imports so the two gates cannot drift — this document deliberately does not restate the count.
 6. `cd web && bun run ui:smoke` — real-Chromium route/crash/mobile smoke gate (`web/scripts/route-smoke.mjs`); also enforced in CI in the `a11y` job against the shipped bundle
 7. Manual score rubric (target ≥ 4/5 each):
    - Material (glass/solid hierarchy)

--- a/docs/internal/design/a11y-checklist.md
+++ b/docs/internal/design/a11y-checklist.md
@@ -3,7 +3,7 @@
 **Product**: Metapi admin
 **Scope**: accessibility checklist
 **Related source of truth**: `docs/internal/design/DESIGN.md`, `web/src/styles/theme.css`
-**Last updated**: 2026-08-23
+**Last updated**: 2026-09-12
 **Status**: living acceptance checklist; known limitations are documented, not an implicit backlog
 
 This document records keyboard, name, contrast, and responsive expectations. Known limitations are evidence only unless promoted to a scoped GitHub issue.
@@ -18,7 +18,7 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 | `aria-label` on icon-only controls       | **pass for chrome**          | Topbar icon buttons labeled; mobile nav open/close labeled; SearchModal close labeled; sidebar collapse labeled when icon-only. Page action grids still have mixed coverage (debt). |
 | Contrast notes for primary text/surfaces | **documented**               | §4 below; body primary ≥ 4.5:1 both themes; muted/meta may fall near threshold.                                                                                                     |
 | Responsive checklist 375 / 768 / 1280    | **documented + shell pass**  | §5; shell breakpoints via `useIsMobile` (~768) and CSS media queries; no wholesale page redesign.                                                                                   |
-| axe-core live scan (authenticated routes)| **pass**                     | 2026-08-18 `bun run a11y:scan`: 15 routes (dashboard/models/sites/accounts/checkin/token-routes/proxy-logs/oauth/about/settings ×6), 0 serious/critical violations.              |
+| axe-core live scan (authenticated routes)| **pass**                     | CI `a11y` job, on every PR and every master merge: serves the real embedded SPA from the Go binary (fresh sqlite runtime DB) and scans the shared route inventory — `DESKTOP_ROUTES` in `web/scripts/route-smoke.mjs`, imported by `a11y-scan.mjs` so the two gates cannot drift — in **both shipped locales** (en + zh-CN). Last master run (`922a2946`): `[a11y] clean — 41 routes × 2 locales scanned, 0 serious/critical violations`. This row cites the run instead of restating a count, because the inventory grows with the app. |
 | FormControl label wiring (form fields)   | **gated**                    | `web/scripts/check-form-control.mjs` (chained into `bun run lint`): 140 `<FormControl>` sites classified, **0 unclassified** (the gate fails on a shape it cannot read rather than skipping it), and all 140 reach a DOM node carrying the injected `id` — 130 `ui/**` primitives + 10 forwarding composites. **0 registered exceptions**: the five composite controls (`EndpointsEditor` / `ScheduleEditor` / `ModelPolicyEditor` / `SiteScopePicker` / `CredentialRefPicker`) now carry the injected id on a `role="group"` root named by `aria-labelledby` (#1300, closed). |
 | Residual a11y debt documented            | **yes**                      | §7                                                                                                                                                                                  |
 

--- a/docs/internal/design/components.md
+++ b/docs/internal/design/components.md
@@ -1,13 +1,15 @@
 # UI component ownership map
 
-**Last verified**: 2026-08-16
+**Last verified**: 2026-09-12
 
 The implementation is the primitive API source of truth. The pre-rewrite `ds-*` library and its gallery no longer exist; use Git history when that implementation history is needed.
 
 | Concern                           | Owner                                                                     |
 | :-------------------------------- | :------------------------------------------------------------------------ |
 | Base UI / shadcn primitives       | `web/src/components/ui/**`                                                |
-| Data-table composition            | `web/src/components/data-table/**`                                        |
+| Cross-feature shared composition  | `web/src/components/common/**` (section card / error / skeleton, query-error banner, confirm dialog, HTTP status badge, credential export, safe external link) |
+| Data-table composition            | `web/src/components/data-table/**` (public surface is its `index.ts`; see [`web-package-boundaries.md`](../web-package-boundaries.md) rule 6) |
+| Form plumbing                     | `web/src/components/form/**` (dirty-close guard)                          |
 | Application shell                 | `web/src/components/layout/**`                                            |
 | Semantic tokens                   | `web/src/styles/theme.css` and `theme-presets.css`                        |
 | Tailwind entry and global recipes | `web/src/styles/index.css`                                                |
@@ -15,7 +17,7 @@ The implementation is the primitive API source of truth. The pre-rewrite `ds-*` 
 
 ## Usage rules
 
-1. Start with an existing primitive and import it through `@/components/ui/*`; feature-specific composition stays in the owning feature.
+1. Start with an existing primitive and import it through `@/components/ui/*`; feature-specific composition stays in the owning feature. A composition moves up to `@/components/common/*` when a **second** feature needs it — not before, and the move lands together with that second consumer (each such move is recorded in the [`web-package-boundaries.md`](../web-package-boundaries.md) precedent log).
 2. Use semantic OKLCH tokens and Tailwind utilities. Do not revive `ds-*`, copy a primitive into a feature, or hard-code a parallel token set.
 3. Keep accessibility behavior in the primitive owner: names, labels, focus rings, invalid state, keyboard interaction, and reduced-motion/transparency behavior.
 4. Confirm light/dark rendering, keyboard behavior, focused Vitest coverage, typecheck, lint, and production build for changed primitives.


### PR DESCRIPTION
## 用户任务与改动摘要

Closes #1342。对四份设计文档（`DESIGN.md` / `BACKEND.md` / `a11y-checklist.md` / `components.md`）逐句对树重读，修掉 **1 个渲染层面的真实损坏 + 5 处与代码相反的陈述 + 1 处被自己规则打脸的措辞 + 1 张漏了两个目录的 ownership map**，并把其中**可机械判定的那一类变成门禁**。

改动面：**5 文件 / +176−28**（4 份 `docs/internal/design/*.md` + `docs/doc_hygiene_test.go`）。**无 `web/src` 改动、无产品 `.go` 改动。**

1. **`DESIGN.md` §2.1 的表在 GitHub 上是坏的**：6 个 body 行里 5 行把 `|` 写在行内代码里却没转义，而 markdown 表格中**代码 span 内的裸 `|` 仍然是分隔符** ⇒ radius 行被切成 **7 列**。theme 行更糟：切分顺带**吃掉了行内代码两侧的空格**，渲染出来是 `light">(plusdata-themeattr for compat) set byThemeProviderand the FOUC bootstrap`（一行 7 处缺空格）。同文件另有 2 行同病：`:root[lang|='zh']`（CSS 属性子串选择器）与 `data-theme-content-layout="full|centered"`。
2. **新门禁 `TestMarkdownTablesAreWellFormed`**：published tree 里每个 `.md` 的 body 行必须与其表头有**相同数量的未转义 `|`**，`\|` 算内容、分隔行豁免。今天扫 **88 张表 / 637 个 body 行**，失败给 file:line + 补救指引，且**表数或 body 行数为 0 即判 vacuous FAIL**。**不检查列对齐**（本树不由 formatter 管，源码参差但渲染一致）。
3. **重写那几行时顺手核了它们描述的东西，值是旧的**：`THEME_FONT_VALUES` / `THEME_RADIUS_VALUES` / `THEME_SCALE_VALUES`（`web/src/lib/theme-customization.ts`）**各含一个表里没写的 `default`**；`public/theme-init.js` 只在值恰为 `serif` 时写 `serif`、否则写 `sans` ⇒ DOM 属性**永远不会是 `default`**。现在每行点名属性 + 列出常量真正允许的取值。
4. **5 处与代码相反的陈述**（逐条见下节）。
5. **`BACKEND.md` 的 env 前缀规则被自己的树打脸** ⇒ 改成它**实际运行的样子**（parity 变量沿用 TS 名不加前缀；Go 独有的旋钮**恰恰为了不被误认成 parity 名**才加 `METAPI_`）。
6. **`components.md` 的 ownership map 漏了 `components/common/**`（11 个跨 feature 组合件 + 1 个 hook，其中两个是本周 #1337 加的）与 `components/form/**`**；`DESIGN.md` §4 的层表同步补三行。晋升规则**只写在 map 里一份**（§4 不复述 —— 一条规则两份副本正是 `BACKEND.md` §2.2 自己警告过的失效方式）。

## 复现、根因与同类影响

**根因**：markdown 表格里的 `|` 在代码 span 内**不失去分隔符语义**，而这类文档天然要写「取值 A|B|C」和 CSS 选择器 —— 也就是**最容易踩的写法恰好是这份文档最需要写的东西**。它不会让任何构建、测试或 lint 失败，只在渲染时静默变形。

**同类影响（已系统扫过，不是只修看见的那张表）**：写了 escape-aware 的扫描器跑遍**全仓 48 个 markdown 文件**（`docs/**` + `README.md` + `AGENTS.md` + `CHANGELOG.md`），改前 **7 行损坏全部在 `DESIGN.md`**，改后 **0 行**，且新规则**没有任何需要豁免的存量** ⇒ 门禁可以直接开成硬失败，不需要白名单。

**顺带核出的 5 处假陈述**：

| 位置 | 原文 | 实测 |
|---|---|---|
| `DESIGN.md` §5 | CI `a11y` job「scans all **15** admin routes」 | `a11y-scan.mjs` 从 `route-smoke.mjs` **import** `DESKTOP_ROUTES` = **41** 条 × 2 语言。脚本自己的注释写着 import 是「so the two gates cannot drift」，而文档**又手抄了一遍数字**并漂了 26。改为点名共享清单 + 明说**故意不复述数字**。`a11y-checklist.md` 同一个 15（带 2026-08-18 日期）改为**引用最近一次 master run 的原始输出行**（`[a11y] clean — 41 routes × 2 locales scanned, 0 serious/critical violations`）作为**有日期的取证**，而不是当作常驻数字 |
| `DESIGN.md` 原则 6 | 「**Progressive adoption** — … **migrate pages gradually**」 | 没有待迁移的东西了：`check-form-control.mjs` 分类每一个 `<FormControl>` 站点，遇到原生控件或读不懂的形状就 FAIL（当前 140 sites / **0 native** / 0 exception）⇒ 改为陈述这个事实 |
| `DESIGN.md` §3 Motion | keyframes「(table row stagger, **landing**, **terminal demo**)」 | `styles/index.css` 实际定义 `slideDown` / `slideUp` / `shimmer` / `tableRowEnter` / `sidebarViewEnter`，**没有** landing 或 terminal-demo 动画 ⇒ 改为点名这 5 个 |
| `DESIGN.md` §2.3 | Anthropic preset 的 cream = `oklch(0.984 **0.005** 95)` | `theme-presets.css:431` 是 `oklch(0.984 **0.004** 95)`。**机械核过 `docs/**` 里全部 52 个 oklch 字面量，只有这 1 个在 `styles/*.css` 里找不到逐字对应** ⇒ 其余 51 个是准的 |
| `BACKEND.md` §2.2 | 门禁是「rules **1–8**」 | `package_boundary_test.go` 有 **9** 条（rule 9 = 生产文件不得 import testing） |

**`BACKEND.md` §1.6 + §6 checklist**：原文「env 名与 TS 一致、**不加 `METAPI_` 前缀**」/「no new prefix scheme」，而树里有 `METAPI_DB_PROFILE`、`METAPI_DB_APPLICATION_NAME`、`METAPI_ENABLE_PROXY_STUB`，且 `config/config.go:628` 是 `firstNonEmpty(get("REDIS_URL"), get("METAPI_REDIS_URL"))`。做法本身是自洽的（parity 变量沿用 TS 名；Go 独有旋钮加前缀**正是为了不被误认成 parity 名**）⇒ 把规则写成它实际运行的样子，并列出这四个证据。**没有改代码去迁就文档**：文档错，代码对。

**有意不做门禁**：散文准确性（那是审计的活，不是正则的活）与列对齐（源码参差不影响渲染）。四份文档的 `Last updated`（2026-08-16 / 08-23 / 09-04 / 09-08）改为本轮实际核验日期。

## 验证证据

- 最终源码：PR head `657734d5aa10692d53f4d2797be96ae3358ef507`；`git status` clean。
- **门禁**：`go test ./docs/...` **ok**（11.2s；新 `TestMarkdownTablesAreWellFormed` + `TestMarkdownTableGateHelpers` 与既有 markdown 卫生 / 相对链接可解析 / 计划代号 / phase 臂 / CHANGELOG 叙事 / API 清单 parity / env parity 全绿）· `go vet ./docs/...` rc=0 · `gofmt -l docs/` **空** · `go build ./cmd/server` rc=0。
- **变异验红（两向）**：① 把 radius 行改成 `` `<body data-theme-radius="none|sm|md">` `` ⇒ FAIL，输出 `docs/internal/design/DESIGN.md:48: markdown table row has 5 cell separators but its header has 3: an unescaped | inside a code span splits the cell, so write \| …`（并报告覆盖面 `88 tables / 637 body rows`）；② **同样三个值改写成 `"none\|sm\|md"` ⇒ PASS**（这一向是证明转义语义正确的唯一证据 —— 只验红不验绿，规则很可能把合法写法一起打红）。精确还原后 `go test ./docs/...` ok。
- **helper 单测**（把门禁生死所在的那一处细节钉死）：`markdownTableCells` 4 例（含未转义 ⇒ 5、转义 ⇒ 3）· `isMarkdownTableSeparator` 5 例（含 `"| --- | b |"` 必须为 **false**：有破折号但也有内容）。
- **改前/改后的全仓扫描**：escape-aware 扫描器跑 48 个 markdown 文件 ⇒ 改前 7 行损坏（全在 `DESIGN.md`）、改后 **0**。
- **web 门禁**：**按构造不适用** —— `git diff --name-only master...HEAD` = `docs/doc_hygiene_test.go` + 4 份 `docs/internal/design/*.md`，**无 `web/` 文件**（vitest / lint / format / knip / boundaries 的输入一个字节未变），CI 复跑作终审。
- Go 全量 race / `go vet ./...`：唯一 `.go` 改动是 `docs/doc_hygiene_test.go`（纯测试文件、所在包无产品代码）⇒ 全仓 race 不可能受影响；交 CI（`vet` + `test-pg` + `test-sqlite` + 4 shard）。
- 真实模型中继 / 下游客户端 E2E：**不适用**（纯文档 + 文档门禁）。
- 未验证项与剩余风险：① 表格**渲染**效果没有肉眼在 GitHub 上复核过 —— 门禁证明的是「每行 cell 数与表头一致」，这是渲染正确的必要条件；最终确认交本 PR 的 Files changed 视图。② `docs/internal/design/*.md` 本轮**只逐句核了被上述发现牵连到的段落**（§2.1 / §2.3 / §3 Motion / §4 / §5、`BACKEND.md` §1.6 / §2.2 / §6、`components.md` 全文、`a11y-checklist.md` §1）；`a11y-checklist.md` §2–§7 与 `BACKEND.md` §3–§5 的逐句对树重读**尚未做**。③ `state-stability.md` 本轮**已核为真、未改**：它点名的 6 个符号全部存在、列的 8 个列表页与实测用 `useUrlTableState` 的 8 个 `*-page.tsx` 逐个吻合、R6 点名的两个脚本都在。

## 自查

- [x] 无凭据、私有主机、内部路径或用户敏感数据泄漏（`leak_guard.py --range master..HEAD` RC=0）
- [x] 行为变化已更新必要测试与现役文档（**无行为变化**；新门禁与其 helper 单测同 PR 落地；#1342 由本 PR 关闭）
- [x] 用户可见文案已走 i18n（不适用：无 UI 文案改动）
