### PR TITLE
fix(web): datetime range filters stack cleanly on mobile (#1351)

### DIFF
--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -430,37 +430,44 @@ export function CheckinPage() {
           owned by DataTablePage; the custom filter bar gates on !error. */}
       {!error && (
         <div className='flex flex-wrap items-center gap-2'>
+          {/* Native datetime controls render in the BROWSER's locale (not
+              the page's): zh-CN browsers get 年月日/24h, en-US browsers get
+              mm/dd/yyyy. What we own is the layout: on mobile the pair stacks
+              full-width so neither clips, and the 至 separator hides instead
+              of orphaning at a wrapped line end. */}
           <CalendarRange
             aria-hidden='true'
-            className='text-muted-foreground size-4'
+            className='text-muted-foreground size-4 max-sm:hidden'
           />
-          <Input
-            type='datetime-local'
-            value={from}
-            onChange={(event) => {
-              updateUrlState({
-                filters: { from: event.target.value },
-                pageIndex: 0,
-              })
-            }}
-            className='w-[200px]'
-            aria-label={t('checkin.page.startTime')}
-          />
-          <span className='text-muted-foreground text-sm'>
-            {t('checkin.page.to')}
-          </span>
-          <Input
-            type='datetime-local'
-            value={to}
-            onChange={(event) => {
-              updateUrlState({
-                filters: { to: event.target.value },
-                pageIndex: 0,
-              })
-            }}
-            className='w-[200px]'
-            aria-label={t('checkin.page.endTime')}
-          />
+          <div className='flex items-center gap-2 max-sm:w-full max-sm:flex-col max-sm:items-stretch'>
+            <Input
+              type='datetime-local'
+              value={from}
+              onChange={(event) => {
+                updateUrlState({
+                  filters: { from: event.target.value },
+                  pageIndex: 0,
+                })
+              }}
+              className='w-[200px] max-sm:w-full'
+              aria-label={t('checkin.page.startTime')}
+            />
+            <span className='text-muted-foreground text-sm max-sm:hidden'>
+              {t('checkin.page.to')}
+            </span>
+            <Input
+              type='datetime-local'
+              value={to}
+              onChange={(event) => {
+                updateUrlState({
+                  filters: { to: event.target.value },
+                  pageIndex: 0,
+                })
+              }}
+              className='w-[200px] max-sm:w-full'
+              aria-label={t('checkin.page.endTime')}
+            />
+          </div>
           <Select
             value={accountId ? String(accountId) : ACCOUNT_FILTER_ALL}
             onValueChange={(value) => {

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -597,30 +597,35 @@ export function ProxyLogsPage() {
                 }}
                 className='w-[130px]'
               />
-              <Input
-                type='datetime-local'
-                aria-label={t('proxyLogs.page.startTime')}
-                value={from}
-                onChange={(event) => {
-                  updateUrlState({
-                    filters: { from: event.target.value },
-                    pageIndex: 0,
-                  })
-                }}
-                className='w-[180px]'
-              />
-              <Input
-                type='datetime-local'
-                aria-label={t('proxyLogs.page.endTime')}
-                value={to}
-                onChange={(event) => {
-                  updateUrlState({
-                    filters: { to: event.target.value },
-                    pageIndex: 0,
-                  })
-                }}
-                className='w-[180px]'
-              />
+              {/* Native datetime controls render in the BROWSER's locale
+                  (not the page's). Layout is what we own: the pair stacks
+                  full-width on mobile so neither clips its time segment. */}
+              <div className='flex items-center gap-2 max-sm:w-full max-sm:flex-col max-sm:items-stretch'>
+                <Input
+                  type='datetime-local'
+                  aria-label={t('proxyLogs.page.startTime')}
+                  value={from}
+                  onChange={(event) => {
+                    updateUrlState({
+                      filters: { from: event.target.value },
+                      pageIndex: 0,
+                    })
+                  }}
+                  className='w-[180px] max-sm:w-full'
+                />
+                <Input
+                  type='datetime-local'
+                  aria-label={t('proxyLogs.page.endTime')}
+                  value={to}
+                  onChange={(event) => {
+                    updateUrlState({
+                      filters: { to: event.target.value },
+                      pageIndex: 0,
+                    })
+                  }}
+                  className='w-[180px] max-sm:w-full'
+                />
+              </div>
             </>
           ),
           expandable: (


### PR DESCRIPTION
## What

Closes #1351.

**Locale finding (evidence)**: native `datetime-local`/`time` controls render in the **browser's** locale, not the page's — verified empirically in this environment's Chromium (context `locale: zh-CN` and `<html lang>` both leave `mm/dd/yyyy` + `AM/PM` untouched; a zh-CN desktop browser renders 年月日/24h). So the format string is the platform's contract, not a bug we can fix without replacing native controls with a custom picker (worse accessibility, worse mobile UX). What the app owns — and what was actually broken — is the **layout** at narrow widths:

1. proxy-logs and check-in filters pinned the two inputs to fixed 180/200px inside a wrapping toolbar, so at 375px the time segment clipped to `--:-- --`;
2. check-in's `至` separator could orphan at a wrapped line end.

**Fix**: the from/to pair becomes one group — side-by-side at ≥640px, stacked full-width below it; the separator hides when stacked (stacking already carries the range semantics; both inputs keep their localized aria-labels). Desktop rendering is unchanged (verified by screenshot; the golden set contains no filter-row page, so no baseline drift).

## Verification

- Targeted vitest (checkin + proxy-logs suites) green; oxlint/oxfmt clean
- Screenshots (mobile 375px): both pages stack the pair full-width, no clipping, no orphan separator
- i18n: no new keys (existing aria-labels reused)