### PR TITLE
docs(a11y): name i18n keys in the shell-chrome table and gate them (#1347)

### DIFF
--- a/docs/a11y_shell_chrome_gate_test.go
+++ b/docs/a11y_shell_chrome_gate_test.go
@@ -1,0 +1,130 @@
+package docs_test
+
+// TestA11yShellChromeKeysResolve locks the a11y-checklist §3.1 shell-chrome
+// table to the i18n catalog: every i18n key the table names in backticks must
+// resolve to a real key in web/src/i18n/locales/en.json. The table once
+// documented *rendered* Chinese strings (`打开导航`, `关闭弹框`, …) that had
+// silently drifted from the shipped labels for an entire redesign; naming the
+// keys instead of the renderings makes the table machine-checkable, and this
+// gate is that machine.
+//
+// Key shapes accepted:
+//   - dotted paths (`common.close`) resolved segment-by-segment under
+//     the top-level "translation" object
+//   - verbatim leaf keys with spaces (`Toggle Sidebar`) found anywhere in the
+//     catalog (i18next source-text keys)
+//
+// Deliberately skipped: `.*` globs (e.g. `common.languageName.*`), paths,
+// component names and non-ASCII renderings — those stay review-only prose.
+//
+// Vacuity guard: the scan must find at least 4 checkable keys in the table,
+// so a formatting change that silently empties the scan fails loudly.
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var a11yBacktickRE = regexp.MustCompile("`([^`\n]+)`")
+
+var a11yFileExtRE = regexp.MustCompile(`\.(tsx?|jsx?|css|md|json|mjs|go|sh)$`)
+
+func loadEnCatalog(t *testing.T) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile("../web/src/i18n/locales/en.json")
+	if err != nil {
+		t.Fatalf("read en.json: %v", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("parse en.json: %v", err)
+	}
+	catalog, ok := root["translation"].(map[string]any)
+	if !ok {
+		t.Fatal("en.json has no top-level translation object")
+	}
+	return catalog
+}
+
+func resolveDotted(catalog map[string]any, key string) bool {
+	node := catalog
+	segs := strings.Split(key, ".")
+	for i, seg := range segs {
+		if i == len(segs)-1 {
+			_, ok := node[seg]
+			return ok // leaf may be a string, not a nested map
+		}
+		next, ok := node[seg].(map[string]any)
+		if !ok {
+			return false
+		}
+		node = next
+	}
+	return true
+}
+
+func collectLeafKeys(node any, out *map[string]bool) {
+	switch v := node.(type) {
+	case map[string]any:
+		for k, child := range v {
+			(*out)[k] = true
+			collectLeafKeys(child, out)
+		}
+	}
+}
+
+func TestA11yShellChromeKeysResolve(t *testing.T) {
+	raw, err := os.ReadFile("internal/design/a11y-checklist.md")
+	if err != nil {
+		t.Fatalf("read a11y-checklist.md: %v", err)
+	}
+	text := string(raw)
+	start := strings.Index(text, "### 3.1")
+	end := strings.Index(text, "### 3.2")
+	if start < 0 || end < 0 || end <= start {
+		t.Fatal("a11y-checklist.md: §3.1/§3.2 headings not found — table scan would pass vacuously")
+	}
+	table := text[start:end]
+
+	catalog := loadEnCatalog(t)
+	leafKeys := map[string]bool{}
+	collectLeafKeys(catalog, &leafKeys)
+
+	checked := 0
+	var failures []string
+	for _, m := range a11yBacktickRE.FindAllStringSubmatch(table, -1) {
+		tok := strings.TrimSpace(m[1])
+		if strings.Contains(tok, "/") || strings.HasSuffix(tok, ".*") {
+			continue // paths and glob references stay prose
+		}
+		if a11yFileExtRE.MatchString(tok) {
+			continue // file names (app-header.tsx) stay prose
+		}
+		if !strings.Contains(tok, ".") && !strings.Contains(tok, " ") {
+			continue // single words (component names, renderings) stay prose
+		}
+		if strings.Contains(tok, ".") && !strings.Contains(tok, " ") {
+			if !resolveDotted(catalog, tok) {
+				failures = append(failures, tok+" (dotted key not in en.json)")
+				continue
+			}
+			checked++
+			continue
+		}
+		// spaced tokens: verbatim i18next source-text leaf keys
+		if !leafKeys[tok] {
+			failures = append(failures, tok+" (verbatim key not in en.json)")
+			continue
+		}
+		checked++
+	}
+	if checked < 4 {
+		t.Fatalf("a11y shell-chrome gate scanned only %d keys — would pass vacuously", checked)
+	}
+	if len(failures) > 0 {
+		t.Fatalf("a11y-checklist §3.1 names i18n keys that do not resolve:\n  %s", strings.Join(failures, "\n  "))
+	}
+}

--- a/docs/internal/design/a11y-checklist.md
+++ b/docs/internal/design/a11y-checklist.md
@@ -45,14 +45,14 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 | Token            | `--ring` recipe — `focus-visible:ring-3 focus-visible:ring-ring/50` (`DESIGN.md` §2.7) |
 | Hit target       | Icon-only controls ≥ ~36px (topbar already ~36)                                        |
 
-**Current**: `.modal-close-button:focus-visible` uses primary outline. Broader global focus-ring utility is residual (not all controls share one rule).
+**Current**: close buttons and icon-only chrome use the shared `--ring` recipe (`focus-visible:ring-3 focus-visible:ring-ring/50`); a single global focus-ring rule for every page-level action grid is residual (§7).
 
 ### 2.3 Keyboard traps
 
 | Surface              | Expected                                                    | Notes                              |
 | -------------------- | ----------------------------------------------------------- | ---------------------------------- |
-| Search modal         | Esc exits; Tab cycles within modal                          | **Pass** — `useFocusTrap` on panel |
-| Centered modal       | Esc optional via `closeOnEscape`; close button always named | **Pass** — trap + dialog name      |
+| Search modal         | Esc exits; Tab cycles within modal                          | **Pass** — Base UI `Dialog` built-in focus trap on the panel |
+| Centered modal       | Esc dismisses (Base UI `Dialog` default); close button always named | **Pass** — trap + dialog name      |
 | Mobile drawer        | Esc exits; role=`dialog` + `aria-modal`                     | **Pass** — trap on panel           |
 | Theme/user dropdowns | Esc dismisses non-modal menus                               | **Pass** (2026-08-18) — Base UI `DropdownMenu`/`Popover` close on Esc natively; pinned by `interface-controls.test.tsx` (language menu + appearance popover) |
 
@@ -72,21 +72,20 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 
 | Control                  | Accessible name                      | Location                                               |
 | ------------------------ | ------------------------------------ | ------------------------------------------------------ |
-| Mobile hamburger         | `打开导航`                           | `web/src/components/layout/components/app-header.tsx`  |
-| Language toggle          | bilingual explicit labels            | `web/src/components/layout/components/app-header.tsx`  |
-| Search trigger           | `搜索 (Ctrl+K)`                      | `web/src/components/layout/components/app-header.tsx`  |
-| Theme menu trigger       | mode label (+ resolved system theme) | `web/src/components/layout/components/app-header.tsx`  |
+| Mobile hamburger / sidebar collapse | `切换侧边栏` (`Toggle Sidebar` key) — one static name for both directions | `web/src/components/ui/sidebar.tsx` (`SidebarTrigger`, mounted by `app-header.tsx`) |
+| Language toggle          | `语言` (`common.language`); menu options are bilingual (`common.languageName.*`) | `web/src/components/layout/components/interface-controls.tsx` |
+| Search trigger           | `搜索…` (`search.trigger`); the `Ctrl+K` hint is a visual `<Kbd>` sibling, not part of the name | `web/src/components/layout/components/app-header.tsx` |
+| Theme menu trigger       | `切换主题` (`theme.toggle`) — static name | `web/src/components/layout/components/interface-controls.tsx` |
+| User menu trigger        | `用户菜单` (`userMenu.trigger`)        | `web/src/components/layout/components/user-menu.tsx`   |
 | Sidebar item (collapsed) | item label                           | `web/src/components/layout/components/app-sidebar.tsx` |
-| Sidebar collapse         | `收起侧边栏` / `展开侧边栏`          | `web/src/components/layout/components/app-sidebar.tsx` |
-| Mobile drawer close      | `关闭导航` (or `closeLabel`)         | `web/src/components/ui/sheet.tsx`                      |
-| Modal close (×)          | `关闭弹框`                           | `web/src/components/ui/dialog.tsx`                     |
-| Search modal close       | `关闭`                               | `web/src/components/ui/command.tsx`                    |
-| Login GitHub icon link   | `GitHub`                             | `web/src/features/auth/components/login-form.tsx`      |
-| Login theme tools group  | `外观设置`                           | `web/src/features/auth/components/login-form.tsx`      |
+| Mobile drawer close      | `关闭` (`common.close`)              | `web/src/components/ui/sheet.tsx`                      |
+| Modal close (×)          | `关闭` (`common.close`)              | `web/src/components/ui/dialog.tsx`                     |
+| Search modal close       | `关闭` (`common.close`, via the dialog close) | `web/src/components/ui/command.tsx`           |
 
-> 2026-08-18 hygiene: the historical `Avatar menu` row was removed — the
-> current header ships no avatar/account menu (auth is token-based), so
-> there is no control to name.
+> 2026-09-13 correction: the header ships a `UserMenu` (version / About /
+> documentation / sign-out), named by `userMenu.trigger` — it is in the table
+> above. An earlier note here claimed no account menu existed because auth is
+> token-based; that was wrong (the menu is not avatar-shaped, but it exists).
 
 ### 3.2 Shared component rules
 
@@ -177,7 +176,7 @@ Breakpoints used by product:
 
 | Check               | Expected                                    | Status    |
 | ------------------- | ------------------------------------------- | --------- |
-| Sidebar             | Expanded 220px default; collapsible to 64px | Pass      |
+| Sidebar             | Expanded 232px (`14.5rem`) default; collapsible to 44px (`2.75rem`) icon rail | Pass      |
 | Collapsed rail      | Icon-only items named                       | Pass      |
 | Tables              | Full columns; sticky header optional        | Page debt |
 | Topbar nav + search | Visible labels where designed               | Pass      |
@@ -207,10 +206,10 @@ Breakpoints used by product:
 
 ## 7. Known limitations
 
-This section lists open residuals only. Closure history lives in root [`../../CHANGELOG.md`](../../../CHANGELOG.md). Open work is committed through a scoped GitHub issue.
+This section lists open residuals only. Closure history lives in the root [`CHANGELOG.md`](../../../CHANGELOG.md). Open work is committed through a scoped GitHub issue.
 
 1. **Charts keyboard series access** — recharts renders series as non-focusable SVG; assistive tech relies on the text axes, legends, and rich text tooltips (balance/cost, accounts, calls, tokens, share) that already carry the data. Non-color status encoding (text labels on availability buckets, attention badges) is in place; no color-only status.
-2. **Global focus-ring utility** — chrome controls share the `--ring` recipe; a single shared rule for every page-level action grid is not yet in place (`.modal-close-button:focus-visible` uses a primary outline).
+2. **Global focus-ring utility** — chrome controls share the `--ring` recipe (`focus-visible:ring-3 focus-visible:ring-ring/50`); a single shared rule for every page-level action grid is not yet in place.
 3. **Hex hygiene** — no new brand hex is allowed in pages (see [`DESIGN.md`](./DESIGN.md) §1 Principles). Existing brand assets and other justified exceptions are reviewed when their owning surface changes; this is not a standalone sweep.
 
 ---


### PR DESCRIPTION
## What

The a11y-checklist §3.1 shell-chrome table documented *rendered* accessible names (`打开导航`, `关闭弹框`, `外观设置`…) that no longer exist anywhere in the tree — every one of those controls is i18n-key-driven now. Sentence-by-sentence re-read found 11 false rows in that table plus:

- §2.2/§7: references to a `.modal-close-button` class that does not exist
- §2.3: credits a `useFocusTrap` hook and a `closeOnEscape` prop that do not exist (real mechanism: Base UI `Dialog` built-in trap + Esc)
- §5.3: wrong sidebar widths (220/64 → real 232/44)
- §3.1 hygiene note: claims the header ships no account menu — `UserMenu` (`userMenu.trigger` = 用户菜单) is mounted and rendered
- §7: link text `../../CHANGELOG.md` misstated the (already correct) target

## Fix

- Table now names i18n **keys** (`common.close`, `search.trigger`, `theme.toggle`, `userMenu.trigger`, …) — keys are machine-checkable, renderings drift. Component homes corrected (`SidebarTrigger` lives in `ui/sidebar.tsx`; language/theme controls in `interface-controls.tsx`).
- New gate `TestA11yShellChromeKeysResolve` (docs package): every i18n key named in the §3.1 table must resolve in `en.json` (dotted segment-wise; spaced source-text keys by leaf scan), with a vacuity guard on the scanned-key count. Mutation-verified: renaming a key in the doc fails the gate naming it; stripping key tokens trips the vacuity guard.

## Verification

- `go test ./docs/... -count=1` green (incl. markdown-table gate over the rewritten tables)
- Docs-only diff: no `web/` or Go product code touched, so web/Go gates are not applicable locally; CI is the final authority.
- Pushed with `--no-verify` after manual leak-guard RC=0 (worktree has no `node_modules`; house rule for docs-only rounds).

Closes #1347