### PR TITLE
fix(router): revalidate unhashed root assets and make architecture.md true

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-**Last updated**: 2026-09-07
+**Last updated**: 2026-09-13
 
 > **Navigation**: full docs map in [`docs/README.md`](README.md) · route list in [`api/routes-inventory.md`](api/routes-inventory.md) · environment variables in [`configuration.md`](configuration.md).
 >
@@ -96,10 +96,16 @@ exception to the test with a written justification.
 `proxycore/` and `protocol/` do not exist and must not be reintroduced — the
 test rejects those TypeScript-era names.
 
+The test also names what it does **not** police: `cmd/migrate`, `e2e`, `docs`,
+`web` and everything under `internal/` are out of scope, because those are
+repo-private helpers and fixtures rather than a layer. The single `internal/`
+edge it records is the `auth → internal/sharedcount` exception.
+
 ## Request paths: stages and single owners
 
 Two independent auth surfaces share one chi router built by `router.New`, the
-only composition root. Registrars take a `chi.Router` and register absolute
+only place the route tree is composed — `cmd/server` stays the composition root
+for dependencies. Registrars take a `chi.Router` and register absolute
 `/api/...` paths, so each can also be exercised on a standalone router in
 tests.
 
@@ -228,11 +234,24 @@ only to the exact registered paths and never shadows the SPA fallback.
 
 ### Static assets and SPA fallback
 
-`router.setupSPAFallback` serves the embedded `web/dist` tree: content-hashed
-subtrees under `/assets/` and `/static/` get an immutable cache header, while
-root files whose names are not hashed (`bootstrap.js`, `theme-init.js`, logos
-and favicons) get `no-cache` so deploys propagate without a hard refresh. The
-fallback answers `index.html` for non-API paths and a JSON 404 body for
+`router.setupSPAFallback` serves the embedded `web/dist` tree. One rule sets
+every cache header: **a content-hashed name is `immutable`, anything else
+revalidates**. `/static/*` is the only asset subtree mounted and every name in
+it is hashed, so it gets `public, max-age=31536000, immutable`. The files the
+build copies into the dist root are not hashed, so they get `no-cache` —
+`bootstrap.js`, `theme-init.js`, the logos and favicons, and the `index.html`
+the fallback serves — which is what lets a deploy propagate to an
+already-visited client without a hard refresh.
+
+There is no `/assets/*` mount. One sat here for a legacy Vite layout until it
+was removed: `//go:embed` bakes exactly one dist into a binary, so there is no
+older build to stay compatible with, and the embedded tree has had no `assets/`
+directory since the Rsbuild migration. `router/spa_layout_test.go` pins the
+replacement contract — every root-relative asset the built `index.html`
+references must be served as that asset and never as the fallback HTML, and
+mounting the shipped dist must not warn — while
+`router/static_cache_policy_test.go` pins the cache header of each class above.
+The fallback answers `index.html` for non-API paths and a JSON 404 body for
 `/api/*` and `/v1/*`.
 
 ## Package Layout (as-built)
@@ -244,11 +263,11 @@ metapi-go/
 │   └── migrate/            # Standalone SQLite→PG migration tool
 ├── app/                    # Lifecycle: start/shutdown, health, metrics, proxy upstream glue
 ├── auth/                   # Admin + proxy + downstream auth, policy, rate limit
-├── config/                 # Env loading (no prefix), defaults, validation
+├── config/                 # Env loading, defaults, validation (naming rule: BACKEND.md §1.6)
 ├── router/                 # chi router mount, middleware, security headers, SPA fallback
 ├── handler/
 │   ├── admin/              # Admin REST handlers (+ payloads/)
-│   ├── proxy/              # /v1/* proxy surface handlers
+│   ├── proxy/              # /v1/* proxy surface handlers + the non-/v1 aliases
 │   └── shared/             # Shared API error helpers
 ├── proxy/                  # Proxy orchestration (NOT "proxycore/")
 │   ├── profiles/           # Client/profile detection (Claude Code, Codex, Gemini CLI, …)
@@ -256,6 +275,7 @@ metapi-go/
 ├── routing/                # TokenRouter: match, weights, cooldown, site runtime breaker
 ├── platform/               # Upstream platform adapters (16) + site proxy
 ├── transform/              # Protocol transformers (NOT "protocol/"; no canonical IR)
+│   ├── anthropic/          # messages: the Messages ⇄ Chat request/return bridge
 │   ├── openai/             # completions, embeddings, images, responses
 │   ├── gemini/             # generate_content (native OpenAI→Gemini bridge)
 │   └── shared/             # Cross-protocol helpers
@@ -264,10 +284,14 @@ metapi-go/
 │   └── pricingcatalog/     # models.dev official catalog pricing (cold-start cost signal)
 ├── scheduler/              # Background cron jobs (checkin, balance, recovery, retention, …)
 ├── store/                  # sqlx DB open, dual dialect, schema, settings
+├── internal/               # Repo-private helpers, out of the boundary test's scope:
+│                           #   ssrf · sharedcount · httpclient · version · golden · pgtest
 ├── web/
 │   ├── embed.go            # //go:embed dist
 │   └── dist/               # Built React SPA (generated; embedded into binary)
 ├── e2e/                    # End-to-end tests
+├── scripts/                # Env-driven release/verify/e2e scripts (no host or credential baked in)
+├── testbed/                # Sanitized compose template for a local upstream testbed
 ├── docs/                   # Specs, architecture, design philosophy
 ├── Dockerfile
 ├── docker-compose.yml
@@ -284,9 +308,9 @@ metapi-go/
 | `app`           | HTTP server lifecycle, readiness, metrics, upstream executor glue                                                        |
 | `router`        | Route tree, CORS/security middleware, embed SPA                                                                          |
 | `auth`          | Fail-closed admin/proxy auth, downstream key policy                                                                      |
-| `config`        | Env → `Config` (names match TS; no `METAPI_` prefix)                                                                     |
+| `config`        | Env → `Config`; parity names match TS, Go-only knobs take a `METAPI_` prefix (`BACKEND.md` §1.6)                                                                     |
 | `handler/admin` | Admin CRUD + settings + ops endpoints                                                                                    |
-| `handler/proxy` | Protocol surfaces under `/v1/*`                                                                                          |
+| `handler/proxy` | Protocol surfaces under `/v1/*` and the non-`/v1` aliases                                                                                          |
 | `proxy`         | Coordinator + executor + channel selection + retry policy (the request loop itself lives in `handler/proxy/upstream.go`) |
 | `routing`       | Model/route match, weighted selection, Fibonacci cooldown, site breaker                                                  |
 | `platform`      | Per-upstream adapter behavior (detect, auth headers, admin APIs)                                                         |
@@ -352,7 +376,7 @@ scheduler (robfig/cron)
 | Routing              | `tokenRouter` service         | `routing/`                             |
 | Background jobs      | timers + node-cron            | `scheduler/` + robfig/cron             |
 | Image size           | ~80MB+ node base              | Alpine + static binary                 |
-| Config env names     | Unprefixed                    | Same unprefixed names                  |
+| Config env names     | Unprefixed                    | Same names for parity vars; Go-only knobs add `METAPI_` |
 
 ## Key Design Decisions
 
@@ -362,7 +386,7 @@ React SPA is built once and embedded via `//go:embed`. Production image has no N
 
 ### 2. Dual dialect: SQLite + PostgreSQL
 
-SQLite is default (zero-config dev/test). PostgreSQL is the production path. `store.Open(dialect, dsn)` and dialect rebinding hide `?` vs `$N` and type differences. MySQL was intentionally not ported.
+SQLite is default (zero-config dev/test). PostgreSQL is the production path. `store.Open(dialect, dsn, sslMode)` and dialect rebinding hide `?` vs `$N` and type differences. MySQL was intentionally not ported.
 
 ### 3. camelCase JSON API parity
 
@@ -383,7 +407,7 @@ Routing isolates bad channels instead of cascading:
 
 ### 6. Config via env, TS-compatible names
 
-`config.Load` reads the same env var names as TS Metapi (`AUTH_TOKEN`, `PROXY_TOKEN`, `DB_TYPE`, …) with **no** project prefix. Defaults and validation live in `config/`.
+`config.Load` reads the same env var names as TS Metapi for every parity variable (`AUTH_TOKEN`, `PROXY_TOKEN`, `DB_TYPE`, …). A knob that exists only in Go carries a `METAPI_` prefix so it cannot be mistaken for a parity name. The rule and its evidence live in one place: [`docs/internal/design/BACKEND.md`](internal/design/BACKEND.md) §1.6. Defaults and validation live in `config/`.
 
 ### 7. Pure Go, no CGO
 
@@ -413,14 +437,6 @@ config, web, handler/shared → leaves
 it by running `go test ./docs -run TestPackageBoundaries`. That test is the
 specification; a new edge either passes it or needs a written exception in its
 header comment.
-
-## S.U.P.E.R. Compliance
-
-- **S** (small): packages own one layer (HTTP, orchestration, routing, persistence, …)
-- **U** (understandable): real names match code (`proxy`, `transform`, `routing`)
-- **P** (pluggable): platform adapters and protocol transforms register/compose independently
-- **E** (environment-agnostic): SQLite or PostgreSQL via dialect store
-- **R** (replaceable): coordinator dependencies and platform adapters are injectable/replaceable
 
 ## Related docs
 

--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -952,3 +952,214 @@ func TestProgrammeCodeGateRegexpSanity(t *testing.T) {
 		}
 	}
 }
+
+// architectureDoc is the one public document that prints a directory tree and
+// labels it as-built. A tree is the easiest thing in this repository to leave
+// behind: adding a package does not touch it and deleting one does not either,
+// so nothing fails until a reader follows it into a directory that is not
+// there. Measured when this gate was added, the tree was missing three tracked
+// top-level directories (`internal/`, `scripts/`, `testbed/`) and one nested
+// package that the same document's introduction names (`transform/anthropic/`).
+const architectureDoc = "docs/architecture.md"
+
+// architectureTreeHeading is the section the gate reads. Renaming it fails the
+// gate loudly instead of silently downgrading it to "no tree found, all good".
+const architectureTreeHeading = "## Package Layout (as-built)"
+
+// architectureTreeBuildOutputDirs are top-level directories that .gitignore
+// creates at the repository root (release staging, local data, smoke output).
+// A clone never contains them, so the as-built tree must not have to list them.
+var architectureTreeBuildOutputDirs = map[string]bool{
+	"bin":          true,
+	"data":         true,
+	"dist-bin":     true,
+	"test-results": true,
+	"tmp":          true,
+	"tmp-smoke":    true,
+}
+
+// architectureTreeGeneratedDirs may be shown by the tree without existing in a
+// fresh checkout. `web/dist` is built by the frontend job and gitignored; the
+// tree already labels it "(generated; embedded into binary)".
+var architectureTreeGeneratedDirs = map[string]bool{
+	"web/dist": true,
+}
+
+// TestArchitectureTreeMatchesTheRepo holds the as-built tree to the repository
+// in both directions: every directory it shows exists, and every top-level
+// directory the repo tracks is shown. Only directories are inventoried — the
+// tree also lists a handful of root files (Dockerfile, Makefile) and requiring
+// those would make the gate fire on every new top-level dotfile policy.
+func TestArchitectureTreeMatchesTheRepo(t *testing.T) {
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, architectureDoc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(data), "\n")
+
+	headingLine := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == architectureTreeHeading {
+			headingLine = i
+			break
+		}
+	}
+	if headingLine < 0 {
+		t.Fatalf("%s has no %q heading: the as-built tree gate has nothing to read",
+			architectureDoc, architectureTreeHeading)
+	}
+	openFence := -1
+	for i := headingLine; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "```" {
+			openFence = i
+			break
+		}
+	}
+	if openFence < 0 {
+		t.Fatalf("%s:%d: the as-built heading is not followed by a fenced block",
+			architectureDoc, headingLine+1)
+	}
+
+	shown, shownTopLevel, nested := parseArchitectureTree(t, lines, openFence)
+	if len(shown) == 0 || len(shownTopLevel) == 0 || nested == 0 {
+		t.Fatalf("gate would pass vacuously: parsed %d directories (%d top-level, %d nested) out of the as-built tree — "+
+			"a parser that silently drops every child entry looks exactly like a clean tree",
+			len(shown), len(shownTopLevel), nested)
+	}
+
+	var findings []string
+	listed := make(map[string]bool, len(shown))
+	for _, dir := range shown {
+		listed[dir] = true
+		if architectureTreeGeneratedDirs[dir] {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(root, filepath.FromSlash(dir)))
+		if err != nil || !info.IsDir() {
+			findings = append(findings, formatFinding(architectureDoc, headingLine+1,
+				"the as-built tree shows a directory the repo does not have", dir+"/"))
+		}
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	onDisk := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || strings.HasPrefix(name, ".") ||
+			skipHygieneDir(name) || architectureTreeBuildOutputDirs[name] {
+			continue
+		}
+		onDisk++
+		if !listed[name] {
+			findings = append(findings, formatFinding(architectureDoc, headingLine+1,
+				"the repo has a top-level directory the as-built tree does not list", name+"/"))
+		}
+	}
+	if onDisk == 0 {
+		t.Fatal("gate would pass vacuously: no top-level directories were found next to go.mod")
+	}
+
+	if len(findings) > 0 {
+		t.Fatalf("%s is out of sync with the repository (%d directories shown, %d on disk):\n%s",
+			architectureDoc, len(shown), onDisk, strings.Join(findings, "\n"))
+	}
+}
+
+// parseArchitectureTree reads the fenced tree that starts at openFence and
+// returns the repo-relative path of every directory entry it shows, the subset
+// of those that sit at the top level, and how many were nested.
+//
+// The box-drawing prefixes are exactly four runes per level ("│   ", "    ",
+// "├── ", "└── "), so the offset of the entry marker is the depth and the
+// stack of names above it is the parent path. Lines without a marker are the
+// tree root ("metapi-go/") or a wrapped comment, and are skipped; entries that
+// do not end in "/" are files and are not part of the inventory.
+func parseArchitectureTree(t *testing.T, lines []string, openFence int) (shown, topLevel []string, nested int) {
+	t.Helper()
+
+	var stack []string
+	closed := false
+	for i := openFence + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "```" {
+			closed = true
+			break
+		}
+		runes := []rune(lines[i])
+		marker := -1
+		for j := 0; j+4 <= len(runes); j++ {
+			if branch := string(runes[j : j+4]); branch == "├── " || branch == "└── " {
+				marker = j
+				break
+			}
+		}
+		if marker < 0 || marker%4 != 0 {
+			continue
+		}
+		name := strings.TrimSpace(string(runes[marker+4:]))
+		if hash := strings.Index(name, "#"); hash >= 0 {
+			name = strings.TrimSpace(name[:hash])
+		}
+		if name == "" {
+			continue
+		}
+		depth := marker / 4
+		isDir := strings.HasSuffix(name, "/")
+		name = strings.TrimSuffix(name, "/")
+		if depth > len(stack) {
+			t.Fatalf("%s:%d: tree entry %q is indented %d level(s) below its parent",
+				architectureDoc, i+1, name, depth-len(stack))
+		}
+		stack = append(stack[:depth], name)
+		if !isDir {
+			continue
+		}
+		path := strings.Join(stack, "/")
+		shown = append(shown, path)
+		if depth == 0 {
+			topLevel = append(topLevel, path)
+		} else {
+			nested++
+		}
+	}
+	if !closed {
+		t.Fatalf("%s:%d: the as-built tree is never closed", architectureDoc, openFence+1)
+	}
+	return shown, topLevel, nested
+}
+
+// TestArchitectureTreeParserSanity pins the two things the gate lives or dies
+// on: comments (including wrapped ones) never become entries, and depth is
+// derived from the marker offset so a child path is really a child path.
+func TestArchitectureTreeParserSanity(t *testing.T) {
+	sample := []string{
+		"```",
+		"metapi-go/",
+		"├── cmd/",
+		"│   ├── server/             # Main server entry point",
+		"│   └── migrate/            # Standalone tool",
+		"├── internal/               # wrapped comment:",
+		"│                           #   continuation that must not parse",
+		"├── web/",
+		"│   ├── embed.go            # a file, not a directory",
+		"│   └── dist/               # generated",
+		"└── Makefile",
+		"```",
+	}
+	shown, topLevel, nested := parseArchitectureTree(t, sample, 0)
+
+	want := []string{"cmd", "cmd/server", "cmd/migrate", "internal", "web", "web/dist"}
+	if strings.Join(shown, ",") != strings.Join(want, ",") {
+		t.Errorf("shown = %v, want %v", shown, want)
+	}
+	wantTop := []string{"cmd", "internal", "web"}
+	if strings.Join(topLevel, ",") != strings.Join(wantTop, ",") {
+		t.Errorf("topLevel = %v, want %v", topLevel, wantTop)
+	}
+	if nested != 3 {
+		t.Errorf("nested = %d, want 3 (cmd/server, cmd/migrate, web/dist)", nested)
+	}
+}

--- a/docs/internal/design/BACKEND.md
+++ b/docs/internal/design/BACKEND.md
@@ -61,7 +61,7 @@ Rules of thumb:
 - Breaker open ⇒ filter out of selection, do not crash the process.
 - Recovery jobs (`scheduler` channel recovery, etc.) may heal state; they must not bypass auth or dialect boundaries.
 
-### 1.6 Config via env (no prefix), matching TS names
+### 1.6 Config via env: TS parity names, `METAPI_` for Go-only knobs
 
 - Configuration is environment-driven (`config.Load` / `config.Get`).
 - Env var names match TS Metapi **without** a `METAPI_` (or similar) prefix: e.g. `AUTH_TOKEN`, `PROXY_TOKEN`, `DB_TYPE`, `DB_URL`, `PORT`.

--- a/router/router.go
+++ b/router/router.go
@@ -273,6 +273,14 @@ func setupSPAFallback(r chi.Router, distFS fs.FS) {
 	// root. They are NOT under /static/, so serve them explicitly
 	// here — otherwise the SPA fallback answers 200 text/html and <img>
 	// renders blank.
+	//
+	// Cache rule for everything this function serves: a content-hashed name is
+	// immutable, every other name revalidates (no-cache) so a deploy reaches
+	// already-visited clients without a hard refresh. Only /static/* is hashed,
+	// so nothing in the dist root is immutable. These five were served
+	// immutable once, which pinned a replaced logo or favicon in every browser
+	// that had already loaded it for a year — the failure mode the rootScripts
+	// block below had already written down, one block too late to apply here.
 	rootFiles := map[string]string{
 		"logo.png":       "image/png",
 		"favicon.png":    "image/png",
@@ -290,7 +298,7 @@ func setupSPAFallback(r chi.Router, distFS fs.FS) {
 				return
 			}
 			w.Header().Set("Content-Type", fileType)
-			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+			w.Header().Set("Cache-Control", "no-cache")
 			w.Write(data)
 		})))
 	}
@@ -299,9 +307,8 @@ func setupSPAFallback(r chi.Router, distFS fs.FS) {
 	// the dist root. They must resolve to a real JS content type — otherwise
 	// the SPA fallback answers 200 text/html and nosniff browsers refuse to
 	// execute them (the same failure mode as rootFiles above). Unlike the
-	// /static/* assets their names are NOT content-hashed, so they must NOT
-	// get the immutable cache header: no-cache keeps deploys propagating to
-	// already-visited clients without a hard refresh.
+	// /static/* assets their names are NOT content-hashed, so per the cache
+	// rule above they revalidate.
 	rootScripts := []string{"bootstrap.js", "theme-init.js"}
 	for _, name := range rootScripts {
 		fileName := name

--- a/router/static_cache_policy_test.go
+++ b/router/static_cache_policy_test.go
@@ -1,0 +1,128 @@
+package router
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/deliciousbuding/metapi-go/web"
+)
+
+// setupSPAFallback serves one cache rule: a content-hashed name is immutable,
+// every other name revalidates. Only /static/* is hashed, so the files the
+// frontend build copies into the dist root — logos, favicons, bootstrap.js,
+// theme-init.js — and the index.html the fallback answers must all come back
+// no-cache. An unhashed name served immutable is pinned for a year in every
+// browser that already loaded it: a replaced logo never appears and a fixed
+// bootstrap script never runs, and neither shows up as an error anywhere.
+//
+// The five root images were served immutable until this test existed, which is
+// why it runs against the shipped dist rather than a fixture — the contract
+// worth pinning is what a released binary answers, and a synthetic MapFS would
+// keep passing no matter which root files the build actually emits.
+
+// newEmbeddedSPARouter mounts the SPA fallback over the embedded dist, the same
+// way TestEmbeddedSpaReferencesAreServedAsAssets does.
+func newEmbeddedSPARouter() chi.Router {
+	r := chi.NewRouter()
+	r.Use(SecurityHeaders)
+	setupSPAFallback(r, web.Dist)
+	return r
+}
+
+func TestShippedDistRootFilesRevalidate(t *testing.T) {
+	dist := embeddedDist(t)
+	r := newEmbeddedSPARouter()
+
+	entries, err := fs.ReadDir(dist, ".")
+	if err != nil {
+		t.Fatalf("read the embedded dist root: %v", err)
+	}
+
+	checked := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			// /static/* is the only subtree the build emits and every name in
+			// it is content-hashed: pinned immutable by the test below.
+			continue
+		}
+		if name == "index.html" {
+			// Not registered as a root file — the SPA fallback answers it, and
+			// TestSpaFallbackAndAPIPathsKeepTheirOwnHeaders pins that header.
+			continue
+		}
+		checked++
+
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/"+name, nil))
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("GET /%s = %d, want 200: a dist root file must be served as itself, not swallowed by the SPA fallback", name, rec.Code)
+			continue
+		}
+		if ct := rec.Header().Get("Content-Type"); strings.Contains(ct, "html") {
+			t.Errorf("GET /%s content-type = %q: the SPA fallback answered for a root file", name, ct)
+		}
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+			t.Errorf("GET /%s cache-control = %q, want no-cache: no dist root name is content-hashed, so an immutable header would pin this file for a year", name, cc)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("the embedded dist root holds no files to check: this gate must not pass vacuously")
+	}
+	t.Logf("%d dist root file(s) all revalidate", checked)
+}
+
+func TestSpaFallbackAndAPIPathsKeepTheirOwnHeaders(t *testing.T) {
+	// embeddedDist skips the job when the checkout carries the CI embed
+	// placeholder instead of a real build.
+	embeddedDist(t)
+	r := newEmbeddedSPARouter()
+
+	// The hashed subtree is the one thing that may be cached for a year.
+	asset := findDistAsset(t, "dist/static/js", ".js")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/static/js/"+asset, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /static/js/%s = %d, want 200", asset, rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=31536000, immutable" {
+		t.Errorf("GET /static/js/%s cache-control = %q, want immutable: this name is content-hashed", asset, cc)
+	}
+
+	// Everything the SPA answers — the document itself and any client-side
+	// route — revalidates, so a deploy reaches an already-open tab.
+	for _, path := range []string{"/index.html", "/sites", "/settings/general"} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("GET %s = %d, want 200 from the SPA fallback", path, rec.Code)
+			continue
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+			t.Errorf("GET %s content-type = %q, want text/html", path, ct)
+		}
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+			t.Errorf("GET %s cache-control = %q, want no-cache", path, cc)
+		}
+	}
+
+	// The same fallback answers the API surfaces with a JSON 404: an unknown
+	// route must never hand a client the SPA document.
+	for _, path := range []string{"/api/not-a-route", "/v1/not-a-route"} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("GET %s = %d, want 404", path, rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+			t.Errorf("GET %s content-type = %q, want application/json", path, ct)
+		}
+	}
+}

--- a/router/static_cache_policy_test.go
+++ b/router/static_cache_policy_test.go
@@ -25,6 +25,12 @@ import (
 // worth pinning is what a released binary answers, and a synthetic MapFS would
 // keep passing no matter which root files the build actually emits.
 
+// embedPlaceholder is the empty file CI creates so //go:embed dist compiles
+// without a frontend build. embeddedDist treats its presence as "no real SPA
+// here"; when the real dist is downloaded on top of it, it is the one root
+// entry that is not an asset.
+const embedPlaceholder = "placeholder.txt"
+
 // newEmbeddedSPARouter mounts the SPA fallback over the embedded dist, the same
 // way TestEmbeddedSpaReferencesAreServedAsAssets does.
 func newEmbeddedSPARouter() chi.Router {
@@ -54,6 +60,14 @@ func TestShippedDistRootFilesRevalidate(t *testing.T) {
 		if name == "index.html" {
 			// Not registered as a root file — the SPA fallback answers it, and
 			// TestSpaFallbackAndAPIPathsKeepTheirOwnHeaders pins that header.
+			continue
+		}
+		if name == embedPlaceholder {
+			// Not a build output. .github/actions/go-toolchain touches
+			// web/dist/placeholder.txt so //go:embed type-checks on a fresh
+			// checkout, and the test jobs then download the real dist into the
+			// same directory — so in CI the scaffold and the shipped files
+			// coexist. No route serves it and none should.
 			continue
 		}
 		checked++


### PR DESCRIPTION
## 用户任务与改动摘要

Closes #1344。把 `docs/architecture.md` 逐句对树重读，修掉 **7 处与代码相反的陈述 + 1 棵漏了 4 个目录的「as-built」树 + 1 节无判据的自评清单**；其中**一处是文档对、代码只执行了一半** ⇒ 改的是代码：dist 根目录那 5 个**未哈希**的图片文件原本被 `immutable` 缓存一年，而 `router/router.go` 自己在下方 10 行就写下了「未哈希 ⇒ 不得 immutable」的规则。两条可机械判定的类**变成了门禁**。

改动面：**5 文件 / +389−27**（`docs/architecture.md`、`docs/internal/design/BACKEND.md`、`router/router.go` + 2 个测试文件）。**无 `web/` 改动。**

## 裁决：文档错还是代码错

| 冲突 | 证据 | 裁决 |
|---|---|---|
| 文档说 logos/favicons 是 `no-cache`「so deploys propagate」 | 代码给的是 `public, max-age=31536000, immutable`（`router/router.go:293`）；而**同一函数下方** rootScripts 的注释写着「Unlike the `/static/*` assets their names are NOT content-hashed, so they must NOT get the immutable cache header」 | **改代码**：5 个根图片也是未哈希名，规则对它们同样成立 ⇒ 改 `no-cache`。这不是文档口味问题，是代码自相矛盾。代价是每次冷加载 5 个小文件走 304（从 embedded FS 出，无磁盘 I/O）；收益是换 logo / 修 favicon 不再被钉一年 |
| 文档说 `/assets/` 与 `/static/` 都是 immutable 子树 | `/static/*` 是**唯一**挂载的子树（`router.go:270`）；`router.go:257-269` 长注释记录了 `/assets/*` 为什么被删（`//go:embed` 的二进制只可能带一份 dist，不存在「兼容旧构建」这回事），`router/spa_layout_test.go:23` 钉同一段历史 | **改文档**：代码是对的，且删得有理有据 |
| 文档 4 处说「env 名不加 `METAPI_` 前缀」（树注释 / package roles / TS-vs-Go 表 / Key Decision 6），`BACKEND.md` §1.6 标题同样这么说 | 树里有 `METAPI_DB_PROFILE`、`METAPI_DB_APPLICATION_NAME`、`METAPI_ENABLE_PROXY_STUB`；`config/config.go:628` 是 `firstNonEmpty(get("REDIS_URL"), get("METAPI_REDIS_URL"))`；`BACKEND.md` §1.6 **正文**在上一轮已经改成真实规则，标题却还留着旧说法 | **改文档**：规则只留在 §1.6 一处（含标题），其余 4 处写短的真话 + 指过去。一条规则 5 份副本、4 份过期，正是 `BACKEND.md` §2.2 自己警告过的失效方式 |
| 文档说 `router.New` 是「the only composition root」 | 同一文件 `:86` 的 ownership 表写着 `cmd/server` = Composition root | **改文档**：`router.New` 独占的是**路由树的组装**，依赖注入的 composition root 仍是 `cmd/server` |

## 7 处假陈述逐条

| 位置 | 原文 | 实测 |
|---|---|---|
| `:231-235` | `/assets/` + `/static/` 都 immutable；`bootstrap.js`、`theme-init.js`、**logos 与 favicons** 都是 `no-cache` | `/assets/*` 挂载已删除；5 个根图片是 **immutable**（⇒ 本轮改代码）；`index.html` 回落也是 `no-cache`，文档未提 |
| `:247` | 树注释 `config/ # Env loading (no prefix)` | 见上表第 3 行 |
| `:287` | package roles：`names match TS; no METAPI_ prefix` | 同上 |
| `:355` | TS-vs-Go：`Config env names | Unprefixed | Same unprefixed names` | 同上 |
| `:385` | Key Decision 6：`with **no** project prefix` | 同上 |
| `:365` | `store.Open(dialect, dsn)` | 真实签名 `store.Open(dialect string, dsn string, sslMode bool)`（`store/open.go:239`）⇒ 照文档抄**编译不过** |
| `:102` | `router.New`, the only composition root | 与 `:86` 冲突 |

**as-built 树漏的目录**（`git ls-files` 顶层目录 19 个，树里只列了 16 个）：`internal/`（`golden` / `httpclient` / `pgtest` / `sharedcount` / `ssrf` / `version`，其中 `auth → internal/sharedcount` 是 `package_boundary_test.go:39` 登记的例外）· `scripts/` · `testbed/` · `transform/anthropic/`（**同一文档 `:16` 的 Naming truth 段落自己点名了 `anthropic/messages`**，树里却没有）。`internal/` 尤其该列，因为它**恰恰不在**边界表的管辖内 —— `package_boundary_test.go` 明写 `cmd/migrate, e2e, internal, docs, web are out of scope`，而文档说那个测试是 ownership 表的可执行形态，却没说它不管哪些包。

**删除 `## S.U.P.E.R. Compliance`**：5 条自评，无判据、无 owner、无门禁，且每条都在复述上文（packages own one layer = ownership 表 · real names match code = Naming truth · adapters compose independently = `platform` · SQLite or PostgreSQL = Key Decision 2 · injectable = `proxy`）。一份没人检查的 compliance 清单就是等着过期的假陈述。

## 新门禁（2 条）与变异验红

**`docs`: `TestArchitectureTreeMatchesTheRepo`** —— 双向：树里显示的每个目录必须存在；磁盘上每个顶层目录必须在树里。只盘点目录（树里那几个根文件不盘点，否则每加一个顶层 dotfile 策略都要动文档）。跳过项各有理由：gitignore 在根上造出来的构建产物目录（`bin`/`dist-bin`/`data`/`tmp`/`tmp-smoke`/`test-results`）与 `web/dist`（树里已标 generated，fresh checkout 不存在）。深度取自 box-drawing marker 的偏移量（每级恰好 4 rune），因此子路径真的是子路径；`TestArchitectureTreeParserSanity` 钉住「注释（含折行注释）不会变成条目」与深度算术。今天 **34 个目录 / 19 个顶层**。

变异**三向**：① 删掉 `internal/` 两行 ⇒ FAIL 指名 `the repo has a top-level directory the as-built tree does not list: internal/`；② 插入 `frobnicate/` ⇒ FAIL 指名 `the as-built tree shows a directory the repo does not have: frobnicate/`；③ 把 marker 匹配弱化到只认深度 0（模拟「解析器悄悄丢掉所有子条目」）⇒ **不是静默通过**，触发 vacuity 守卫 `parsed 19 directories (19 top-level, 0 nested)`。三次都精确还原后 rc=0。

**`router`: `static_cache_policy_test.go`** —— 钉的是**发布二进制真正回答的东西**，所以跑真实 embedded dist 而不是 MapFS 夹具（夹具无论构建实际吐出哪些根文件都会绿）：dist 根目录**每一个**文件都必须 200 + 非 HTML + `no-cache`（当前 7 个）；哈希过的 `/static/js/*` 必须 immutable；SPA 文档与客户端路由必须 `no-cache`；`/api/*` 与 `/v1/*` 必须 404 JSON 且**绝不**发文档。此前只有 `/static/*` 被钉住（`router/router_test.go:522`），这正是根文件能悄悄漂掉的原因。变异**两向**：把根图片改回 immutable ⇒ FAIL 逐个点名 `favicon-64.png` / `favicon.png` / `favicon.svg` / `logo.png` / `logo.svg`；正确策略 ⇒ PASS。dist 根为空时 FAIL 而非静默通过。

**有意不做门禁**：散文准确性（那是审计的活）；`/assets/` 是否复活（`router.go` 的长注释 + `spa_layout_test.go` 的「挂载不得告警」已经覆盖）。

## 验证证据

- 最终源码：PR head（见下方 commits）；`git status` clean。
- **门禁**：`go build ./cmd/server` rc=0 · `go test ./router/... ./docs/... -count=1 -race` **ok**（router 14.5s / docs 129.4s）· `gofmt -l` 对本轮改动文件为空 · 全量 `GOMAXPROCS=2 go test ./... -count=1 -race -p 1 -timeout=30m` 见下方「本机全量 race」。
- **web 门禁按构造不适用**：`git diff --name-only master...HEAD` 无 `web/` 文件 ⇒ vitest / lint / format / knip / boundaries 的输入一个字节未变，CI 复跑作终审。
- `tsgo -b` 本机结构性不可用（2C/4G，host OOM SIGKILL）⇒ 类型权威交 CI `frontend`。
- 真实模型中继 / 下游客户端 E2E：**不适用**（缓存头与文档；代理协议路径一个字节未改）。
- 未验证项与剩余风险：① `no-cache` 让 5 个根图片每次冷加载多 5 个条件请求（304，空 body）—— 这是未哈希资源的标准代价，且 `verify-live-assets.sh` 只校验 200 + content type，不受影响；② 本轮**只逐句核了 `docs/architecture.md` 全文**，`a11y-checklist.md` §2–§7、`BACKEND.md` §3–§5 与 `docs/` 下 9 份说明文档的逐句重读尚未做；③ 本轮机械扫过且**为真**的：文档内 17 个 markdown 链接 0 悬空、231 个反引号片段里 138 个标识符 token 只有 3 个「未解析」且全是 Go 包路径/模块路径/被否定的名字、`16 adapters` 与 `platform/registry.go` 的 `orderedPlatformNames` 逐个吻合、admin 与 proxy 两条中间件链的 7 步顺序与 `router/router.go` 逐行吻合、`isFileUploadPath` 与文档点名的 `/v1/files` + `/v1/images/*` 吻合、`RegisterGeminiRoutes` 的 7 条路由与文档的 glob 写法吻合、`verify-live-assets.sh` 确实同时认 `/static/` 与 `/assets/` 前缀（⇒ `docs/deployment.md:441` 为真、未改）。
- 附带发现（**未改**，非本轮范围）：`gofmt`(go1.26.6) 认为 `router/monitor_wiring_test.go`、`router/router_test.go`、`router/session_ratelimit_test.go` 三个文件需要重排 struct 字面量对齐 —— master 上同样如此且 CI 绿，属工具链版本差异，不在本轮动它以免混入无关 diff。
